### PR TITLE
Finish Gcal Step Definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,7 @@ lazy val telnetd = project
   .in(file("modules/telnetd"))
   .dependsOn(service)
   .settings(commonSettings)
+  .settings(resolvers += "bmjames Bintray Repo" at "https://dl.bintray.com/bmjames/maven")
   .settings(
     libraryDependencies += "org.tpolecat" %% "tuco-core" % "0.1.0"
   )

--- a/modules/core/src/main/scala/gem/config/GcalConfig.scala
+++ b/modules/core/src/main/scala/gem/config/GcalConfig.scala
@@ -1,14 +1,16 @@
 package gem
 package config
 
-import gem.enum.{GcalArc, GcalContinuum, GcalShutter}
+import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
+
+import java.time.Duration
 
 import scalaz._
 import Scalaz._
 
 import GcalConfig.GcalLamp
 
-case class GcalConfig(lamp: GcalLamp, shutter: GcalShutter) {
+case class GcalConfig(lamp: GcalLamp, filter: GcalFilter, diffuser: GcalDiffuser, shutter: GcalShutter, exposureTime: Duration, coadds: Int) {
   def continuum: Option[GcalContinuum] =
     lamp.swap.toOption
 

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -4,7 +4,7 @@ import doobie.imports._
 import edu.gemini.spModel.core._
 
 import java.sql.Timestamp
-import java.time.Instant
+import java.time.{Duration, Instant}
 import java.util.logging.Level
 
 import scala.reflect.runtime.universe.TypeTag
@@ -43,6 +43,9 @@ package object dao extends MoreTupleOps with ToUserProgramRoleOps {
 
   implicit val InstantMeta: Meta[Instant] =
     Meta[Timestamp].nxmap(_.toInstant, Timestamp.from)
+
+  implicit val DurationMeta: Meta[Duration] =
+    Meta[Long].xmap(Duration.ofSeconds, _.getSeconds)
 
   def capply2[A, B, T](f: (A, B) => T)(
     implicit ca: Composite[(Option[A], Option[B])]

--- a/modules/importer/src/main/scala/ConfigReader.scala
+++ b/modules/importer/src/main/scala/ConfigReader.scala
@@ -259,10 +259,32 @@ object ConfigReader {
         }
       }
 
+      val Filter = Key.enum[OldGcal.Filter, GcalFilter]("filter",
+        OldGcal.Filter.NONE  -> GcalFilter.None,
+        OldGcal.Filter.ND_10 -> GcalFilter.Nd10,
+        OldGcal.Filter.ND_16 -> GcalFilter.Nd16,
+        OldGcal.Filter.ND_20 -> GcalFilter.Nd20,
+        OldGcal.Filter.ND_30 -> GcalFilter.Nd30,
+        OldGcal.Filter.ND_40 -> GcalFilter.Nd40,
+        OldGcal.Filter.ND_45 -> GcalFilter.Nd45,
+        OldGcal.Filter.ND_50 -> GcalFilter.Nd50,
+        OldGcal.Filter.GMOS  -> GcalFilter.Gmos,
+        OldGcal.Filter.HROS  -> GcalFilter.Hros,
+        OldGcal.Filter.NIR   -> GcalFilter.Nir
+      )
+
+      val Diffuser = Key.enum[OldGcal.Diffuser, GcalDiffuser]("diffuser",
+        OldGcal.Diffuser.IR      -> GcalDiffuser.Ir,
+        OldGcal.Diffuser.VISIBLE -> GcalDiffuser.Visible
+      )
+
       val Shutter = Key.enum[OldGcal.Shutter, GcalShutter]("shutter",
         OldGcal.Shutter.CLOSED -> GcalShutter.Closed,
         OldGcal.Shutter.OPEN   -> GcalShutter.Open
       )
+
+      val ExposureTime = Key[Duration]("exposureTime", _.getSeconds.toString)(Read.durSecs)
+      val Coadds       = Key[Int     ]("coadds",       _.toString)(Read.int)
     }
   }
 

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -160,8 +160,12 @@ object Importer extends SafeApp {
 
       case ("ARC" | "FLAT", i) =>
         val l = config.uget(Legacy.Calibration.Lamp)
+        val f = config.uget(Legacy.Calibration.Filter)
+        val d = config.uget(Legacy.Calibration.Diffuser)
         val s = config.uget(Legacy.Calibration.Shutter)
-        GcalStep(i, GcalConfig(l, s))
+        val e = config.uget(Legacy.Calibration.ExposureTime)
+        val c = config.uget(Legacy.Calibration.Coadds)
+        GcalStep(i, GcalConfig(l, f, d, s, e, c))
 
       case x =>
         sys.error("Unknown observeType: " + x + config.mkString("\n>  ", "\n>  ", ""))

--- a/project/gen2.scala
+++ b/project/gen2.scala
@@ -143,13 +143,15 @@ object gen2 {
         io.transact(xa).unsafePerformIO
       },
 
+      enum("GcalDiffuser") {
+        type GcalDiffuserRec = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        val io = sql"select id, id tag, short_name, long_name, obsolete from e_gcal_diffuser".query[(String, GcalDiffuserRec)].list
+        io.transact(xa).unsafePerformIO
+      },
+
       enum("GcalShutter") {
-        type GcalShutterRec = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
-        val io = sql"""
-          SELECT enumlabel x, enumlabel a, enumlabel b, enumlabel c
-          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
-          WHERE pg_type.typname = 'gcal_shutter'
-         """.query[(String, GcalShutterRec)].list
+        type GcalShutterRec = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        val io = sql"select id, id tag, short_name, long_name, obsolete from e_gcal_shutter".query[(String, GcalShutterRec)].list
         io.transact(xa).unsafePerformIO
       },
 

--- a/sql/V001__Initial_Setup.sql
+++ b/sql/V001__Initial_Setup.sql
@@ -57,18 +57,6 @@ CREATE TYPE f2_decker AS ENUM (
 ALTER TYPE f2_decker OWNER TO postgres;
 
 --
--- Name: gcal_shutter; Type: TYPE; Schema: public; Owner: postgres
---
-
-CREATE TYPE gcal_shutter AS ENUM (
-    'Open',
-    'Closed'
-);
-
-
-ALTER TYPE gcal_shutter OWNER TO postgres;
-
---
 -- Name: identifier; Type: DOMAIN; Schema: public; Owner: postgres
 --
 
@@ -241,6 +229,32 @@ CREATE TABLE e_gcal_arc (
 
 
 ALTER TABLE e_gcal_arc OWNER TO postgres;
+
+--
+-- Name: e_gcal_diffuser; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gcal_diffuser (
+    id character varying(20) NOT NULL,
+    short_name character varying(20) NOT NULL,
+    obsolete boolean NOT NULL,
+    long_name character varying(20) NOT NULL
+);
+
+ALTER TABLE e_gcal_diffuser OWNER TO postgres;
+
+--
+-- Name: e_gcal_shutter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gcal_shutter (
+    id character varying(20) NOT NULL,
+    short_name character varying(20) NOT NULL,
+    obsolete boolean NOT NULL,
+    long_name character varying(20) NOT NULL
+);
+
+ALTER TABLE e_gcal_shutter OWNER TO postgres;
 
 --
 -- Name: e_instrument; Type: TABLE; Schema: public; Owner: postgres
@@ -589,8 +603,14 @@ CREATE TABLE step_gcal (
     cuar_arc boolean NOT NULL DEFAULT FALSE,
     thar_arc boolean NOT NULL DEFAULT FALSE,
     xe_arc boolean NOT NULL DEFAULT FALSE,
-    shutter gcal_shutter NOT NULL,
-    CONSTRAINT check_lamp CHECK ((continuum IS NULL) = (ar_arc OR cuar_arc OR thar_arc OR xe_arc))
+    filter identifier NOT NULL,
+    diffuser identifier NOT NULL,
+    shutter identifier NOT NULL,
+    exposure_time integer NOT NULL,
+    coadds integer NOT NULL DEFAULT 1,
+    CONSTRAINT check_lamp CHECK ((continuum IS NULL) = (ar_arc OR cuar_arc OR thar_arc OR xe_arc)),
+    CONSTRAINT check_exposure_time CHECK (exposure_time >= 0),
+    CONSTRAINT check_coadds CHECK (coadds > 0)
 );
 
 
@@ -725,6 +745,26 @@ ArArc	Ar arc	Ar arc	f
 ThArArc	ThAr arc	ThAr arc	f
 CuArArc	CuAr arc	CuAr arc	f
 XeArc	Xe arc	Xe arc	f
+\.
+
+
+--
+-- Data for Name: e_gcal_diffuser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gcal_diffuser (id, short_name, obsolete, long_name) FROM stdin;
+Ir	IR	f	IR
+Visible	Visible	f	Visible
+\.
+
+
+--
+-- Data for Name: e_gcal_shutter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gcal_shutter (id, short_name, obsolete, long_name) FROM stdin;
+Open	Open	f	Open
+Closed	Closed	f	Closed
 \.
 
 
@@ -936,6 +976,22 @@ ALTER TABLE ONLY e_gcal_continuum
 
 ALTER TABLE ONLY e_gcal_arc
     ADD CONSTRAINT e_gcal_arc_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e_gcal_diffuser; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY e_gcal_diffuser
+    ADD CONSTRAINT e_gcal_diffuser_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e_gcal_shutter; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY e_gcal_shutter
+    ADD CONSTRAINT e_gcal_shutter_pkey PRIMARY KEY (id);
 
 
 --
@@ -1274,6 +1330,31 @@ ALTER TABLE ONLY step_f2
 
 ALTER TABLE ONLY step_gcal
     ADD CONSTRAINT step_gcal_gcal_continuum_fkey FOREIGN KEY (continuum) REFERENCES e_gcal_continuum(id);
+
+
+--
+-- Name: step_gcal_gcal_filter_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY step_gcal
+    ADD CONSTRAINT step_gcal_gcal_filter_fkey FOREIGN KEY (filter) REFERENCES e_gcal_filter(id);
+
+
+--
+-- Name: step_gcal_gcal_diffuser_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY step_gcal
+    ADD CONSTRAINT step_gcal_gcal_diffuser_fkey FOREIGN KEY (diffuser) REFERENCES e_gcal_diffuser(id);
+
+
+--
+-- Name: step_gcal_gcal_shutter_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY step_gcal
+    ADD CONSTRAINT step_gcal_gcal_shutter_fkey FOREIGN KEY (shutter) REFERENCES e_gcal_shutter(id);
+
 
 --
 -- Name: step_gcal_index_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres


### PR DESCRIPTION
This PR fills in missing gcal parameters to complete manual Gcal steps (and eventually expanded smart gcal steps).  It also switches the gcal shutter type to an enum table to be consistent with the other fields.

__Note:__ Once again I updated the `V001__Initial_Setup.sql` file rather than adding a new migration.  The reasoning is that (a) it seems better if all the initial program model is in a single file and (b) more importantly though I could add columns to `step_gcal` in a separate migration, programs have to be reimported anyway to pick up the data in the new fields.