### PR TITLE
Make StepDao.selectAll select all

### DIFF
--- a/modules/core/src/main/scala/gem/Step.scala
+++ b/modules/core/src/main/scala/gem/Step.scala
@@ -3,6 +3,8 @@ package gem
 import gem.config._
 import gem.enum.SmartGcalType
 
+import scalaz.Functor
+
 sealed abstract class Step[A] extends Product with Serializable {
   def instrument: A
 }
@@ -12,3 +14,16 @@ final case class DarkStep     [A](instrument: A)                               e
 final case class GcalStep     [A](instrument: A, gcal:      GcalConfig)        extends Step[A]
 final case class ScienceStep  [A](instrument: A, telescope: TelescopeConfig)   extends Step[A]
 final case class SmartGcalStep[A](instrument: A, smartGcalType: SmartGcalType) extends Step[A]
+
+object Step {
+  implicit val FunctorStep: Functor[Step] = new Functor[Step] {
+    def map[A, B](fa: Step[A])(f: A => B): Step[B] =
+      fa match {
+        case BiasStep(a)         => BiasStep(f(a))
+        case DarkStep(a)         => DarkStep(f(a))
+        case GcalStep(a, g)      => GcalStep(f(a), g)
+        case ScienceStep(a, t)   => ScienceStep(f(a), t)
+        case SmartGcalStep(a, s) => SmartGcalStep(f(a), s)
+      }
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -45,7 +45,7 @@ object ObservationDao {
   def select(id: Observation.Id): ConnectionIO[Observation[Step[_]]] =
     for {
       on <- selectFlat(id)
-      ss <- StepDao.selectAll(id)
+      ss <- StepDao.selectEmpty(id)
     } yield on.copy(steps = ss)
 
   def selectAllFlat(pid: Program.Id): ConnectionIO[List[Observation[Nothing]]] =

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -5,21 +5,12 @@ import gem.enum.{F2Disperser, F2Filter, F2FpUnit, SmartGcalType}
 
 import doobie.imports._
 
-import java.time.{Duration, Instant}
-
 import scala.util.Random
 import scalaz._, Scalaz._
-import scalaz.effect.IO
 
 // Sample code that exercises SmartGcalDao.select.
-
-object SmartGcalSample {
-  val xa = DriverManagerTransactor[IO](
-    "org.postgresql.Driver",
-    "jdbc:postgresql:gem",
-    "postgres",
-    ""
-  )
+object SmartGcalSample extends TimedSample {
+  type Result = List[(SmartGcalKey, SmartGcalType, List[GcalConfig])]
 
   val allF2: Vector[SmartGcalKey] =
     (for {
@@ -37,27 +28,19 @@ object SmartGcalSample {
   def nextKey(): SmartGcalKey =
     allF2(rand.nextInt(allF2.size))
 
-  def runSelects(qs: List[(SmartGcalKey, SmartGcalType)]): ConnectionIO[List[(SmartGcalKey, SmartGcalType, List[GcalConfig])]] =
-    qs.traverseU { case (k, t) =>
+  override def runl(args: List[String]): ConnectionIO[Result] =
+    ((1 to 1000).toList.map(_ => (nextKey, nextType))).traverseU { case (k, t) =>
       SmartGcalDao.select(k, t).map { g => (k, t, g) }
     }
 
-  def main(args: Array[String]): Unit = {
-    val querys = (1 to 1000).toList.map(_ => (nextKey, nextType))
-    val start  = Instant.now()
-    val result = runSelects(querys).transact(xa).unsafePerformIO()
-    val end    = Instant.now()
+  override def format(r: Result): String =
+    r.mkString(", \n")
 
-    println(result.mkString(", \n"))
-    println(Duration.ofMillis(end.toEpochMilli - start.toEpochMilli))
-
-    //
-    // A bit less than 1.6 seconds ...  adding indices doesn't seem to make a
-    // difference:
-    //
-    //    "smart_f2_baseline_disperser_filter_fpu_idx" btree (baseline, disperser, filter, fpu)
-    //    "smart_f2_lamp_disperser_filter_fpu_idx" btree (lamp, disperser, filter, fpu)
-    //
-
-  }
+  //
+  // A bit less than 1.6 seconds ...  adding indices doesn't seem to make a
+  // difference:
+  //
+  //    "smart_f2_baseline_disperser_filter_fpu_idx" btree (baseline, disperser, filter, fpu)
+  //    "smart_f2_lamp_disperser_filter_fpu_idx" btree (lamp, disperser, filter, fpu)
+  //
 }

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -1,0 +1,21 @@
+package gem.dao
+
+import gem.{Observation, Step}
+import gem.config.InstrumentConfig
+import gem.enum.Instrument
+
+import doobie.imports._
+
+//import scalaz._, Scalaz._
+
+object StepDaoSample extends TimedSample {
+  type Result = List[Step[InstrumentConfig]]
+
+  val oid = Observation.Id.unsafeFromString("GS-2016A-Q-102-108")
+
+  override def runl(args: List[String]): ConnectionIO[Result] =
+    StepDao.selectAll(oid, Instrument.Flamingos2)
+
+  override def format(r: Result): String =
+    r.mkString(", \n")
+}

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -2,11 +2,8 @@ package gem.dao
 
 import gem.{Observation, Step}
 import gem.config.InstrumentConfig
-import gem.enum.Instrument
 
 import doobie.imports._
-
-//import scalaz._, Scalaz._
 
 object StepDaoSample extends TimedSample {
   type Result = List[Step[InstrumentConfig]]
@@ -14,7 +11,7 @@ object StepDaoSample extends TimedSample {
   val oid = Observation.Id.unsafeFromString("GS-2016A-Q-102-108")
 
   override def runl(args: List[String]): ConnectionIO[Result] =
-    StepDao.selectAll(oid, Instrument.Flamingos2)
+    StepDao.selectAll(oid)
 
   override def format(r: Result): String =
     r.mkString(", \n")

--- a/modules/db/src/test/scala/gem/dao/TimedSample.scala
+++ b/modules/db/src/test/scala/gem/dao/TimedSample.scala
@@ -1,0 +1,32 @@
+package gem.dao
+
+import doobie.imports._
+
+import java.time.{Duration, Instant}
+
+import scalaz.effect.IO
+
+trait TimedSample {
+  type Result
+
+  val xa = DriverManagerTransactor[IO](
+    "org.postgresql.Driver",
+    "jdbc:postgresql:gem",
+    "postgres",
+    ""
+  )
+
+  def runl(args: List[String]): ConnectionIO[Result]
+
+  def format(r: Result): String
+
+  def main(args: Array[String]): Unit = {
+    val p     = runl(args.toList)
+    val start = Instant.now()
+    val a     = p.transact(xa).unsafePerformIO()
+    val end   = Instant.now()
+
+    println(format(a))
+    println(Duration.ofMillis(end.toEpochMilli - start.toEpochMilli))
+  }
+}


### PR DESCRIPTION
This PR updates the `StepDao.selectAll` method to return steps containing their corresponding instrument configuration.  It also adds a sample application to exercise the `selectAll` function.  Outstanding issues include:

* Each observation is associated with an instrument, and all steps will have a corresponding instrument configuration.  You supply the expected instrument in the call to `selectAll`.  If you are correct all is well.  If you are wrong the query will generate an exception.   There are at least two ways to fix that:

  1. Don't specify the instrument and instead query the observation to read it.

  2. Amend the instrument-specific queries like `selectF2` to anticipate `null` values in the join.  Null rows could be skipped resulting in an empty list of steps instead of an exception.

* Sample applications are fine for development but we need to figure out a testing environment to use with the database.