### PR TITLE
Location refactor and find function.

### DIFF
--- a/modules/core/src/main/scala/gem/Location.scala
+++ b/modules/core/src/main/scala/gem/Location.scala
@@ -1,5 +1,6 @@
 package gem
 
+import scala.annotation.tailrec
 import scalaz._, Scalaz._
 import scalaz.Ordering.{EQ, GT, LT}
 
@@ -10,46 +11,167 @@ import scalaz.Ordering.{EQ, GT, LT}
   * `Location` is a proper prefex of another, then it sorts ahead of the other
   * `Location`.
   */
-sealed abstract case class Location(toIList: IList[Int]) {
+sealed trait Location {
 
-  // Use the sketchy sealed abstract case class technique to control the
-  // NonEmptyList values that are passed to the constructor.  We want to
-  // ensure that trailing Int.MinValue is always trimmed so that EQ and ==
-  // agree.
+  // These functions aren't of any use to clients.  Instead they are involved
+  // in the cacluation of Locations that fall between two other locations.
 
-  def toList: List[Int] =
-    toIList.toList
+  /** Infinite Stream of position elements corresponding to this Location. */
+  protected def positions: Stream[Int]
 
-  override def toString: String =
-    toList.mkString("{", ",", "}")
+  /** Minimum size required to obtain all the fixed elements in this Location,
+    * if any.  Beginning and End Locations have no fixed elements.
+    */
+  protected def minPrefixLength: Int
 }
 
 object Location {
-  private def trim(is: Seq[Int]): IList[Int] =
-    trim(IList(is: _*))
 
-  // Remove trailing Int.MinValue so that == agrees with EQ.
-  private def trim(is: IList[Int]): IList[Int] =
-    is.dropRightWhile(_ == Int.MinValue)
+  /** A marker for the first Location.  No other Location comes before the
+    * Beginning.  Beginning should not be used to order elements unless you
+    * are sure no elements will ever need to be inserted before Beginning.  Use
+    * Beginning to calculate Locations that fall before the first existing
+    * Location (if any).
+    */
+  case object Beginning extends Location {
+    protected def positions: Stream[Int] =
+      Stream.continually(Int.MinValue)
+
+    protected def minPrefixLength: Int =
+      0
+
+    override def toString: String =
+      "{α}"
+  }
+
+  /** A Location that falls somewhere between the Beginning and End.
+    */
+  sealed abstract case class Middle(posList: OneAnd[IList, Int]) extends Location {
+    def positions: Stream[Int] =
+      posList.toStream #::: Stream.continually(Int.MinValue)
+
+    def toIList: IList[Int] =
+      posList.head +: posList.tail
+
+    def toList: List[Int] =
+      posList.head :: posList.tail.toList
+
+    protected def minPrefixLength: Int =
+      1 + posList.tail.length
+
+    override def toString =
+      toList.mkString("{", ",", "}")
+  }
+
+  /** A marker for the last Location.  No other Location comes after the End.
+    * End should not be used to order elements unless you are sure no elements
+    * will ever need to be inserted after End.  Use End to calculate new
+    * Locations that fall after the last existing Location (if any).
+    */
+  case object End extends Location {
+    def positions: Stream[Int] =
+      Stream.continually(Int.MaxValue)
+
+    protected def minPrefixLength: Int =
+      0
+
+    override def toString: String =
+      "{ω}"
+  }
+
+  // Constructors
 
   def apply(is: Int*): Location =
-    new Location(trim(is)) {}
+    fromTrimmedIList(IList(is: _*))
 
-  def fromList(is: List[Int]): Location =
-    new Location(trim(is)) {}
+  def fromFoldable[F[_]: Foldable](fi: F[Int]): Location =
+    fromTrimmedIList(IList.fromFoldable(fi))
 
-  def fromIList(is: IList[Int]): Location =
-    new Location(trim(is)) {}
+  private def fromTrimmedIList(is: IList[Int]): Location =
+    is.dropRightWhile(_ === Int.MinValue) match {
+      case INil()      => Beginning
+      case ICons(h, t) => new Location.Middle(OneAnd(h, t)) {}
+    }
 
-  def fromNel(n: NonEmptyList[Int]): Location =
-    new Location(trim(n.list)) {}
+  /** Assuming not all provided Ints are `Int.MinValue`, produces a `Middle`
+    * `Location`.
+    */
+  def unsafeMiddle(i: Int, is: Int*): Location.Middle =
+    unsafeMiddle(i :: is.toList)
 
-  implicit val OrderLocation: Order[Location] = Order.order { (l0, l1) =>
-    l0.toList
-      .zipAll(l1.toList, Int.MinValue, Int.MinValue)
-      .find { case (a, b) => a =/= b }
-      .fold[Ordering](EQ) { case (a, b) => (a < b) ?[Ordering] LT | GT }
+  /** Assuming not all provided Ints are `Int.MinValue`, produces a `Middle`
+    * `Location`.
+    */
+  def unsafeMiddle[F[_]: Foldable](fi: F[Int]): Location.Middle =
+    fromFoldable(fi) match {
+      case m: Location.Middle => m
+      case _                  => sys.error("Location arguments do not form a Middle position: " + fi.toList.mkString(", "))
+    }
+
+
+  // Utility
+
+  /** Finds `count` `Location`s that fall evenly distributed between `l0` and
+    * `l1`, assuming these locations are not the same.
+    *
+    * @param count how many locations to find
+    * @param start starting location (exclusive)
+    * @param end ending Location (exclusive)
+    *
+    * @return sorted list of `Location` where every element is GT l0 and LT l1
+    *         (or vice versa if l0 is GT l1)
+    */
+  def find(count: Int, start: Location, end: Location): IList[Location.Middle] = {
+    val Zero  = BigInt(0)
+    val One   = BigInt(1)
+    val Max   = BigInt(Int.MaxValue)
+    val Min   = BigInt(Int.MinValue)
+    val Radix = Max + Min.abs + One
+
+    def toBase10(loc: Location, len: Int): BigInt =
+      loc.positions.take(len).foldRight((Zero, One)) { case (i, (acc, pow)) =>
+        (acc + (BigInt(i) + Min.abs) * pow, pow * Radix)
+      }._1
+
+    def fromBase10(bi: BigInt): Location.Middle = {
+      @tailrec
+      def go(rem: BigInt, tail: IList[Int]): Location.Middle = {
+        val (a, b) = rem /% Radix
+        val head   = (b + Min).intValue
+        if (a === Zero) new Location.Middle(OneAnd(head, tail)) {} else go(a, head +: tail)
+      }
+      go(bi, IList.empty)
+    }
+
+    @tailrec
+    def go(len: Int): IList[Location.Middle] = {
+      val start10 = toBase10(start, len)
+      val end10   = toBase10(end, len)
+      val avail   = end10 - start10 - One
+
+      if (avail < count)
+        go(len + 1)
+      else {
+        val incr = (BigDecimal.exact(avail) / (count + 1)).setScale(0, BigDecimal.RoundingMode.CEILING).toBigInt
+        IList.fromList((1 to count).toList.map(i => fromBase10(start10 + (incr * i))))
+      }
+    }
+
+    if ((count <= 0) || (start >= end)) INil[Location.Middle]
+    else go(start.minPrefixLength max end.minPrefixLength)
   }
+
+  // Type Classes
+
+  implicit val OrderLocation: Order[Location] = Order.order(Function.untupled {
+    case (Beginning,  Beginning )                => EQ
+    case (End,        End       )                => EQ
+    case (Middle(m0), Middle(m1)) if (m0 === m1) => EQ
+    case (l0,         l1        )                =>
+      l0.positions.zip(l1.positions)
+        .find { case (a, b) => a =/= b }
+        .fold[Ordering](EQ) { case (a, b) => (a < b) ?[Ordering] LT | GT }
+  })
 
   implicit val ShowLocation: Show[Location] = Show.shows(_.toString)
 }

--- a/modules/core/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/Arbitraries.scala
@@ -4,9 +4,25 @@ import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
 
+import scalaz._, Scalaz._
+
 trait Arbitraries {
 
+  implicit val arbLocationMiddle: Arbitrary[Location.Middle] =
+    Arbitrary {
+      for {
+        i  <- choose(Int.MinValue + 1, Int.MaxValue)
+        is <- arbitrary[List[Int]]
+      } yield Location.unsafeMiddle(i, is: _*)
+    }
+
   implicit val arbLocation: Arbitrary[Location] =
-    Arbitrary { arbitrary[List[Int]].map(Location.fromList) }
+    Arbitrary {
+      Gen.frequency[Location](
+        (1, Location.Beginning),
+        (8, arbitrary[Location.Middle]),
+        (1, Location.End)
+      )
+    }
 
 }

--- a/modules/core/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/Arbitraries.scala
@@ -13,7 +13,7 @@ trait Arbitraries {
       for {
         i  <- choose(Int.MinValue + 1, Int.MaxValue)
         is <- arbitrary[List[Int]]
-      } yield Location.unsafeMiddle(i, is: _*)
+      } yield Location.unsafeMiddle(i +: is)
     }
 
   implicit val arbLocation: Arbitrary[Location] =

--- a/modules/core/src/test/scala/gem/LocationSpec.scala
+++ b/modules/core/src/test/scala/gem/LocationSpec.scala
@@ -5,12 +5,25 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
 import scalaz._, Scalaz._
+import scalaz.Ordering._
 
 class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbitraries {
-  "construction" should "trim trailing min values" in {
-    forAll { (l: Location) =>
+  "Construction" should "trim trailing min values from Middle" in {
+    forAll { (l: Location.Middle) =>
       val t = l.toIList
       t shouldEqual t.dropRightWhile(_ == Int.MinValue)
+    }
+  }
+
+  it should "produce Beginning if given an empty list" in {
+    Location.fromFoldable(List.empty[Int]) shouldEqual Location.Beginning
+  }
+
+  it should "produce beginning if given all Int.MinValue" in {
+    forAll { (i: Int) =>
+      val count = (i % 10).abs
+      val mins  = List.fill(count)(Int.MinValue)
+      Location.fromFoldable(mins) shouldEqual Location.Beginning
     }
   }
 
@@ -19,11 +32,89 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
       Order[Location].equal(l0, l1) shouldEqual (l0 == l1)
     }
   }
-}
 
-object LocationSpec {
-  private val ws = Array(' ', '\t', '\n', '\f', '\r')
-  private val r  = new Random
-  private def randomWhitespace: String =
-    new String((0 to r.nextInt(10)).toArray.map(_ => ws(r.nextInt(ws.size))))
+  "Find" should "return an empty list if the two positions are the same" in {
+    forAll { (l: Location) =>
+      Location.find(10, l, l) shouldEqual IList.empty[Location.Middle]
+    }
+  }
+
+  it should "return an empty list if the first position is >= the second" in {
+    forAll { (l0: Location, l1: Location) =>
+      val res = Order[Location].order(l0, l1) match {
+        case LT => Location.find(10, l1, l0)
+        case _  => Location.find(10, l0, l1)
+      }
+      res shouldEqual IList.empty[Location.Middle]
+    }
+  }
+
+  it should "find nothing if asked for a negative or 0 count" in {
+    forAll { (i: Int, l0: Location, l1: Location) =>
+      val negOrZero = -(i.abs)
+      Location.find(negOrZero, l0, l1) shouldEqual IList.empty[Location.Middle]
+    }
+  }
+
+  it should "find an arbitrary numer of Locations between unequal positions" in {
+    forAll { (i: Int, l0: Location, l1: Location) =>
+      val count = (i % 10000).abs + 1
+      Order[Location].order(l0, l1) match {
+        case LT => Location.find(count, l0, l1) should have length count
+        case GT => Location.find(count, l1, l0) should have length count
+        case EQ => Location.find(count, l0, l1) should have length 0
+      }
+    }
+  }
+
+  it should "produce a sorted list of Location.Middle" in {
+    forAll { (i: Int, l0: Location, l1: Location) =>
+      val count = (i % 10000).abs + 1
+      val res   = Order[Location].order(l0, l1) match {
+        case LT => l0 +: Location.find(count, l0, l1).widen[Location] :+ l1
+        case _  => l1 +: Location.find(count, l1, l0).widen[Location] :+ l0
+      }
+      res.sorted shouldEqual res
+    }
+  }
+
+  it should "grow the position list if necessary" in {
+    Location.find(1, Location(1, 2), Location(1,3)) match {
+      case ICons(res, INil()) =>
+        res.toList match {
+          case 1 :: 2 :: p :: Nil =>
+            p should not be Int.MinValue
+
+          case l                  =>
+            fail(s"Expectd List(1, 2, p) not ${l.mkString(",")}")
+        }
+
+      case l                =>
+        fail(s"Expected a single result not ${l.toList.mkString(",")}")
+    }
+  }
+
+  private def check(count: Int, low: Location, hi: Location, expected: List[Int]*): org.scalatest.compatible.Assertion =
+    Location.find(count, low, hi).toList.map(_.toList) shouldEqual expected.toList
+
+  it should "evenly space values it finds" in {
+    check(2, Location( 0), Location(10),  3 :: Nil,  6 :: Nil)
+    check(2, Location( 0), Location( 9),  3 :: Nil,  6 :: Nil)
+    check(2, Location( 0), Location( 8),  3 :: Nil,  6 :: Nil)
+    check(2, Location( 0), Location( 7),  2 :: Nil,  4 :: Nil)
+    check(2, Location( 0), Location( 6),  2 :: Nil,  4 :: Nil)
+    check(2, Location( 0), Location( 5),  2 :: Nil,  4 :: Nil)
+    check(2, Location( 0), Location( 4),  1 :: Nil,  2 :: Nil)
+    check(2, Location( 0), Location( 3),  1 :: Nil,  2 :: Nil)
+    check(2, Location(-7), Location( 0), -5 :: Nil, -3 :: Nil)
+
+    check(1, Location(1, 2), Location(1, 3),  1 :: 2 :: 0 :: Nil)
+    check(2, Location(1, 2), Location(1, 3),  1 :: 2 :: -715827883 :: Nil, 1 :: 2 :: 715827882 :: Nil)
+
+    check(2, Location(0), Location(2), 0 :: 715827883 :: Nil, 1 :: -715827882 :: Nil)
+
+    check(1, Location.Beginning,         Location.End,               -1 :: Nil)
+    check(1, Location.Beginning,         Location(Int.MinValue + 2), Int.MinValue + 1 :: Nil)
+    check(1, Location(Int.MaxValue - 2), Location.End,               Int.MaxValue - 1 :: Nil)
+  }
 }

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -13,7 +13,7 @@ import scalaz._, Scalaz._
 
 object StepDao {
 
-  def insert[I <: InstrumentConfig](oid: Observation.Id, loc: Location, s: Step[I]): ConnectionIO[Int] =
+  def insert[I <: InstrumentConfig](oid: Observation.Id, loc: Location.Middle, s: Step[I]): ConnectionIO[Int] =
     for {
       id <- insertBaseSlice(oid, loc, s.instrument, StepType.forStep(s))
       _  <- s match {
@@ -25,7 +25,7 @@ object StepDao {
       _  <- insertConfigSlice(id, s.instrument)
     } yield id
 
-  private def insertBaseSlice(oid: Observation.Id, loc: Location, i: InstrumentConfig, t: StepType): ConnectionIO[Int] =
+  private def insertBaseSlice(oid: Observation.Id, loc: Location.Middle, i: InstrumentConfig, t: StepType): ConnectionIO[Int] =
     for {
       _  <- sql"""INSERT INTO step (observation_id, location, instrument, step_type)
                        VALUES ($oid, $loc, ${Instrument.forConfig(i).tag}, ${t.tag} :: step_type)

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -49,8 +49,8 @@ package object dao extends MoreTupleOps with ToUserProgramRoleOps {
   implicit val InstantMeta: Meta[Instant] =
     Meta[Timestamp].nxmap(_.toInstant, Timestamp.from)
 
-  implicit val LocationMeta: Meta[Location] =
-    Meta[List[Int]].nxmap(Location.fromList, _.toList)
+  implicit val LocationMeta: Meta[Location.Middle] =
+    Meta[List[Int]].nxmap(Location.unsafeMiddle(_), _.toList)
 
   implicit val DurationMeta: Meta[Duration] =
     Meta[Long].xmap(Duration.ofSeconds, _.getSeconds)

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -95,7 +95,7 @@ object Importer extends SafeApp {
         ObservationDao.insert(newObs) *>
         configs.zipWithIndex.traverseU { case (c, n) =>
           for {
-            id <- StepDao.insert(newObs.id, Location(n * 100), c)
+            id <- StepDao.insert(newObs.id, Location.unsafeMiddle(n * 100), c)
             _  <- obsLog.get(n).foldMap { oldDataset =>
                     val lab = Dataset.Label.unsafeFromString(oldDataset.getLabel.toString)
                     val tim = Instant.ofEpochMilli(oldDataset.getTimestamp)


### PR DESCRIPTION
This PR updates `Location` to

* Add `Beginning` and `End` marker locations.  `Beginning` is a location that comes before all others and `End`, correspondingly, comes after all others.  You use the markers to insert elements at the front or end of a sequence.  For example, to put something at the beginning of the list you find a `Location` that falls between `Beginning` and the `Location` of the current first element.  Similarly you can find `Location`s between `Beginning` and `End` when inserting the initial elements of the sequence.

* Add `Middle` locations for all positions associated with elements in the sequence.

* Provide a `find` method for obtaining evenly spaced `Location`s between two given `Locations`.