### PR TITLE
F2 Read Mode

### DIFF
--- a/modules/core/src/main/scala/gem/config/InstrumentConfig.scala
+++ b/modules/core/src/main/scala/gem/config/InstrumentConfig.scala
@@ -10,23 +10,23 @@ sealed abstract class InstrumentConfig extends Product with Serializable
 sealed trait SmartGcalKey
 
 final case class F2SmartGcalKey(
-  fpu:       F2FpUnit,
+  disperser: F2Disperser,
   filter:    F2Filter,
-  disperser: F2Disperser
+  fpu:       F2FpUnit
 ) extends SmartGcalKey
 
 final case class F2Config(
-  fpu:           F2FpUnit,
-  mosPreimaging: Boolean,
+  disperser:     F2Disperser,
   exposureTime:  Duration,
   filter:        F2Filter,
+  fpu:           F2FpUnit,
   lyotWheel:     F2LyotWheel,
-  disperser:     F2Disperser,
+  mosPreimaging: Boolean,
   windowCover:   F2WindowCover
 ) extends InstrumentConfig {
 
   def smartGcalKey: F2SmartGcalKey =
-    F2SmartGcalKey(fpu, filter, disperser)
+    F2SmartGcalKey(disperser, filter, fpu)
 }
 
 // TODO: temporary, until all instruments are supported

--- a/modules/core/src/main/scala/gem/config/InstrumentConfig.scala
+++ b/modules/core/src/main/scala/gem/config/InstrumentConfig.scala
@@ -22,6 +22,7 @@ final case class F2Config(
   fpu:           F2FpUnit,
   lyotWheel:     F2LyotWheel,
   mosPreimaging: Boolean,
+  readMode:      F2ReadMode,
   windowCover:   F2WindowCover
 ) extends InstrumentConfig {
 

--- a/modules/core/src/main/scala/gem/enum/package.scala
+++ b/modules/core/src/main/scala/gem/enum/package.scala
@@ -11,8 +11,8 @@ package object enum {
   implicit class InstrumentCompanionOps(companion: Instrument.type) {
     def forConfig(c: InstrumentConfig): Instrument =
       c match {
-        case F2Config(_, _, _, _, _, _, _) => Instrument.Flamingos2
-        case GenericConfig(i)              => i
+        case F2Config(_, _, _, _, _, _, _, _) => Instrument.Flamingos2
+        case GenericConfig(i)                 => i
       }
   }
 

--- a/modules/db/src/main/scala/gem/dao/GcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GcalDao.scala
@@ -14,7 +14,7 @@ object GcalDao {
 
     for {
       _ <- sql"""INSERT INTO gcal (continuum, ar_arc, cuar_arc, thar_arc, xe_arc, filter, diffuser, shutter, exposure_time, coadds)
-                      VALUES (${gcal.continuum}, ${arcs(ArArc)}, ${arcs(CuArArc)}, ${arcs(ThArArc)}, ${arcs(XeArc)}, ${gcal.filter}, ${gcal.diffuser}, ${gcal.shutter}, ${gcal.exposureTime.getSeconds}, ${gcal.coadds})
+                      VALUES (${gcal.continuum}, ${arcs(ArArc)}, ${arcs(CuArArc)}, ${arcs(ThArArc)}, ${arcs(XeArc)}, ${gcal.filter}, ${gcal.diffuser}, ${gcal.shutter}, ${gcal.exposureTime}, ${gcal.coadds})
               """.update.run
       id <- sql"select lastval()".query[Int].unique
     } yield id

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -88,10 +88,10 @@ object StepDao {
   private def insertConfigSlice(id: Int, i: InstrumentConfig): ConnectionIO[Int] =
     i match {
 
-      case F2Config(fpu, mosPreimaging, exposureTime, filter, lyotWheel, disperser, windowCover) =>
+      case F2Config(disperser, exposureTime, filter, fpu, lyotWheel, mosPreimaging, windowCover) =>
         sql"""
-          INSERT INTO step_f2 (step_f2_id, fpu, mos_preimaging, exposure_time, filter, lyot_wheel, disperser, window_cover)
-          VALUES ($id, $fpu, $mosPreimaging, $exposureTime, $filter, $lyotWheel, $disperser, $windowCover)
+          INSERT INTO step_f2 (step_f2_id, disperser, exposure_time, filter, fpu, lyot_wheel, mos_preimaging, window_cover)
+          VALUES ($id, $disperser, $exposureTime, $filter, $fpu, $lyotWheel, $mosPreimaging, $windowCover)
         """.update.run
 
       case GenericConfig(i) => 0.point[ConnectionIO]
@@ -182,12 +182,12 @@ object StepDao {
     */
   def selectF2(oid: Observation.Id): ConnectionIO[List[F2Config]] =
     sql"""
-      SELECT i.fpu,
-             i.mos_preimaging,
+      SELECT i.disperser,
              i.exposure_time,
              i.filter,
+             i.fpu,
              i.lyot_wheel,
-             i.disperser,
+             i.mos_preimaging,
              i.window_cover
         FROM step s
              LEFT OUTER JOIN step_f2 i

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -88,10 +88,10 @@ object StepDao {
   private def insertConfigSlice(id: Int, i: InstrumentConfig): ConnectionIO[Int] =
     i match {
 
-      case F2Config(disperser, exposureTime, filter, fpu, lyotWheel, mosPreimaging, windowCover) =>
+      case F2Config(disperser, exposureTime, filter, fpu, lyotWheel, mosPreimaging, readMode, windowCover) =>
         sql"""
-          INSERT INTO step_f2 (step_f2_id, disperser, exposure_time, filter, fpu, lyot_wheel, mos_preimaging, window_cover)
-          VALUES ($id, $disperser, $exposureTime, $filter, $fpu, $lyotWheel, $mosPreimaging, $windowCover)
+          INSERT INTO step_f2 (step_f2_id, disperser, exposure_time, filter, fpu, lyot_wheel, mos_preimaging, read_mode, window_cover)
+          VALUES ($id, $disperser, $exposureTime, $filter, $fpu, $lyotWheel, $mosPreimaging, $readMode, $windowCover)
         """.update.run
 
       case GenericConfig(i) => 0.point[ConnectionIO]
@@ -188,6 +188,7 @@ object StepDao {
              i.fpu,
              i.lyot_wheel,
              i.mos_preimaging,
+             i.read_mode,
              i.window_cover
         FROM step s
              LEFT OUTER JOIN step_f2 i

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -91,7 +91,7 @@ object StepDao {
       case F2Config(fpu, mosPreimaging, exposureTime, filter, lyotWheel, disperser, windowCover) =>
         sql"""
           INSERT INTO step_f2 (step_f2_id, fpu, mos_preimaging, exposure_time, filter, lyot_wheel, disperser, window_cover)
-          VALUES ($id, $fpu, $mosPreimaging, ${exposureTime.getSeconds}, $filter, $lyotWheel, $disperser, $windowCover)
+          VALUES ($id, $fpu, $mosPreimaging, $exposureTime, $filter, $lyotWheel, $disperser, $windowCover)
         """.update.run
 
       case GenericConfig(i) => 0.point[ConnectionIO]

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -53,7 +53,7 @@ package object dao extends MoreTupleOps with ToUserProgramRoleOps {
     Meta[List[Int]].nxmap(Location.unsafeMiddle(_), _.toList)
 
   implicit val DurationMeta: Meta[Duration] =
-    Meta[Long].xmap(Duration.ofSeconds, _.getSeconds)
+    Meta[Long].xmap(Duration.ofMillis, _.toMillis)
 
   def capply2[A, B, T](f: (A, B) => T)(
     implicit ca: Composite[(Option[A], Option[B])]

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -14,10 +14,10 @@ object SmartGcalSample extends TimedSample {
 
   val allF2: Vector[SmartGcalKey] =
     (for {
-      u <- F2FpUnit.all
-      f <- F2Filter.all
       d <- F2Disperser.all
-    } yield F2SmartGcalKey(u, f, d)).toVector
+      f <- F2Filter.all
+      u <- F2FpUnit.all
+    } yield F2SmartGcalKey(d, f, u)).toVector
 
 
   val rand = new Random(0)

--- a/modules/describe/src/main/scala/gem/describe/F2Describe.scala
+++ b/modules/describe/src/main/scala/gem/describe/F2Describe.scala
@@ -44,7 +44,7 @@ trait F2Describe {
   object LyotWheelProp extends Prop[F2Config] {
     type B = F2LyotWheel
     val eq: Equal[F2LyotWheel]  = implicitly
-    val lens: F2Config @> F2LyotWheel = Lens.lensu((a,b) => a.copy(lyoutWheel = b), _.lyoutWheel)
+    val lens: F2Config @> F2LyotWheel = Lens.lensu((a,b) => a.copy(lyotWheel = b), _.lyotWheel)
     val meta = forEnumerated[F2LyotWheel](Attrs(lab("Lyot Wheel"), Science, SingleStep))
   }
 

--- a/modules/importer/src/main/scala/ConfigReader.scala
+++ b/modules/importer/src/main/scala/ConfigReader.scala
@@ -65,7 +65,7 @@ object ConfigReader {
     val long:          Read[Long         ] = cast[Long]
     val offsetAngle:   Read[Angle        ] = string.map(s => Angle.fromArcsecs(s.toDouble))
     val yesNo:         Read[Boolean      ] = cast[YesNoType].map(_.toBoolean)
-    val durSecs:       Read[Duration     ] = double.map(_.toLong).map(Duration.ofSeconds(_))
+    val durSecs:       Read[Duration     ] = double.map(d => (d * 1000).round).map(Duration.ofMillis(_))
   }
 
 
@@ -132,8 +132,8 @@ object ConfigReader {
     }
 
     case object Observe extends System("observe") {
-      val ObserveType   = Key[String  ]("observeType",  identity             )(Read.string)
-      val ExposureTime  = Key[Duration]("exposureTime", _.getSeconds.toString)(Read.durSecs)
+      val ObserveType   = Key[String  ]("observeType",  identity           )(Read.string)
+      val ExposureTime  = Key[Duration]("exposureTime", _.toMillis.toString)(Read.durSecs)
     }
 
     case object Instrument extends System("instrument") {
@@ -283,7 +283,7 @@ object ConfigReader {
         OldGcal.Shutter.OPEN   -> GcalShutter.Open
       )
 
-      val ExposureTime = Key[Duration]("exposureTime", _.getSeconds.toString)(Read.durSecs)
+      val ExposureTime = Key[Duration]("exposureTime", _.toMillis.toString)(Read.durSecs)
       val Coadds       = Key[Int     ]("coadds",       _.toString)(Read.int)
     }
   }

--- a/modules/importer/src/main/scala/ConfigReader.scala
+++ b/modules/importer/src/main/scala/ConfigReader.scala
@@ -196,6 +196,13 @@ object ConfigReader {
           OldF2.LyotWheel.OPEN       -> F16
         )
 
+        import F2ReadMode._
+        val ReadMode    = Key.enum[OldF2.ReadMode, F2ReadMode]("readMode",
+          OldF2.ReadMode.BRIGHT_OBJECT_SPEC -> Bright,
+          OldF2.ReadMode.MEDIUM_OBJECT_SPEC -> Medium,
+          OldF2.ReadMode.FAINT_OBJECT_SPEC  -> Faint
+        )
+
         // It appears that the window cover is sometimes "bare" and sometimes
         // wrapped in `Some` ... it is not `None` in my test data so there's
         // not a mapping for it.

--- a/modules/importer/src/main/scala/ConfigReader.scala
+++ b/modules/importer/src/main/scala/ConfigReader.scala
@@ -146,18 +146,12 @@ object ConfigReader {
 
       object F2 {
 
-        import F2FpUnit._
-        val Fpu         = Key.enum[OldF2.FPUnit, F2FpUnit]("fpu",
-          OldF2.FPUnit.PINHOLE        -> Pinhole,
-          OldF2.FPUnit.SUBPIX_PINHOLE -> SubPixPinhole,
-          OldF2.FPUnit.FPU_NONE       -> None,
-          OldF2.FPUnit.CUSTOM_MASK    -> Custom,
-          OldF2.FPUnit.LONGSLIT_1     -> LongSlit1,
-          OldF2.FPUnit.LONGSLIT_2     -> LongSlit2,
-          OldF2.FPUnit.LONGSLIT_3     -> LongSlit3,
-          OldF2.FPUnit.LONGSLIT_4     -> LongSlit4,
-          OldF2.FPUnit.LONGSLIT_6     -> LongSlit6,
-          OldF2.FPUnit.LONGSLIT_8     -> LongSlit8
+        import F2Disperser._
+        val Disperser   = Key.enum[OldF2.Disperser, F2Disperser]("disperser",
+          OldF2.Disperser.NONE    -> NoDisperser,
+          OldF2.Disperser.R1200HK -> R1200HK,
+          OldF2.Disperser.R1200JH -> R1200JH,
+          OldF2.Disperser.R3000   -> R3000
         )
 
         import F2Filter._
@@ -176,6 +170,20 @@ object ConfigReader {
           OldF2.Filter.Y       -> Y
         )
 
+        import F2FpUnit._
+        val Fpu         = Key.enum[OldF2.FPUnit, F2FpUnit]("fpu",
+          OldF2.FPUnit.PINHOLE        -> Pinhole,
+          OldF2.FPUnit.SUBPIX_PINHOLE -> SubPixPinhole,
+          OldF2.FPUnit.FPU_NONE       -> None,
+          OldF2.FPUnit.CUSTOM_MASK    -> Custom,
+          OldF2.FPUnit.LONGSLIT_1     -> LongSlit1,
+          OldF2.FPUnit.LONGSLIT_2     -> LongSlit2,
+          OldF2.FPUnit.LONGSLIT_3     -> LongSlit3,
+          OldF2.FPUnit.LONGSLIT_4     -> LongSlit4,
+          OldF2.FPUnit.LONGSLIT_6     -> LongSlit6,
+          OldF2.FPUnit.LONGSLIT_8     -> LongSlit8
+        )
+
         import F2LyotWheel._
         val LyotWheel   = Key.enum[OldF2.LyotWheel, F2LyotWheel]("lyotWheel",
           OldF2.LyotWheel.GEMS       -> F33Gems,
@@ -186,14 +194,6 @@ object ConfigReader {
           OldF2.LyotWheel.HIGH       -> F32High,
           OldF2.LyotWheel.LOW        -> F32Low,
           OldF2.LyotWheel.OPEN       -> F16
-        )
-
-        import F2Disperser._
-        val Disperser   = Key.enum[OldF2.Disperser, F2Disperser]("disperser",
-          OldF2.Disperser.NONE    -> NoDisperser,
-          OldF2.Disperser.R1200HK -> R1200HK,
-          OldF2.Disperser.R1200JH -> R1200JH,
-          OldF2.Disperser.R3000   -> R3000
         )
 
         // It appears that the window cover is sometimes "bare" and sometimes

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -196,8 +196,9 @@ object Importer extends SafeApp {
         val fpu           = config.uget(Legacy.Instrument.F2.Fpu)
         val lyoutWheel    = config.uget(Legacy.Instrument.F2.LyotWheel)
         val mosPreimaging = config.uget(Legacy.Instrument.MosPreImaging)
+        val readMode      = config.uget(Legacy.Instrument.F2.ReadMode)
         val windowCover   = config.cgetOrElse(Legacy.Instrument.F2.WindowCover, F2WindowCover.Open)
-        F2Config(disperser, exposureTime, filter, fpu, lyoutWheel, mosPreimaging, windowCover)
+        F2Config(disperser, exposureTime, filter, fpu, lyoutWheel, mosPreimaging, readMode, windowCover)
 
       case _ => GenericConfig(i)
     }

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -190,14 +190,14 @@ object Importer extends SafeApp {
     i match {
       case Instrument.Flamingos2 =>
 
-        val fpu           = config.uget(Legacy.Instrument.F2.Fpu)
-        val mosPreimaging = config.uget(Legacy.Instrument.MosPreImaging)
+        val disperser     = config.uget(Legacy.Instrument.F2.Disperser)
         val exposureTime  = config.cgetOrElse(Legacy.Observe.ExposureTime, Duration.ofMillis(0))
         val filter        = config.uget(Legacy.Instrument.F2.Filter)
+        val fpu           = config.uget(Legacy.Instrument.F2.Fpu)
         val lyoutWheel    = config.uget(Legacy.Instrument.F2.LyotWheel)
-        val disperser     = config.uget(Legacy.Instrument.F2.Disperser)
+        val mosPreimaging = config.uget(Legacy.Instrument.MosPreImaging)
         val windowCover   = config.cgetOrElse(Legacy.Instrument.F2.WindowCover, F2WindowCover.Open)
-        F2Config(fpu, mosPreimaging, exposureTime, filter, lyoutWheel, disperser, windowCover)
+        F2Config(disperser, exposureTime, filter, fpu, lyoutWheel, mosPreimaging, windowCover)
 
       case _ => GenericConfig(i)
     }

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -192,7 +192,7 @@ object Importer extends SafeApp {
 
         val fpu           = config.uget(Legacy.Instrument.F2.Fpu)
         val mosPreimaging = config.uget(Legacy.Instrument.MosPreImaging)
-        val exposureTime  = config.cgetOrElse(Legacy.Observe.ExposureTime, Duration.ofSeconds(0))
+        val exposureTime  = config.cgetOrElse(Legacy.Observe.ExposureTime, Duration.ofMillis(0))
         val filter        = config.uget(Legacy.Instrument.F2.Filter)
         val lyoutWheel    = config.uget(Legacy.Instrument.F2.LyotWheel)
         val disperser     = config.uget(Legacy.Instrument.F2.Disperser)

--- a/modules/importer/src/main/scala/Importer.scala
+++ b/modules/importer/src/main/scala/Importer.scala
@@ -194,11 +194,11 @@ object Importer extends SafeApp {
         val exposureTime  = config.cgetOrElse(Legacy.Observe.ExposureTime, Duration.ofMillis(0))
         val filter        = config.uget(Legacy.Instrument.F2.Filter)
         val fpu           = config.uget(Legacy.Instrument.F2.Fpu)
-        val lyoutWheel    = config.uget(Legacy.Instrument.F2.LyotWheel)
+        val lyotWheel     = config.uget(Legacy.Instrument.F2.LyotWheel)
         val mosPreimaging = config.uget(Legacy.Instrument.MosPreImaging)
         val readMode      = config.uget(Legacy.Instrument.F2.ReadMode)
         val windowCover   = config.cgetOrElse(Legacy.Instrument.F2.WindowCover, F2WindowCover.Open)
-        F2Config(disperser, exposureTime, filter, fpu, lyoutWheel, mosPreimaging, readMode, windowCover)
+        F2Config(disperser, exposureTime, filter, fpu, lyotWheel, mosPreimaging, readMode, windowCover)
 
       case _ => GenericConfig(i)
     }

--- a/modules/importer/src/main/scala/SmartGcalImporter.scala
+++ b/modules/importer/src/main/scala/SmartGcalImporter.scala
@@ -46,11 +46,11 @@ object SmartGcalImporter extends SafeApp {
 
     val disperserS :: filterS :: fpuS :: gcal = input
 
-    val u = Fpu.read(OldF2.FPUnit.byName(fpuS).getValue)
-    val f = Filter.read(OldF2.Filter.byName(filterS).getValue)
     val d = Disperser.read(OldF2.Disperser.byName(disperserS).getValue)
+    val f = Filter.read(OldF2.Filter.byName(filterS).getValue)
+    val u = Fpu.read(OldF2.FPUnit.byName(fpuS).getValue)
 
-    (F2SmartGcalKey(u, f, d), gcal)
+    (F2SmartGcalKey(d, f, u), gcal)
   }
 
   // -------------------------------------------------------------------------

--- a/modules/importer/src/main/scala/SmartGcalImporter.scala
+++ b/modules/importer/src/main/scala/SmartGcalImporter.scala
@@ -107,7 +107,7 @@ object SmartGcalImporter extends SafeApp {
     val f = Filter.read(OldGcal.Filter.getFilter(filterS))
     val d = Diffuser.read(OldGcal.Diffuser.getDiffuser(diffuserS))
     val s = Shutter.read(OldGcal.Shutter.getShutter(shutterS))
-    val e = Duration.ofSeconds(expS.toLong)
+    val e = Duration.ofMillis(expS.toLong * 1000)
     val c = coaddsS.toInt
 
     val b = GcalBaselineType.unsafeFromTag(baselineS)

--- a/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
+++ b/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
@@ -230,9 +230,9 @@ ALTER TABLE e_f2_lyot_wheel OWNER TO postgres;
 
 CREATE TABLE e_f2_read_mode (
     id                        identifier            PRIMARY KEY,
-    short_name                character varying(20) NOT NULL,
+    short_name                character varying(8)  NOT NULL,
     long_name                 character varying(20) NOT NULL,
-    log_name                  character varying(8)  NOT NULL,
+    description               character varying(20) NOT NULL,
     minimum_exposure_time     milliseconds          NOT NULL,
     recommended_exposure_time milliseconds          NOT NULL,
     readout_time              milliseconds          NOT NULL,
@@ -800,10 +800,10 @@ HartmannB	Hartmann B (H2)	0	0	f	Hartmann B (H2)
 -- Data for Name: e_f2_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY e_f2_read_mode (id, short_name, long_name, log_name, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise) FROM stdin;
-Bright	Bright Object	Strong Source	bright	1500	5000	8000	1	11.7
-Medium	Medium Object	Medium Source	medium	6000	21000	14000	4	6.0
-Faint	Faint Object	Weak Source	faint	12000	85000	20000	8	5.0
+COPY e_f2_read_mode (id, short_name, long_name, description, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise) FROM stdin;
+Bright	bright	Bright Object	Strong Source	1500	5000	8000	1	11.7
+Medium	medium	Medium Object	Medium Source	6000	21000	14000	4	6.0
+Faint	faint	Faint Object	Weak Source	12000	85000	20000	8	5.0
 \.
 
 

--- a/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
+++ b/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
@@ -223,6 +223,27 @@ CREATE TABLE e_f2_lyot_wheel (
 
 ALTER TABLE e_f2_lyot_wheel OWNER TO postgres;
 
+
+--
+-- Name: e_f2_read_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_f2_read_mode (
+    id                        identifier            PRIMARY KEY,
+    short_name                character varying(20) NOT NULL,
+    long_name                 character varying(20) NOT NULL,
+    log_name                  character varying(8)  NOT NULL,
+    minimum_exposure_time     milliseconds          NOT NULL,
+    recommended_exposure_time milliseconds          NOT NULL,
+    readout_time              milliseconds          NOT NULL,
+    read_count                smallint              NOT NULL,
+    read_noise                double precision      NOT NULL
+);
+
+
+ALTER TABLE e_f2_read_mode OWNER TO postgres;
+
+
 --
 -- Name: e_f2_window_cover; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -624,6 +645,7 @@ CREATE TABLE step_f2 (
     fpu            identifier    NOT NULL    REFERENCES e_f2_fpunit       ON DELETE CASCADE,
     lyot_wheel     identifier    NOT NULL    REFERENCES e_f2_lyot_wheel   ON DELETE CASCADE,
     mos_preimaging boolean       NOT NULL,
+    read_mode      identifier    NOT NULL    REFERENCES e_f2_read_mode    ON DELETE CASCADE,
     window_cover   identifier    NOT NULL    REFERENCES e_f2_window_cover ON DELETE CASCADE
 );
 
@@ -771,6 +793,17 @@ GemsUnder	GeMS Under	0.78400000000000003	0.0899999999999999967	f	f/33 (GeMS unde
 GemsOver	GeMS Over	0.78400000000000003	0.0899999999999999967	f	f/33 (GeMS over-sized)
 HartmannA	Hartmann A (H1)	0	0	f	Hartmann A (H1)
 HartmannB	Hartmann B (H2)	0	0	f	Hartmann B (H2)
+\.
+
+
+--
+-- Data for Name: e_f2_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_f2_read_mode (id, short_name, long_name, log_name, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise) FROM stdin;
+Bright	Bright Object	Strong Source	bright	1500	5000	8000	1	11.7
+Medium	Medium Object	Medium Source	medium	6000	21000	14000	4	6.0
+Faint	Faint Object	Weak Source	faint	12000	85000	20000	8	5.0
 \.
 
 

--- a/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
+++ b/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
@@ -79,14 +79,14 @@ ALTER DOMAIN coadds OWNER TO postgres;
 
 
 --
--- Name: seconds; Type: DOMAIN; Schema: public; Owner: postgres
+-- Name: milliseconds; Type: DOMAIN; Schema: public; Owner: postgres
 --
 
-CREATE DOMAIN seconds AS integer
+CREATE DOMAIN milliseconds AS integer
     DEFAULT    0
-    CONSTRAINT seconds_check CHECK (VALUE >= 0);
+    CONSTRAINT miliseconds_check CHECK (VALUE >= 0);
 
-ALTER DOMAIN seconds OWNER TO postgres;
+ALTER DOMAIN milliseconds OWNER TO postgres;
 
 
 --
@@ -619,7 +619,7 @@ ALTER TABLE step_dark OWNER TO postgres;
 CREATE TABLE step_f2 (
     step_f2_id     integer       PRIMARY KEY REFERENCES step              ON DELETE CASCADE,
     disperser      identifier    NOT NULL    REFERENCES e_f2_disperser    ON DELETE CASCADE,
-    exposure_time  seconds       NOT NULL,
+    exposure_time  milliseconds  NOT NULL,
     filter         identifier    NOT NULL    REFERENCES e_f2_filter       ON DELETE CASCADE,
     fpu            identifier    NOT NULL    REFERENCES e_f2_fpunit       ON DELETE CASCADE,
     lyot_wheel     identifier    NOT NULL    REFERENCES e_f2_lyot_wheel   ON DELETE CASCADE,
@@ -636,17 +636,17 @@ ALTER TABLE step_f2 OWNER TO postgres;
 --
 
 CREATE TABLE gcal (
-    gcal_id       SERIAL      PRIMARY KEY,
+    gcal_id       SERIAL       PRIMARY KEY,
     continuum     identifier                          REFERENCES e_gcal_continuum ON DELETE CASCADE,
-    ar_arc        boolean     NOT NULL DEFAULT FALSE,
-    cuar_arc      boolean     NOT NULL DEFAULT FALSE,
-    thar_arc      boolean     NOT NULL DEFAULT FALSE,
-    xe_arc        boolean     NOT NULL DEFAULT FALSE,
-    filter        identifier  NOT NULL                REFERENCES e_gcal_filter    ON DELETE CASCADE,
-    diffuser      identifier  NOT NULL                REFERENCES e_gcal_diffuser  ON DELETE CASCADE,
-    shutter       identifier  NOT NULL                REFERENCES e_gcal_shutter   ON DELETE CASCADE,
-    exposure_time seconds     NOT NULL,
-    coadds        coadds      NOT NULL,
+    ar_arc        boolean      NOT NULL DEFAULT FALSE,
+    cuar_arc      boolean      NOT NULL DEFAULT FALSE,
+    thar_arc      boolean      NOT NULL DEFAULT FALSE,
+    xe_arc        boolean      NOT NULL DEFAULT FALSE,
+    filter        identifier   NOT NULL                REFERENCES e_gcal_filter    ON DELETE CASCADE,
+    diffuser      identifier   NOT NULL                REFERENCES e_gcal_diffuser  ON DELETE CASCADE,
+    shutter       identifier   NOT NULL                REFERENCES e_gcal_shutter   ON DELETE CASCADE,
+    exposure_time milliseconds NOT NULL,
+    coadds        coadds       NOT NULL,
     CONSTRAINT check_lamp CHECK ((continuum IS NULL) = (ar_arc OR cuar_arc OR thar_arc OR xe_arc))
 );
 

--- a/project/gen2.scala
+++ b/project/gen2.scala
@@ -127,8 +127,8 @@ object gen2 {
       },
 
       enum("F2ReadMode") {
-        type F2ReadModeRec = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'logName -> String, 'minimumExposureTime -> Duration, 'recommendedExposureTime -> Duration, 'readoutTime -> Duration, 'readCount -> Int, 'readNoise -> Double`.T
-        val io = sql"select id, id tag, short_name, long_name, log_name, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise from e_f2_read_mode".query[(String, F2ReadModeRec)].list
+        type F2ReadModeRec = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'description -> String, 'minimumExposureTime -> Duration, 'recommendedExposureTime -> Duration, 'readoutTime -> Duration, 'readCount -> Int, 'readNoise -> Double`.T
+        val io = sql"select id, id tag, short_name, long_name, description, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise from e_f2_read_mode".query[(String, F2ReadModeRec)].list
         io.transact(xa).unsafePerformIO
       },
 


### PR DESCRIPTION
This PR makes a few adjustments, all related to adding a Flamingos2 read mode field to the model.

1. Sorted `F2Config` class and `step_f2` table fields since the order was seemingly random.  Since there are various places where the fields are listed, this makes it easier to line everything up and easier to insert new fields.

2. Switched exposure time database domain definition to milliseconds since F2 supports fractional second exposure times and the bright read mode minimum exposure time is 1.5 seconds.  This was actually a bug in the import in which we were truncating fractional second exposure times.

3. Added read mode.  This required updates to `gen2` to support `java.time.Duration`.