### PR TITLE
Enable idea to find generated source code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val core = project
       "com.chuusai" %% "shapeless"   % shapelessVersion
     ),
     sourceGenerators in Compile +=
-      Def.task { gen2(sourceManaged.value / "gem").unsafePerformIO }.taskValue
+      Def.task { gen2((sourceManaged in Compile).value / "gem").unsafePerformIO }.taskValue
   )
 
 lazy val db = project


### PR DESCRIPTION
This little change on the build let's idea on my machine to find the generated code automatically. Would be good that somebody else could test it