### PR TITLE
Smart GCal  Steps

### DIFF
--- a/modules/core/src/main/scala/gem/Step.scala
+++ b/modules/core/src/main/scala/gem/Step.scala
@@ -9,8 +9,8 @@ sealed abstract class Step[A] extends Product with Serializable {
   def instrument: A
 }
 
-final case class BiasStep   [A](instrument: A)                             extends Step[A]
-final case class DarkStep   [A](instrument: A)                             extends Step[A]
-final case class GcalStep   [A](instrument: A, gcal:      GcalConfig)      extends Step[A]
-final case class ScienceStep[A](instrument: A, telescope: TelescopeConfig) extends Step[A]
-final case class SmartStep  [A](instrument: A, smartCal:  SmartCalConfig)  extends Step[A]
+final case class BiasStep     [A](instrument: A)                             extends Step[A]
+final case class DarkStep     [A](instrument: A)                             extends Step[A]
+final case class GcalStep     [A](instrument: A, gcal:      GcalConfig)      extends Step[A]
+final case class ScienceStep  [A](instrument: A, telescope: TelescopeConfig) extends Step[A]
+final case class SmartGcalStep[A](instrument: A, smartGcal: SmartGcalConfig) extends Step[A]

--- a/modules/core/src/main/scala/gem/Step.scala
+++ b/modules/core/src/main/scala/gem/Step.scala
@@ -1,7 +1,7 @@
 package gem
 
 import gem.config._
-import gem.enum.StepType
+import gem.enum.{SmartGcalType, StepType}
 
 import scalaz._, Scalaz._
 
@@ -9,8 +9,8 @@ sealed abstract class Step[A] extends Product with Serializable {
   def instrument: A
 }
 
-final case class BiasStep     [A](instrument: A)                             extends Step[A]
-final case class DarkStep     [A](instrument: A)                             extends Step[A]
-final case class GcalStep     [A](instrument: A, gcal:      GcalConfig)      extends Step[A]
-final case class ScienceStep  [A](instrument: A, telescope: TelescopeConfig) extends Step[A]
-final case class SmartGcalStep[A](instrument: A, smartGcal: SmartGcalConfig) extends Step[A]
+final case class BiasStep     [A](instrument: A)                               extends Step[A]
+final case class DarkStep     [A](instrument: A)                               extends Step[A]
+final case class GcalStep     [A](instrument: A, gcal:      GcalConfig)        extends Step[A]
+final case class ScienceStep  [A](instrument: A, telescope: TelescopeConfig)   extends Step[A]
+final case class SmartGcalStep[A](instrument: A, smartGcalType: SmartGcalType) extends Step[A]

--- a/modules/core/src/main/scala/gem/config/SmartCalConfig.scala
+++ b/modules/core/src/main/scala/gem/config/SmartCalConfig.scala
@@ -1,20 +1,6 @@
 package gem
 package config
 
-import scalaz._
+import gem.enum.SmartGcalType
 
-final case class SmartCalConfig(smartCalType: SmartCalConfig.Type)
-
-object SmartCalConfig {
-  sealed trait Type extends Product with Serializable
-  object Type {
-    case object Arc           extends Type
-    case object Flat          extends Type
-    case object DayBaseline   extends Type
-    case object NightBaseline extends Type
-
-    val Default = Arc
-    val All     = NonEmptyList(Arc, Flat, DayBaseline, NightBaseline)
-  }
-}
-
+final case class SmartCalConfig(smartGcalType: SmartGcalType)

--- a/modules/core/src/main/scala/gem/config/SmartCalConfig.scala
+++ b/modules/core/src/main/scala/gem/config/SmartCalConfig.scala
@@ -1,6 +1,0 @@
-package gem
-package config
-
-import gem.enum.SmartGcalType
-
-final case class SmartCalConfig(smartGcalType: SmartGcalType)

--- a/modules/core/src/main/scala/gem/config/SmartGcalConfig.scala
+++ b/modules/core/src/main/scala/gem/config/SmartGcalConfig.scala
@@ -1,0 +1,6 @@
+package gem
+package config
+
+import gem.enum.SmartGcalType
+
+final case class SmartGcalConfig(smartGcalType: SmartGcalType)

--- a/modules/core/src/main/scala/gem/config/SmartGcalConfig.scala
+++ b/modules/core/src/main/scala/gem/config/SmartGcalConfig.scala
@@ -1,6 +1,0 @@
-package gem
-package config
-
-import gem.enum.SmartGcalType
-
-final case class SmartGcalConfig(smartGcalType: SmartGcalType)

--- a/modules/core/src/main/scala/gem/enum/package.scala
+++ b/modules/core/src/main/scala/gem/enum/package.scala
@@ -20,11 +20,11 @@ package object enum {
   implicit class StepTypeCompanionOps(companion: StepType.type) {
     def forStep(s: Step[_]): StepType =
       s match {
-        case BiasStep(_)        => StepType.Bias
-        case DarkStep(_)        => StepType.Dark
-        case GcalStep(_, _)     => StepType.Gcal
-        case ScienceStep(_, _)  => StepType.Science
-        case SmartStep(_, _)    => StepType.Smart
+        case BiasStep(_)         => StepType.Bias
+        case DarkStep(_)         => StepType.Dark
+        case GcalStep(_, _)      => StepType.Gcal
+        case ScienceStep(_, _)   => StepType.Science
+        case SmartGcalStep(_, _) => StepType.SmartGcal
       }
   }
 

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -21,7 +21,7 @@ object StepDao {
               case DarkStep(_)         => insertDarkSlice(id)
               case ScienceStep(_, t)   => insertScienceSlice(id, t)
               case GcalStep(_, g)      => insertGcalSlice(id, g)
-              case SmartGcalStep(_, s) => insertSmartGcalSlice(id, s)
+              case SmartGcalStep(_, t) => insertSmartGcalSlice(id, t)
             }
       _  <- insertConfigSlice(id, s.instrument)
     } yield id
@@ -72,10 +72,10 @@ object StepDao {
     """.update.run
   }
 
-  private def insertSmartGcalSlice(id: Int, s: SmartGcalConfig): ConnectionIO[Int] =
+  private def insertSmartGcalSlice(id: Int, t: SmartGcalType): ConnectionIO[Int] =
     sql"""
       INSERT INTO step_smart_gcal (step_smart_gcal_id, type)
-      VALUES ($id, $s)
+      VALUES ($id, $t)
     """.update.run
 
   private def insertScienceSlice(id: Int, t: TelescopeConfig): ConnectionIO[Int] =
@@ -128,7 +128,7 @@ object StepDao {
           } yield GcalStep(i, GcalConfig(l, f, d, s, e, c))).getOrElse(sys.error("missing gcal information: " + gcal))
 
         case StepType.SmartGcal =>
-          smartGcalType.map(t => SmartGcalStep(i, SmartGcalConfig(t))).getOrElse(sys.error("missing smart gcal type"))
+          smartGcalType.map(t => SmartGcalStep(i, t)).getOrElse(sys.error("missing smart gcal type"))
 
         case StepType.Science =>
           telescope.apply2(TelescopeConfig(_, _))

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -17,11 +17,11 @@ object StepDao {
     for {
       id <- insertBaseSlice(oid, loc, s.instrument, StepType.forStep(s))
       _  <- s match {
-              case BiasStep(_)       => insertBiasSlice(id)
-              case DarkStep(_)       => insertDarkSlice(id)
-              case ScienceStep(_, t) => insertScienceSlice(id, t)
-              case GcalStep(_, g)    => insertGcalSlice(id, g)
-              case SmartStep(_, s)   => insertSmartSlice(id, s)
+              case BiasStep(_)         => insertBiasSlice(id)
+              case DarkStep(_)         => insertDarkSlice(id)
+              case ScienceStep(_, t)   => insertScienceSlice(id, t)
+              case GcalStep(_, g)      => insertGcalSlice(id, g)
+              case SmartGcalStep(_, s) => insertSmartGcalSlice(id, s)
             }
       _  <- insertConfigSlice(id, s.instrument)
     } yield id
@@ -72,9 +72,9 @@ object StepDao {
     """.update.run
   }
 
-  private def insertSmartSlice(id: Int, s: SmartCalConfig): ConnectionIO[Int] =
+  private def insertSmartGcalSlice(id: Int, s: SmartGcalConfig): ConnectionIO[Int] =
     sql"""
-      INSERT INTO step_smart_gcal (step_smart_id, type)
+      INSERT INTO step_smart_gcal (step_smart_gcal_id, type)
       VALUES ($id, $s)
     """.update.run
 
@@ -127,8 +127,8 @@ object StepDao {
             c    <- coaddsOpt
           } yield GcalStep(i, GcalConfig(l, f, d, s, e, c))).getOrElse(sys.error("missing gcal information: " + gcal))
 
-        case StepType.Smart =>
-          smartGcalType.map(t => SmartStep(i, SmartCalConfig(t))).getOrElse(sys.error("missing smart gcal type"))
+        case StepType.SmartGcal =>
+          smartGcalType.map(t => SmartGcalStep(i, SmartGcalConfig(t))).getOrElse(sys.error("missing smart gcal type"))
 
         case StepType.Science =>
           telescope.apply2(TelescopeConfig(_, _))

--- a/project/gen2.scala
+++ b/project/gen2.scala
@@ -165,6 +165,16 @@ object gen2 {
         io.transact(xa).unsafePerformIO
       },
 
+      enum("SmartGcalType") {
+        type SmartGcalTypeRec = Record.`'tag -> String`.T
+        val io = sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'smart_gcal_type'
+        """.query[(String, SmartGcalTypeRec)].list
+        io.transact(xa).unsafePerformIO
+      },
+
       enum("EventType") {
         type EventTypeRec = Record.`'tag -> String`.T
         val io = sql"""

--- a/sql/V001__Initial_Setup.sql
+++ b/sql/V001__Initial_Setup.sql
@@ -126,7 +126,7 @@ CREATE TYPE step_type AS ENUM (
     'Dark',
     'Gcal',
     'Science',
-    'Smart'
+    'SmartGcal'
 );
 
 
@@ -664,8 +664,8 @@ ALTER TABLE step_gcal OWNER TO postgres;
 --
 
 CREATE TABLE step_smart_gcal (
-    step_smart_id integer PRIMARY KEY REFERENCES step ON DELETE CASCADE,
-    type          smart_gcal_type NOT NULL
+    step_smart_gcal_id integer PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    type               smart_gcal_type NOT NULL
 );
 
 

--- a/sql/V001__Initial_Setup.sql
+++ b/sql/V001__Initial_Setup.sql
@@ -133,6 +133,20 @@ CREATE TYPE step_type AS ENUM (
 ALTER TYPE step_type OWNER TO postgres;
 
 --
+-- Name: smart_gcal_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE smart_gcal_type AS ENUM (
+    'Arc',
+    'Flat',
+    'DayBaseline',
+    'NightBaseline'
+);
+
+ALTER TYPE smart_gcal_type OWNER TO postgres;
+
+
+--
 -- Name: target_type; Type: TYPE; Schema: public; Owner: postgres
 --
 
@@ -644,6 +658,18 @@ CREATE TABLE step_gcal (
 
 
 ALTER TABLE step_gcal OWNER TO postgres;
+
+--
+-- Name: step_gcal; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_smart_gcal (
+    step_smart_id integer PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    type          smart_gcal_type NOT NULL
+);
+
+
+ALTER TABLE step_smart_gcal OWNER TO postgres;
 
 --
 -- Name: step_science; Type: TABLE; Schema: public; Owner: postgres


### PR DESCRIPTION
Adds a table, etc., for smart gcal steps.  Normalizes the various combinations of spelling and capitalization to SmartGcal for consistency.

__Note:__ we cannot distinguish smart steps from normal gcal steps in imported data, but I propose that the import just treat all existing smart steps as manual gcals.  If that doesn't turn out to be sufficient, we'll need an update to the old sequence model to inject some kind of "smart" key into the smart steps.