### PR TITLE
Warning Removal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,19 @@ lazy val testLibs = Seq(
 lazy val commonSettings = Seq(
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq(
-    "-feature",
     "-deprecation",
-    "-language:higherKinds"
+    "-encoding", "UTF-8",
+    "-feature",
+    "-language:higherKinds",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Xfuture",
+    "-Ywarn-unused-import"
   ),
   addCompilerPlugin("org.spire-math" %% "kind-projector" % kpVersion),
   libraryDependencies ++= ("org.scala-lang" %  "scala-reflect" % scalaVersion.value +: testLibs)

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,11 @@ lazy val testLibs = Seq(
 
 lazy val commonSettings = Seq(
   scalaVersion := "2.11.8",
+  scalacOptions ++= Seq(
+    "-feature",
+    "-deprecation",
+    "-language:higherKinds"
+  ),
   addCompilerPlugin("org.spire-math" %% "kind-projector" % kpVersion),
   libraryDependencies ++= ("org.scala-lang" %  "scala-reflect" % scalaVersion.value +: testLibs)
 )

--- a/modules/core/src/main/scala/gem/Observation.scala
+++ b/modules/core/src/main/scala/gem/Observation.scala
@@ -5,8 +5,8 @@ import gem.enum.Instrument
 import scalaz._, Scalaz._
 
 case class Observation[S](
-  id: Observation.Id, 
-  title: String, 
+  id: Observation.Id,
+  title: String,
   instrument: Option[Instrument], // redundant? this is on the steps too
   steps: List[S])
 

--- a/modules/core/src/main/scala/gem/Step.scala
+++ b/modules/core/src/main/scala/gem/Step.scala
@@ -1,9 +1,7 @@
 package gem
 
 import gem.config._
-import gem.enum.{SmartGcalType, StepType}
-
-import scalaz._, Scalaz._
+import gem.enum.SmartGcalType
 
 sealed abstract class Step[A] extends Product with Serializable {
   def instrument: A

--- a/modules/core/src/main/scala/gem/User.scala
+++ b/modules/core/src/main/scala/gem/User.scala
@@ -2,8 +2,6 @@ package gem
 
 import gem.enum.ProgramRole
 
-import java.time._
-
 import scala.language.implicitConversions
 
 import scalaz._, Scalaz._, scalaz.syntax.Ops

--- a/modules/core/src/main/scala/gem/User.scala
+++ b/modules/core/src/main/scala/gem/User.scala
@@ -2,8 +2,11 @@ package gem
 
 import gem.enum.ProgramRole
 
-import scalaz._, Scalaz._, scalaz.syntax.Ops
 import java.time._
+
+import scala.language.implicitConversions
+
+import scalaz._, Scalaz._, scalaz.syntax.Ops
 
 final case class User[A](
   id: User.Id,

--- a/modules/core/src/test/scala/gem/LocationSpec.scala
+++ b/modules/core/src/test/scala/gem/LocationSpec.scala
@@ -3,7 +3,6 @@ package gem
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.util.Random
 import scalaz._, Scalaz._
 import scalaz.Ordering._
 
@@ -60,8 +59,8 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
     forAll { (i: Int, l0: Location, l1: Location) =>
       val count = (i % 10000).abs + 1
       Order[Location].order(l0, l1) match {
-        case LT => Location.find(count, l0, l1) should have length count
-        case GT => Location.find(count, l1, l0) should have length count
+        case LT => Location.find(count, l0, l1).length shouldEqual count
+        case GT => Location.find(count, l1, l0).length shouldEqual count
         case EQ => Location.find(count, l0, l1) should have length 0
       }
     }

--- a/modules/db/src/main/scala/gem/dao/DatasetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/DatasetDao.scala
@@ -6,9 +6,6 @@ import doobie.imports._
 
 import java.time.Instant
 
-import scalaz._, Scalaz._
-
-
 object DatasetDao {
   def insert(sid: Int, d: Dataset): ConnectionIO[Int] =
     sql"""

--- a/modules/db/src/main/scala/gem/dao/EventLogDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EventLogDao.scala
@@ -8,8 +8,6 @@ import gem.enum.EventType.{Abort, Continue, EndIntegration, EndSequence, EndSlew
 import java.time.Instant
 import doobie.imports._
 
-import scalaz._, Scalaz._
-
 
 object EventLogDao {
 

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -10,8 +10,6 @@ import edu.gemini.spModel.core.ProgramId._
 import doobie.imports._
 import doobie.contrib.postgresql.syntax._
 
-import java.util.{Calendar, GregorianCalendar}
-
 import scalaz._, Scalaz._
 
 object ProgramDao {
@@ -51,12 +49,7 @@ object ProgramDao {
                    ${pid.index})
     """.update.run
 
-  private def insertDailyProgramIdSlice(pid: ProgramId.Daily): ConnectionIO[Int] = {
-    val cal = new GregorianCalendar(pid.siteVal.timezone())
-    // Calendar month is 0-based, day starts at 2PM / 14:00 local time
-    cal.set(pid.year, pid.month - 1, pid.day, 14, 0, 0)
-    cal.set(Calendar.MILLISECOND, 0)
-
+  private def insertDailyProgramIdSlice(pid: ProgramId.Daily): ConnectionIO[Int] =
     sql"""
       INSERT INTO program (program_id,
                           site,
@@ -65,9 +58,8 @@ object ProgramDao {
             VALUES (${pid: Program.Id},
                     ${pid.siteVal.toString},
                     ${pid.ptypeVal.toString},
-                    ${cal.getTime})
+                    ${new java.util.Date(pid.start)})
     """.update.run
-  }
 
   private def insertArbitraryProgramIdSlice(pid: ProgramId.Arbitrary): ConnectionIO[Int] =
     pid.semester.traverse(SemesterDao.canonicalize) *>

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -1,14 +1,11 @@
 package gem
 package dao
 
-import gem.enum._
-import gem.config._
-
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.ProgramId._
 
 import doobie.imports._
-import doobie.contrib.postgresql.syntax._
+//import doobie.contrib.postgresql.syntax._
 
 import scalaz._, Scalaz._
 

--- a/modules/db/src/main/scala/gem/dao/SemesterDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SemesterDao.scala
@@ -4,7 +4,6 @@ package dao
 import edu.gemini.spModel.core._
 
 import doobie.imports._
-//import doobie.contrib.postgresql.syntax._
 
 import scalaz._, Scalaz._
 

--- a/modules/db/src/main/scala/gem/dao/SemesterDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SemesterDao.scala
@@ -2,13 +2,11 @@ package gem
 package dao
 
 import edu.gemini.spModel.core._
-import edu.gemini.spModel.core.ProgramId._
 
 import doobie.imports._
-import doobie.contrib.postgresql.syntax._
+//import doobie.contrib.postgresql.syntax._
 
 import scalaz._, Scalaz._
-import scalaz.effect._
 
 object SemesterDao {
 

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -6,7 +6,7 @@ import gem.config._
 import gem.enum._
 
 import doobie.imports._
-import doobie.contrib.postgresql.pgtypes._
+//import doobie.contrib.postgresql.pgtypes._
 
 import java.time.Duration
 import scalaz._, Scalaz._

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -6,7 +6,6 @@ import gem.config._
 import gem.enum._
 
 import doobie.imports._
-//import doobie.contrib.postgresql.pgtypes._
 
 import java.time.Duration
 import scalaz._, Scalaz._

--- a/modules/importer/src/main/scala/ConfigReader.scala
+++ b/modules/importer/src/main/scala/ConfigReader.scala
@@ -65,7 +65,7 @@ object ConfigReader {
     val long:          Read[Long         ] = cast[Long]
     val offsetAngle:   Read[Angle        ] = string.map(s => Angle.fromArcsecs(s.toDouble))
     val yesNo:         Read[Boolean      ] = cast[YesNoType].map(_.toBoolean)
-    val durSecs:       Read[Duration     ] = double.map(_.toInt).map(s => Duration.ofSeconds(s.toLong))
+    val durSecs:       Read[Duration     ] = double.map(_.toLong).map(Duration.ofSeconds(_))
   }
 
 

--- a/modules/importer/src/main/scala/ConfigReader.scala
+++ b/modules/importer/src/main/scala/ConfigReader.scala
@@ -65,7 +65,7 @@ object ConfigReader {
     val long:          Read[Long         ] = cast[Long]
     val offsetAngle:   Read[Angle        ] = string.map(s => Angle.fromArcsecs(s.toDouble))
     val yesNo:         Read[Boolean      ] = cast[YesNoType].map(_.toBoolean)
-    val durSecs:       Read[Duration     ] = double.map(_.toInt).map(Duration.ofSeconds(_))
+    val durSecs:       Read[Duration     ] = double.map(_.toInt).map(s => Duration.ofSeconds(s.toLong))
   }
 
 

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -5,9 +5,7 @@ import gem.enum._
 import gem.config._
 
 import edu.gemini.pot.sp.{ISPProgram, ISPObservation}
-import edu.gemini.spModel.io.SpImportService
 import edu.gemini.spModel.core._
-import edu.gemini.pot.spdb.{ IDBDatabaseService, DBLocalDatabase }
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP;
 
@@ -21,13 +19,10 @@ import scala.collection.JavaConverters._
 import scalaz._, Scalaz._
 import scalaz.effect._
 import scalaz.concurrent.Task
-import scalaz.std.effect.closeable._
 
 import doobie.imports._
-import doobie.free.connection.ConnectionOp
 
 object Importer extends SafeApp {
-  import Program.Id._
   // import ConfigSyntax._
   import ConfigReader._
 

--- a/modules/importer/src/main/scala/Reader.scala
+++ b/modules/importer/src/main/scala/Reader.scala
@@ -2,13 +2,9 @@ package gem
 
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.spModel.io.impl.PioSpXmlParser
-import edu.gemini.spModel.io.SpImportService
-import edu.gemini.spModel.core.ProgramId
-import edu.gemini.spModel.core.ProgramId._
 import edu.gemini.pot.spdb.{ IDBDatabaseService, DBLocalDatabase }
 
 import java.io._
-import java.util.logging.{ Logger, Level }
 
 import scalaz.Scalaz._
 import scalaz.effect._
@@ -20,7 +16,7 @@ case class ProgramReader(parser: PioSpXmlParser) {
       IO(new InputStreamReader(fis, "UTF-8")).using { r =>
         IO {
           parser.parseDocument(r) match {
-            case p: ISPProgram => Some(p) 
+            case p: ISPProgram => Some(p)
             case _             => None // not a science program
           }
         }
@@ -29,7 +25,7 @@ case class ProgramReader(parser: PioSpXmlParser) {
 }
 
 object ProgramReader {
-  
+
   implicit val IDBDatabaseServiceResource: Resource[IDBDatabaseService] =
     new Resource[IDBDatabaseService] {
       def close(db: IDBDatabaseService) = IO(db.getDBAdmin.shutdown())

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -1,8 +1,6 @@
 package gem
 
 import edu.gemini.spModel.core._
-import gem.enum.Instrument
-import gem.config._
 import java.time.Duration
 import argonaut._, Argonaut._, ArgonautShapeless._
 import scalaz.{ ISet, OneAnd, Order }

--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -44,7 +44,7 @@ object Service {
   def tryLogin[M[_]: Monad: Catchable: Capture](
     user: User.Id, pass: String, xa: Transactor[M], txa: Transactor[Task]
   ): M[Option[Service[M]]] =
-    xa.transact(UserDao.selectWithRoles(user, pass)).flatMap {
+    xa.trans(UserDao.selectWithRoles(user, pass)).flatMap {
       case None    => Option.empty[Service[M]].point[M]
       case Some(u) => Log.newLog[M](s"session:$u.name", txa).map(l => Some(Service[M](xa, l, u)))
     }

--- a/modules/telnetd/src/main/scala/command/ls.scala
+++ b/modules/telnetd/src/main/scala/command/ls.scala
@@ -2,7 +2,6 @@ package gem
 package telnetd
 package command
 
-import gem.dao.ProgramDao
 import net.bmjames.opts.{ intOption, help, metavar, short, long, value, strArgument }
 import net.bmjames.opts.types.Parser
 import tuco._, Tuco._

--- a/modules/telnetd/src/main/scala/command/passwd.scala
+++ b/modules/telnetd/src/main/scala/command/passwd.scala
@@ -2,7 +2,6 @@ package gem
 package telnetd
 package command
 
-import gem.enum.ProgramRole
 import net.bmjames.opts.types._
 import tuco._, Tuco._
 

--- a/modules/telnetd/src/main/scala/interact.scala
+++ b/modules/telnetd/src/main/scala/interact.scala
@@ -1,11 +1,8 @@
 package gem
 package telnetd
 
-import gem.dao.UserDao
-import gem.enum.ProgramRole
-
-import doobie.imports.{ Capture => DCapture, Transactor }
-import scalaz._, Scalaz._, scalaz.effect._, scalaz.concurrent.Task
+import doobie.imports.Transactor
+import scalaz._, Scalaz._, scalaz.concurrent.Task
 import tuco._, Tuco._
 
 /** Module defining the behavior of our telnet server, parameterized over transactors. */


### PR DESCRIPTION
This tiny PR removes all compile warnings (in conjunction with the SmartGcal step PR which handles a couple "match may not be exhaustive" warnings).  Most warnings were about using higher kinded types so I just enabled that everywhere instead of importing it into individual classes.  We're all about high kinds.

I think we should soon enable `-Xfatal-warnings` as well.  Warnings tend to pile up if you don't deal with them, as you can see in the "ocs" project build.