### PR TITLE
Program DAO selectFull

### DIFF
--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -99,91 +99,10 @@ object ProgramDao {
        .map(Program(pid, _, Nil))
        .option
 
-  // The full program select is a 5-table join. Decoding requires some busywork that's made slightly
-  // simpler by factoring out sub-encoders for different subsets of columns.
-  private implicit val OptionGcalConfigComposite: Composite[Option[GcalConfig]] = {
-    import GcalConfig.GcalArcs
-    import GcalArc._
-    Composite[(Option[GcalContinuum], Boolean, Boolean, Boolean, Boolean, Option[GcalShutter])].xmap({
-      case (None, _, _, _, _, None) =>
-        None
-
-      case (None, ar, cuar, thar, xe, Some(shutter)) =>
-        GcalConfig.mkLamp(None, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe).map {
-          GcalConfig(_, shutter)
-        }
-
-      case (Some(continuum), _, _, _, _, Some(shutter)) =>
-        Some(GcalConfig(continuum.left[GcalArcs], shutter))
-
-      case x => sys.error("Unexecpted Option[GcalConfig] inputs: " + x)
-    }, _ => sys.error("decode only"))
-  }
-
-
-  private implicit val OptionTelescopeConfigComposite = capply2(TelescopeConfig)
-
-  private implicit val OptionStepComposite: Composite[Option[Step[_]]] =
-    Composite[(Option[StepType], Option[Instrument], Option[GcalConfig], Option[TelescopeConfig])].xmap({
-      case (None,                   None,    None,    None   ) => None
-      case (Some(StepType.Bias),    Some(i), None,    None   ) => Some(BiasStep(i))
-      case (Some(StepType.Dark),    Some(i), None,    None   ) => Some(DarkStep(i))
-      case (Some(StepType.Gcal),    Some(i), Some(c), None   ) => Some(GcalStep(i, c))
-      case (Some(StepType.Science), Some(i), None,    Some(c)) => Some(ScienceStep(i, c))
-      case x => sys.error("Unexpected Option[Step] inputs: " + x)
-    }, _ => sys.error("decode only"))
-
-  private implicit val OptionObservationOptionStep: Composite[Option[(Observation[Nothing], Option[Step[_]])]] =
-    Composite[(Option[Observation.Id], Option[String], Option[Step[_]])].xmap({
-      case (None,      None,        None) => None
-      case (Some(oid), Some(title), step) => Some((Observation(oid, title, None, Nil), step))
-      case x => sys.error("Unexpected Option[(Observation[Nothing], Option[Step[_]])] inputs: " + x)
-    }, _ => sys.error("decode only"))
-
-  /** Select a program by Id, with fully-populated Observations and steps. */
+  /** Select a program by id, with full Observation information. */
   def selectFull(pid: Program.Id): ConnectionIO[Option[Program[Observation[Step[_]]]]] =
-    sql"""
-      SELECT p.program_id,
-             p.title,
-             o.observation_id,
-             o.title,
-             s.step_type,
-             s.instrument,
-             sg.continuum,
-             sg.ar_arc,
-             sg.cuar_arc,
-             sg.thar_arc,
-             sg.xe_arc,
-             sg.shutter,
-             sc.offset_p,
-             sc.offset_q
-        FROM program p
-             LEFT OUTER JOIN observation o ON o.program_id = p.program_id
-             LEFT OUTER JOIN step s ON s.observation_id = o.observation_id
-             LEFT OUTER JOIN step_gcal sg
-                ON sg.observation_id = s.observation_id AND sg.index = s.index
-             LEFT OUTER JOIN step_science sc
-                ON sc.observation_id = s.observation_id AND sc.index = s.index
-       WHERE p.program_id = $pid
-    ORDER BY o.observation_id, s.index;
-    """.query[(Program.Id, String, Option[(Observation[Nothing], Option[Step[_]])])]
-       .list.map { rows =>
-         rows.headOption.map { case (pid, title, _) =>
-
-           // Compute the list of observations by grouping by Obs[Nothing] and then collecting the
-           // associated steps, if any, which will remain in order through this transformation.
-           val obs: List[Observation[Step[_]]] =
-             rows.collect { case (_, _, Some(p)) => p }
-                 .groupBy(_._1)
-                 .toList
-                 .map { case (obs, rows) =>
-                   obs.copy(steps = rows.collect { case (_, Some(s)) => s } )
-                 }
-
-            // Done!
-            Program(pid, title, obs)
-
-         }
-       }
-
+    for {
+      opn <- selectFlat(pid)
+      os  <- ObservationDao.selectAll(pid)
+    } yield opn.map(_.copy(observations = os))
 }

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -72,7 +72,7 @@ object StepDao {
   private case class StepKernel(
     i: Instrument,
     stepType: StepType, // todo: make an enum
-    gcal: (Option[GcalContinuum], Boolean, Boolean, Boolean, Boolean, Option[GcalShutter]),
+    gcal: (Option[GcalContinuum], Option[Boolean], Option[Boolean], Option[Boolean], Option[Boolean], Option[GcalShutter]),
     telescope: (Option[OffsetP],  Option[OffsetQ])
   ) {
     def toStep: Step[Instrument] =
@@ -83,10 +83,14 @@ object StepDao {
 
         case StepType.Gcal =>
           import GcalArc._
-          val (continuumOpt, ar, cuar, thar, xe, shutterOpt) = gcal
+          val (continuumOpt, arOpt, cuarOpt, tharOpt, xeOpt, shutterOpt) = gcal
           (for {
-            l <- GcalConfig.mkLamp(continuumOpt, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe)
-            s <- shutterOpt
+            ar   <- arOpt
+            cuar <- cuarOpt
+            thar <- tharOpt
+            xe   <- xeOpt
+            l    <- GcalConfig.mkLamp(continuumOpt, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe)
+            s    <- shutterOpt
           } yield GcalStep(i, GcalConfig(l, s))).getOrElse(sys.error("missing gcal information: " + gcal))
 
         case StepType.Science =>


### PR DESCRIPTION
This PR contains a bug fix for the `StepDao` and a simple proposal for reworking `ProgramDao.selectFull`.    Previously `selectFull` referenced (or pretends to reference) all step fields in all tables in a single query building up a `Program[Observation[Step[_]]]` result.  This is clearly not complete now and not scalable going forward but the right way to do this also isn't obvious to me.  I'm proposing a straightforward change to multiple small queries.  If there is a better way, please let me know.