### PR TITLE
Change sourceManaged directory?

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val core = project
       "org.scalaz"  %% "scalaz-core" % scalazVersion,
       "com.chuusai" %% "shapeless"   % shapelessVersion
     ),
+    sourceManaged <<= baseDirectory { _ / "src_managed" },
     sourceGenerators in Compile +=
       Def.task { gen2(sourceManaged.value / "gem").unsafePerformIO }.taskValue
   )


### PR DESCRIPTION
I'm wondering if we might consider changing `sourceManaged` so that it isn't created in the `target` directory.  Whenever you touch the build file and sync in Idea, it forgets that the generated sources directory should be treated as source files.  That happens even if you move it out of the target directory, but at least there's a bit less fiddling with it because you don't have to cancel the exclusion on the `target` directory first.

Where they are written (other than in a `target` subdirectory) doesn't matter much to me.  I chose `src_managed` because there was already an entry in `.gitignore` for it.
