### PR TITLE
Smart gcal select

### DIFF
--- a/modules/core/src/main/scala/gem/enum/package.scala
+++ b/modules/core/src/main/scala/gem/enum/package.scala
@@ -28,4 +28,14 @@ package object enum {
       }
   }
 
+  /** Add fold on SmartGcalType. */
+  implicit class SmartGcalTypeOps(t: SmartGcalType) {
+    def fold[X](lamp: GcalLampType => X, baseline: GcalBaselineType => X): X =
+      t match {
+        case SmartGcalType.Arc           => lamp(GcalLampType.Arc)
+        case SmartGcalType.Flat          => lamp(GcalLampType.Flat)
+        case SmartGcalType.DayBaseline   => baseline(GcalBaselineType.Day)
+        case SmartGcalType.NightBaseline => baseline(GcalBaselineType.Night)
+      }
+  }
 }

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -1,18 +1,11 @@
 package gem.dao
 
 import gem.config.{F2SmartGcalKey, GcalConfig, SmartGcalKey}
-import gem.enum.{GcalBaselineType, GcalLampType, SmartGcalType}
+import gem.enum._
 import doobie.imports._
 import scalaz._, Scalaz._
 
 object SmartGcalDao {
-  def split(t: SmartGcalType): GcalLampType \/ GcalBaselineType =
-    t match {
-      case SmartGcalType.Arc           => GcalLampType.Arc.left
-      case SmartGcalType.Flat          => GcalLampType.Flat.left
-      case SmartGcalType.DayBaseline   => GcalBaselineType.Day.right
-      case SmartGcalType.NightBaseline => GcalBaselineType.Night.right
-    }
 
   def selectF2(k: F2SmartGcalKey, t: SmartGcalType): ConnectionIO[List[Int]] = {
     def byLamp(l: GcalLampType): ConnectionIO[List[Int]] =
@@ -35,7 +28,7 @@ object SmartGcalDao {
            AND fpu       = ${k.fpu}
       """.query[Int].list
 
-    split(t).fold(byLamp, byBaseline)
+    t.fold(byLamp, byBaseline)
   }
 
   def select(k: SmartGcalKey, t: SmartGcalType): ConnectionIO[List[GcalConfig]] =

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -1,10 +1,52 @@
 package gem.dao
 
 import gem.config.{F2SmartGcalKey, GcalConfig, SmartGcalKey}
-import gem.enum.{GcalBaselineType, GcalLampType}
+import gem.enum.{GcalBaselineType, GcalLampType, SmartGcalType}
 import doobie.imports._
+import scalaz._, Scalaz._
 
 object SmartGcalDao {
+  def split(t: SmartGcalType): GcalLampType \/ GcalBaselineType =
+    t match {
+      case SmartGcalType.Arc           => GcalLampType.Arc.left
+      case SmartGcalType.Flat          => GcalLampType.Flat.left
+      case SmartGcalType.DayBaseline   => GcalBaselineType.Day.right
+      case SmartGcalType.NightBaseline => GcalBaselineType.Night.right
+    }
+
+  def selectF2(k: F2SmartGcalKey, t: SmartGcalType): ConnectionIO[List[Int]] = {
+    def byLamp(l: GcalLampType): ConnectionIO[List[Int]] =
+      sql"""
+        SELECT gcal_id
+          FROM smart_f2
+         WHERE lamp      = $l :: gcal_lamp_type
+           AND disperser = ${k.disperser}
+           AND filter    = ${k.filter}
+           AND fpu       = ${k.fpu}
+      """.query[Int].list
+
+    def byBaseline(b: GcalBaselineType): ConnectionIO[List[Int]] =
+      sql"""
+        SELECT gcal_id
+          FROM smart_f2
+         WHERE baseline  = $b :: gcal_baseline_type
+           AND disperser = ${k.disperser}
+           AND filter    = ${k.filter}
+           AND fpu       = ${k.fpu}
+      """.query[Int].list
+
+    split(t).fold(byLamp, byBaseline)
+  }
+
+  def select(k: SmartGcalKey, t: SmartGcalType): ConnectionIO[List[GcalConfig]] =
+    for {
+      ids <- k match {
+              case f2: F2SmartGcalKey => selectF2(f2, t)
+            }
+      gcs <- ids.traverseU { GcalDao.select }.map(_.flatten)
+    } yield gcs
+
+
   def insert(l: GcalLampType, b: GcalBaselineType, k: SmartGcalKey, g: GcalConfig): ConnectionIO[Int] = {
     def insertSmartF2(gcalId: Int, k: F2SmartGcalKey): ConnectionIO[Int] =
       sql"""

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -1,0 +1,60 @@
+package gem.dao
+
+import gem.config.{GcalConfig, SmartGcalKey, F2SmartGcalKey}
+import gem.enum.{F2Disperser, F2Filter, F2FpUnit, SmartGcalType}
+
+import doobie.imports._
+
+import java.time.{Duration, Instant}
+
+import scala.util.Random
+import scalaz._, Scalaz._
+import scalaz.effect.IO
+
+// Sample code that exercises SmartGcalDao.select.
+
+object SmartGcalSample {
+  val xa = DriverManagerTransactor[IO](
+    "org.postgresql.Driver",
+    "jdbc:postgresql:gem",
+    "postgres",
+    ""
+  )
+
+  val allF2: Vector[SmartGcalKey] =
+    (for {
+      u <- F2FpUnit.all
+      f <- F2Filter.all
+      d <- F2Disperser.all
+    } yield F2SmartGcalKey(u, f, d)).toVector
+
+
+  val rand = new Random(0)
+
+  def nextType(): SmartGcalType =
+    SmartGcalType.all(rand.nextInt(4))
+
+  def nextKey(): SmartGcalKey =
+    allF2(rand.nextInt(allF2.size))
+
+  def runSelects: ConnectionIO[List[(SmartGcalKey, SmartGcalType, List[GcalConfig])]] =
+    (1 to 1000).toList.map(_ => (nextKey, nextType)).traverseU { case (k, t) =>
+      SmartGcalDao.select(k, t).map { g => (k, t, g) }
+    }
+
+  def runc: IO[Unit] =
+    for {
+      l <- runSelects.transact(xa)
+      _ <- IO.putStrLn(l.mkString(",\n"))
+      _ <- IO.putStrLn("Done.")
+    } yield ()
+
+  def main(args: Array[String]): Unit = {
+    val start = Instant.now()
+    runc.unsafePerformIO()
+    val end   = Instant.now()
+
+    println(Duration.ofMillis(end.toEpochMilli - start.toEpochMilli))
+    // A bit less than 1.6 seconds ...
+  }
+}


### PR DESCRIPTION
A small PR that updates the `SmartGcalDao` to add a select by key and `SmartGcalType`.  The type is one of `Arc`, `Flat`, `DayBaseline`, or `NightBaseline`.  Each entry in a smart gcal table like `smart_f2` is tagged with a `lamp` type which is `Arc` or `Flat`, and a `baseline` type which is `Day` or `Night`.  Depending on the `SmartGcalType` (and the instrument fields), the row is selected or not.

````
gem-# select * from smart_f2;
 lamp | baseline |  disperser  | filter |    fpu    | gcal_id 
------+----------+-------------+--------+-----------+---------
 Arc  | Night    | R1200JH     | JH     | LongSlit1 |       1
 Arc  | Night    | R1200JH     | JH     | LongSlit2 |       2
 Arc  | Night    | R1200JH     | JH     | LongSlit3 |       3
...
````

This PR highlights a problem that I don't know how to address.  The issue is that the most efficient query would join the instrument key table (e.g., `smart_f2`) with `gcal` to produce an immediate result.  Unfortunately that would require duplicating the 10 fields of `gcal` for each instrument and type (lamp vs. baseline).  In other words, duplicating 10 gcal fields (2 x #instruments) times in the code.

Rather than do that, I just run separate queries:  an initial query of `smart_f2` for all the matching `gcal_id` and then the `gcal` table with the appropriate ids.  I think there must be a better way?