### PR TITLE
Initial multi-sequence ideas

### DIFF
--- a/modules/core/src/main/scala/gem/Observation.scala
+++ b/modules/core/src/main/scala/gem/Observation.scala
@@ -5,10 +5,10 @@ import gem.enum.Instrument
 import scalaz._, Scalaz._
 
 case class Observation[S](
-  id: Observation.Id, 
-  title: String, 
+  id: Observation.Id,
+  title: String,
   instrument: Option[Instrument], // redundant? this is on the steps too
-  steps: List[S])
+  sequences: List[S])
 
 object Observation {
 
@@ -35,8 +35,10 @@ object Observation {
   implicit def ObservationTraverse[T]: Traverse[Observation[?]] =
     new Traverse[Observation[?]] {
       def traverseImpl[G[_]: Applicative, A, B](fa: Observation[A])(f: A => G[B]): G[Observation[B]] =
-        fa.steps.traverse(f).map(ss => fa.copy(steps = ss))
+        fa.sequences.traverse(f).map(ss => fa.copy(sequences = ss))
     }
+
+  implicit val EqualObservationId: Equal[Observation.Id] = Equal.equalA
 
 }
 

--- a/modules/core/src/main/scala/gem/Sequence.scala
+++ b/modules/core/src/main/scala/gem/Sequence.scala
@@ -3,6 +3,10 @@ package gem
 import scalaz._
 import Scalaz._
 
+case class Sequence[S](
+  id: Sequence.Id,
+  steps: List[S])
+
 object Sequence {
 
   trait Id {
@@ -10,22 +14,34 @@ object Sequence {
     def name: String
   }
 
-  object Id extends ((Observation.Id, String) => Option[Sequence.Id]) {
-    def apply(o: Observation.Id, n: String): Option[Sequence.Id] =
+  object Id {
+    def fromName(o: Observation.Id, n: String): Option[Sequence.Id] =
       !(n.contains('-') || "" === n.trim) option new Sequence.Id {
         override val oid: Observation.Id = o
         override val name: String        = n.trim
 
+        override def equals(o: Any): Boolean =
+          o match {
+            case id: Id => id.oid === oid && id.name === name
+            case _      => false
+          }
+
+        override def hashCode: Int =
+          41 * (41 + oid.hashCode) +  name.hashCode
+
         override def toString: String =
           s"${oid.toString}-$n"
       }
+
+    def unsafeFromName(o: Observation.Id, n: String): Sequence.Id =
+      fromName(o, n) | sys.error(s"Illegal sequence name '$n'")
 
     def fromString(s: String): Option[Sequence.Id] =
       s.lastIndexOf('-') match {
         case -1 => None
         case  n =>
           val (a, b) = s.splitAt(n)
-          Observation.Id.fromString(a).flatMap { Id(_, b.drop(1)) }
+          Observation.Id.fromString(a).flatMap { Id.fromName(_, b.drop(1)) }
       }
 
     def unsafeFromString(s: String): Sequence.Id =
@@ -35,4 +51,11 @@ object Sequence {
       Some((arg.oid, arg.name))
   }
 
+  implicit def SequenceTraverse[T]: Traverse[Sequence[?]] =
+    new Traverse[Sequence[?]] {
+      def traverseImpl[G[_]: Applicative, A, B](fa: Sequence[A])(f: A => G[B]): G[Sequence[B]] =
+        fa.steps.traverse(f).map(ss => fa.copy(steps = ss))
+    }
+
+  implicit val EqualSequenceId: Equal[Sequence.Id] = Equal.equalA
 }

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -9,14 +9,14 @@ object ObservationDao {
 
   def insert(o: Observation[_]): ConnectionIO[Int] =
     sql"""
-      INSERT INTO observation (observation_id, 
-                              program_id, 
-                              observation_index, 
+      INSERT INTO observation (observation_id,
+                              program_id,
+                              observation_index,
                               title,
                               instrument)
-            VALUES (${o.id}, 
-                    ${o.id.pid}, 
-                    ${o.id.index}, 
+            VALUES (${o.id},
+                    ${o.id.pid},
+                    ${o.id.index},
                     ${o.title},
                     ${o.instrument})
     """.update.run
@@ -25,24 +25,24 @@ object ObservationDao {
     sql"""
       SELECT title, instrument
         FROM observation
-       WHERE observation_id = ${id}
+       WHERE observation_id = $id
     """.query[(String, Option[Instrument])]
        .unique
        .map { case (t, i) =>
          Observation(id, t, i, Nil)
-       }      
+       }
 
-  def select(id: Observation.Id): ConnectionIO[Observation[Step[_]]] =
+  def select(id: Observation.Id): ConnectionIO[Observation[Sequence[_]]] =
     for {
       on <- selectFlat(id)
       ss <- StepDao.selectAll(id)
-    } yield on.copy(steps = ss)
+    } yield on.copy(sequences = ss)
 
   def selectAllFlat(pid: Program.Id): ConnectionIO[List[Observation[Nothing]]] =
     sql"""
       SELECT observation_index, title, instrument
         FROM observation
-       WHERE program_id = ${pid}
+       WHERE program_id = $pid
     ORDER BY observation_index
     """.query[(Int, String, Option[Instrument])]
        .map { case (n, t, i) =>

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -10,53 +10,53 @@ import scalaz._, Scalaz._
 
 object StepDao {
 
-  def insert[I <: InstrumentConfig](oid: Observation.Id, index: Int, s: Step[I]): ConnectionIO[Int] =
-    insertBaseSlice(oid, index, s.instrument, StepType.forStep(s)) *> {
+  def insert[I <: InstrumentConfig](sid: Sequence.Id, index: Int, s: Step[I]): ConnectionIO[Int] =
+    insertBaseSlice(sid, index, s.instrument, StepType.forStep(s)) *> {
       s match {
-        case BiasStep(_)       => insertBiasSlice(oid, index)
-        case DarkStep(_)       => insertDarkSlice(oid, index)
-        case ScienceStep(_, t) => insertScienceSlice(oid, index, t)
-        case GcalStep(_, g)    => insertGCalSlice(oid, index, g)
+        case BiasStep(_)       => insertBiasSlice(sid, index)
+        case DarkStep(_)       => insertDarkSlice(sid, index)
+        case ScienceStep(_, t) => insertScienceSlice(sid, index, t)
+        case GcalStep(_, g)    => insertGCalSlice(sid, index, g)
       }
-    } *> insertConfigSlice(oid, index, s.instrument)
+    } *> insertConfigSlice(sid, index, s.instrument)
 
-  private def insertBaseSlice(oid: Observation.Id, index: Int, i: InstrumentConfig, t: StepType): ConnectionIO[Int] =
+  private def insertBaseSlice(sid: Sequence.Id, index: Int, i: InstrumentConfig, t: StepType): ConnectionIO[Int] =
     sql"""
-      INSERT INTO step (observation_id, index, instrument, step_type)
-      VALUES ($oid, ${index}, ${Instrument.forConfig(i).tag}, ${t.tag} :: step_type)
+      INSERT INTO step (observation_id, sequence_name, index, instrument, sequence_id, step_type)
+      VALUES (${sid.oid}, ${sid.name}, $index, ${Instrument.forConfig(i).tag}, $sid, ${t.tag} :: step_type)
     """.update.run
 
-  private def insertBiasSlice(oid: Observation.Id, index: Int): ConnectionIO[Int] =
+  private def insertBiasSlice(sid: Sequence.Id, index: Int): ConnectionIO[Int] =
     sql"""
-      INSERT INTO step_bias (observation_id, index)
-      VALUES (${oid.toString}, ${index})
+      INSERT INTO step_bias (sequence_id, index)
+      VALUES ($sid, $index)
     """.update.run
 
-  private def insertDarkSlice(oid: Observation.Id, index: Int): ConnectionIO[Int] =
+  private def insertDarkSlice(sid: Sequence.Id, index: Int): ConnectionIO[Int] =
     sql"""
-      INSERT INTO step_dark (observation_id, index)
-      VALUES (${oid.toString}, ${index})
+      INSERT INTO step_dark (sequence_id, index)
+      VALUES ($sid, $index)
     """.update.run
 
-  private def insertGCalSlice(oid: Observation.Id, index: Int, gcal: GcalConfig): ConnectionIO[Int] =
+  private def insertGCalSlice(sid: Sequence.Id, index: Int, gcal: GcalConfig): ConnectionIO[Int] =
     sql"""
-      INSERT INTO step_gcal (observation_id, index, gcal_lamp, shutter)
-      VALUES (${oid.toString}, ${index}, ${gcal.lamp}, ${gcal.shutter} :: gcal_shutter)
+      INSERT INTO step_gcal (sequence_id, index, gcal_lamp, shutter)
+      VALUES ($sid, $index, ${gcal.lamp}, ${gcal.shutter} :: gcal_shutter)
     """.update.run
 
-  private def insertScienceSlice(oid: Observation.Id, index: Int, t: TelescopeConfig): ConnectionIO[Int] =
+  private def insertScienceSlice(sid: Sequence.Id, index: Int, t: TelescopeConfig): ConnectionIO[Int] =
     sql"""
-      INSERT INTO step_science (observation_id, index, offset_p, offset_q)
-      VALUES (${oid}, ${index}, ${t.p}, ${t.q})
+      INSERT INTO step_science (sequence_id, index, offset_p, offset_q)
+      VALUES ($sid, $index, ${t.p}, ${t.q})
     """.update.run
 
-    private def insertConfigSlice(oid: Observation.Id, index: Int, i: InstrumentConfig): ConnectionIO[Int] =
+    private def insertConfigSlice(sid: Sequence.Id, index: Int, i: InstrumentConfig): ConnectionIO[Int] =
       i match {
 
         case F2Config(fpu, mosPreimaging, exposureTime, filter, lyotWheel, disperser, windowCover) =>
           sql"""
-            INSERT INTO step_f2 (observation_id, index, fpu, mos_preimaging, exposure_time, filter, lyot_wheel, disperser, window_cover)
-            VALUES ($oid, $index, $fpu, $mosPreimaging, ${exposureTime.getSeconds}, $filter, $lyotWheel, $disperser, $windowCover)
+            INSERT INTO step_f2 (sequence_id, index, fpu, mos_preimaging, exposure_time, filter, lyot_wheel, disperser, window_cover)
+            VALUES ($sid, $index, $fpu, $mosPreimaging, ${exposureTime.getSeconds}, $filter, $lyotWheel, $disperser, $windowCover)
           """.update.run
 
         case GenericConfig(i) => 0.point[ConnectionIO]
@@ -65,6 +65,7 @@ object StepDao {
 
   // The type we get when we select the fully joined step
   private case class StepKernel(
+    sid: Sequence.Id,
     i: Instrument,
     stepType: StepType, // todo: make an enum
     gcal: (Option[GCalLamp], Option[GCalShutter]),
@@ -89,21 +90,51 @@ object StepDao {
       }
   }
 
-  def selectAll(oid: Observation.Id): ConnectionIO[List[Step[Instrument]]] =
+  def selectIds(oid: Observation.Id): ConnectionIO[List[Sequence.Id]] =
     sql"""
-      SELECT s.instrument,
-             s.step_type,
-             sg.gcal_lamp,
-             sg.shutter,
-             sc.offset_p,
-             sc.offset_q
-        FROM step s
-             LEFT OUTER JOIN step_gcal sg
-                ON sg.observation_id = s.observation_id AND sg.index = s.index
-             LEFT OUTER JOIN step_science sc
-                ON sc.observation_id = s.observation_id AND sc.index = s.index
-       WHERE s.observation_id = ${oid}
-    ORDER BY s.index
-    """.query[StepKernel].map(_.toStep).list
+          SELECT DISTINCT sequence_id
+            FROM step
+           WHERE observation_id = $oid
+        ORDER BY sequence_id
+       """.query[Sequence.Id].list
 
+  def selectAll(oid: Observation.Id): ConnectionIO[List[Sequence[Step[Instrument]]]] =
+    sql"""
+       SELECT s.sequence_id,
+              s.instrument,
+              s.step_type,
+              sg.gcal_lamp,
+              sg.shutter,
+              sc.offset_p,
+              sc.offset_q
+       FROM step s
+              LEFT OUTER JOIN step_gcal sg
+                 ON sg.sequence_id = s.sequence_id AND sg.index = s.index
+              LEFT OUTER JOIN step_science sc
+                 ON sc.sequence_id = s.sequence_id AND sc.index = s.index
+       WHERE s.observation_id = $oid
+    ORDER BY s.sequence_id, s.index
+    """.query[StepKernel].list.map { (lst: List[StepKernel]) =>
+      lst.groupBy(_.sid).map { case (sid, sks) => Sequence(sid, sks.map(_.toStep)) }.toList
+    }
+
+  def selectAll(sid: Sequence.Id): ConnectionIO[Option[Sequence[Step[Instrument]]]] =
+    sql"""
+       SELECT s.sequence_id,
+              s.instrument,
+              s.step_type,
+              sg.gcal_lamp,
+              sg.shutter,
+              sc.offset_p,
+              sc.offset_q
+       FROM step s
+              LEFT OUTER JOIN step_gcal sg
+                 ON sg.sequence_id = s.sequence_id AND sg.index = s.index
+              LEFT OUTER JOIN step_science sc
+                 ON sc.sequence_id = s.sequence_id AND sc.index = s.index
+       WHERE s.sequence_id = $sid
+    ORDER BY s.index
+    """.query[StepKernel].list.map { (lst: List[StepKernel]) =>
+      lst.headOption.map { sk => Sequence(sk.sid, lst.map(_.toStep)) }
+    }
 }

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -3,13 +3,12 @@ package gem
 import gem.dao._
 import gem.enum._
 import gem.config._
-
-import edu.gemini.pot.sp.{ISPProgram, ISPObservation}
+import edu.gemini.pot.sp.{ISPObservation, ISPProgram}
 import edu.gemini.spModel.io.SpImportService
 import edu.gemini.spModel.core._
-import edu.gemini.pot.spdb.{ IDBDatabaseService, DBLocalDatabase }
+import edu.gemini.pot.spdb.{DBLocalDatabase, IDBDatabaseService}
 import edu.gemini.spModel.config.ConfigBridge
-import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP;
+import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
 
 import java.io._
 import java.{ util => JU }
@@ -17,13 +16,13 @@ import java.util.logging.{ Logger, Level }
 import java.time.Duration
 
 import scala.collection.JavaConverters._
-
-import scalaz._, Scalaz._
+import scalaz._
+import Scalaz._
 import scalaz.effect._
 import scalaz.concurrent.Task
 import scalaz.std.effect.closeable._
-
 import doobie.imports._
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.WindowCover
 
 object Importer extends SafeApp {
   import Program.Id._
@@ -84,9 +83,10 @@ object Importer extends SafeApp {
         )
 
         val configs = ss.flatMap(unsafeFromConfig)
+        val sid     = Sequence.Id.unsafeFromName(newObs.id, "seq0") // need a default id for old sequences
 
         ObservationDao.insert(newObs) *>
-        configs.zipWithIndex.traverse { case (c, n) => StepDao.insert(newObs.id, n, c) }.void
+        configs.zipWithIndex.traverse { case (c, n) => StepDao.insert(sid, n, c) }.void
 
       }
 


### PR DESCRIPTION
This PR contains a straightforward extension of the model to allow an observation to have multiple sequences.  A few notes:

1) I changed `sql/V001__Initial_Setup.sql` directly instead of creating a new migration.  I suppose that's not the proper way to do things but maybe until we have actual production data to migrate it would be less confusing to just clean/migrate each time?

2) I don't have much experience with relational databases so bear with me.  I'm not sure for example whether it makes sense to place two indices on the step table (one for `observation_id` and one for `sequence_id`).

3) It would probably be best to wait for more information from science before merging this PR regardless.  Maybe it doesn't make sense.