### PR TITLE
Smart Gcal Expansion

### DIFF
--- a/modules/core/src/main/scala/gem/Location.scala
+++ b/modules/core/src/main/scala/gem/Location.scala
@@ -79,8 +79,8 @@ object Location {
       "{ω}"
   }
 
-  def beginning: Location = Beginning
-  def end: Location       = End
+  val beginning: Location = Beginning
+  val end: Location       = End
 
   // Constructors
 
@@ -181,7 +181,7 @@ object Location {
   })
 
   implicit val OrderMiddle: Order[Location.Middle] =
-    Order.orderBy(m => m: Location)
+    OrderLocation.contramap[Location.Middle](lm => lm: Location)
 
   implicit val ShowLocation: Show[Location] = Show.shows(_.toString)
 }

--- a/modules/core/src/main/scala/gem/Location.scala
+++ b/modules/core/src/main/scala/gem/Location.scala
@@ -11,7 +11,7 @@ import scalaz.Ordering.{EQ, GT, LT}
   * `Location` is a proper prefex of another, then it sorts ahead of the other
   * `Location`.
   */
-sealed trait Location {
+sealed trait Location extends Product with Serializable {
 
   // These functions aren't of any use to clients.  Instead they are involved
   // in the cacluation of Locations that fall between two other locations.
@@ -78,6 +78,9 @@ object Location {
     override def toString: String =
       "{ω}"
   }
+
+  def beginning: Location = Beginning
+  def end: Location       = End
 
   // Constructors
 
@@ -176,6 +179,9 @@ object Location {
         .find { case (a, b) => a =/= b }
         .fold[Ordering](EQ) { case (a, b) => (a < b) ?[Ordering] LT | GT }
   })
+
+  implicit val OrderMiddle: Order[Location.Middle] =
+    Order.orderBy(m => m: Location)
 
   implicit val ShowLocation: Show[Location] = Show.shows(_.toString)
 }

--- a/modules/core/src/main/scala/gem/SmartGcal.scala
+++ b/modules/core/src/main/scala/gem/SmartGcal.scala
@@ -17,6 +17,6 @@ object SmartGcal {
   case object      NoMappingDefined                   extends ExpansionError
 
   def stepNotFound(loc: Location.Middle): ExpansionError = StepNotFound(loc)
-  def notSmartGcal: ExpansionError                       = NotSmartGcal
-  def noMappingDefined: ExpansionError                   = NoMappingDefined
+  val notSmartGcal: ExpansionError                       = NotSmartGcal
+  val noMappingDefined: ExpansionError                   = NoMappingDefined
 }

--- a/modules/core/src/main/scala/gem/SmartGcal.scala
+++ b/modules/core/src/main/scala/gem/SmartGcal.scala
@@ -2,15 +2,11 @@ package gem
 
 import gem.config.InstrumentConfig
 
-import scalaz.\/
-
 object SmartGcal {
 
   sealed trait ExpansionError extends Product with Serializable
 
-  type ExpansionResult[A] = ExpansionError \/ A
   type ExpandedSteps      = List[GcalStep[InstrumentConfig]]
-  type LookupResult       = ExpansionResult[ExpandedSteps]
 
   final case class StepNotFound(loc: Location.Middle) extends ExpansionError
   case object      NotSmartGcal                       extends ExpansionError

--- a/modules/core/src/main/scala/gem/SmartGcal.scala
+++ b/modules/core/src/main/scala/gem/SmartGcal.scala
@@ -1,0 +1,22 @@
+package gem
+
+import gem.config.InstrumentConfig
+
+import scalaz.\/
+
+object SmartGcal {
+
+  sealed trait ExpansionError extends Product with Serializable
+
+  type ExpansionResult[A] = ExpansionError \/ A
+  type ExpandedSteps      = List[GcalStep[InstrumentConfig]]
+  type LookupResult       = ExpansionResult[ExpandedSteps]
+
+  final case class StepNotFound(loc: Location.Middle) extends ExpansionError
+  case object      NotSmartGcal                       extends ExpansionError
+  case object      NoMappingDefined                   extends ExpansionError
+
+  def stepNotFound(loc: Location.Middle): ExpansionError = StepNotFound(loc)
+  def notSmartGcal: ExpansionError                       = NotSmartGcal
+  def noMappingDefined: ExpansionError                   = NoMappingDefined
+}

--- a/modules/core/src/main/scala/gem/config/GcalConfig.scala
+++ b/modules/core/src/main/scala/gem/config/GcalConfig.scala
@@ -22,31 +22,33 @@ object GcalConfig {
   type GcalArcs = OneAnd[ISet, GcalArc]
   type GcalLamp = GcalContinuum \/ GcalArcs
 
-  def mkLamp(continuum: GcalContinuum): GcalLamp =
-    continuum.left
+  object GcalLamp {
+    def fromConfig(continuum: Option[GcalContinuum], arcs: (GcalArc, Boolean)*): Option[GcalLamp] = {
+      // Extract the arc lamps to include, if any.
+      val as = arcs.filter(_._2).unzip._1.toList
 
-  def mkLamp(arc0: GcalArc, arcs: GcalArc*): GcalLamp =
-    OneAnd(arc0, ISet.fromList(arcs.toList)).right
+      // Extract the continuum lamp, assuming there are no arcs.
+      val co = continuum.flatMap { c => as.isEmpty option c.left[GcalArcs] }
 
-  def mkLamp(continuum: Option[GcalContinuum], arcs: (GcalArc, Boolean)*): Option[GcalLamp] = {
-    // Extract the arc lamps to include, if any.
-    val as = arcs.filter(_._2).unzip._1.toList
+      // Prepare the arc lamps, assuming there is no continuum.
+      val ao = as match {
+        case h :: t if continuum.isEmpty => Some(OneAnd(h, ISet.fromList(t)).right[GcalContinuum])
+        case _                           => None
+      }
 
-    // Extract the continuum lamp, assuming there are no arcs.
-    val co = continuum.flatMap { c => as.isEmpty option c.left[GcalArcs] }
-
-    // Prepare the arc lamps, assuming there is no continuum.
-    val ao = as match {
-      case h :: t if continuum.isEmpty => Some(OneAnd(h, ISet.fromList(t)).right[GcalContinuum])
-      case _                           => None
+      co orElse ao
     }
 
-    co orElse ao
+    def fromContinuum(continuum: GcalContinuum): GcalLamp =
+      continuum.left
+
+    def fromArcs(arc0: GcalArc, arcs: GcalArc*): GcalLamp =
+      OneAnd(arc0, ISet.fromList(arcs.toList)).right
+
+    def unsafeFromConfig(continuum: Option[GcalContinuum], arcs: (GcalArc, Boolean)*): GcalLamp =
+      fromConfig(continuum, arcs: _*).getOrElse {
+        sys.error(s"misconfigured Gcal lamps: continuum=$continuum, arcs=[${arcs.filter(_._2).unzip._1.mkString(",")}]")
+      }
   }
-
-  def unsafeMkLamp(continuum: Option[GcalContinuum], arcs: (GcalArc, Boolean)*): GcalLamp =
-    mkLamp(continuum, arcs: _*).getOrElse {
-      sys.error(s"misconfigured Gcal lamps: continuum=$continuum, arcs=[${arcs.filter(_._2).unzip._1.mkString(",")}]")
-    }
 }
 

--- a/modules/core/src/main/scala/gem/config/GcalConfig.scala
+++ b/modules/core/src/main/scala/gem/config/GcalConfig.scala
@@ -22,6 +22,12 @@ object GcalConfig {
   type GcalArcs = OneAnd[ISet, GcalArc]
   type GcalLamp = GcalContinuum \/ GcalArcs
 
+  def mkLamp(continuum: GcalContinuum): GcalLamp =
+    continuum.left
+
+  def mkLamp(arc0: GcalArc, arcs: GcalArc*): GcalLamp =
+    OneAnd(arc0, ISet.fromList(arcs.toList)).right
+
   def mkLamp(continuum: Option[GcalContinuum], arcs: (GcalArc, Boolean)*): Option[GcalLamp] = {
     // Extract the arc lamps to include, if any.
     val as = arcs.filter(_._2).unzip._1.toList

--- a/modules/core/src/main/scala/gem/config/InstrumentConfig.scala
+++ b/modules/core/src/main/scala/gem/config/InstrumentConfig.scala
@@ -5,9 +5,15 @@ import gem.enum._
 
 import java.time.Duration
 
-sealed abstract class InstrumentConfig extends Product with Serializable
-
 sealed trait SmartGcalKey
+
+sealed abstract class InstrumentConfig extends Product with Serializable {
+  def smartGcalKey: Option[SmartGcalKey] =
+    this match {
+      case f2: F2Config     => Some(f2.key)
+      case GenericConfig(_) => None
+    }
+}
 
 final case class F2SmartGcalKey(
   disperser: F2Disperser,
@@ -26,7 +32,7 @@ final case class F2Config(
   windowCover:   F2WindowCover
 ) extends InstrumentConfig {
 
-  def smartGcalKey: F2SmartGcalKey =
+  def key: F2SmartGcalKey =
     F2SmartGcalKey(disperser, filter, fpu)
 }
 

--- a/modules/db/src/main/scala/gem/dao/GcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GcalDao.scala
@@ -1,6 +1,7 @@
 package gem.dao
 
 import gem.config.GcalConfig
+import gem.config.GcalConfig.GcalLamp
 import doobie.imports._
 import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
 import gem.enum.GcalArc.{ArArc, CuArArc, ThArArc, XeArc}
@@ -33,7 +34,7 @@ object GcalDao {
     coadds:    Int)
   {
     def toGcalConfig: Option[GcalConfig] =
-      GcalConfig.mkLamp(continuum, ArArc -> ar_arc, CuArArc -> cuar_arc, ThArArc -> thar_arc, XeArc -> xe_arc).map { lamp =>
+      GcalLamp.fromConfig(continuum, ArArc -> ar_arc, CuArArc -> cuar_arc, ThArArc -> thar_arc, XeArc -> xe_arc).map { lamp =>
         GcalConfig(lamp, filter, diffuser, shutter, expTime, coadds)
       }
   }

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -46,7 +46,7 @@ object ObservationDao {
     for {
       on <- selectFlat(id)
       ss <- StepDao.selectAllEmpty(id)
-    } yield on.copy(steps = ss)
+    } yield on.copy(steps = ss.unzip._2)
 
   def selectAllFlat(pid: Program.Id): ConnectionIO[List[Observation[Nothing]]] =
     sql"""

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -46,7 +46,7 @@ object ObservationDao {
     for {
       on <- selectFlat(id)
       ss <- StepDao.selectAllEmpty(id)
-    } yield on.copy(steps = ss.unzip._2)
+    } yield on.copy(steps = ss.values)
 
   def selectAllFlat(pid: Program.Id): ConnectionIO[List[Observation[Nothing]]] =
     sql"""

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -45,7 +45,7 @@ object ObservationDao {
   def select(id: Observation.Id): ConnectionIO[Observation[Step[_]]] =
     for {
       on <- selectFlat(id)
-      ss <- StepDao.selectEmpty(id)
+      ss <- StepDao.selectAllEmpty(id)
     } yield on.copy(steps = ss)
 
   def selectAllFlat(pid: Program.Id): ConnectionIO[List[Observation[Nothing]]] =

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -139,14 +139,12 @@ object SmartGcalDao {
       }.void
 
     for {
-      steps <- StepDao.selectAll(oid).right
+      steps <- StepDao.selectAll(oid).injectRight
       (locBefore, locAfter) = bounds(steps)
       gcal  <- lookup(MaybeConnectionIO.fromOption(steps.lookup(loc)), loc)
-      _     <- for {
-                 // replaces the smart gcal step with the expanded manual gcal steps
-                 _ <- StepDao.delete(oid, loc).right[ExpansionError]
-                 _ <- insert(locBefore, gcal, locAfter).right[ExpansionError]
-               } yield ()
+      // replaces the smart gcal step with the expanded manual gcal steps
+      _     <- StepDao.delete(oid, loc).injectRight
+      _     <- insert(locBefore, gcal, locAfter).injectRight
     } yield gcal
   }
 }

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -60,31 +60,41 @@ object SmartGcalDao {
     } yield r
   }
 
-  private def lookup(step: Option[Step[InstrumentConfig]], loc: Location.Middle): ConnectionIO[LookupResult] = {
+  type ExpansionResult[A] = EitherConnectionIO[ExpansionError, A]
+
+  private def lookup(step: MaybeConnectionIO[Step[InstrumentConfig]], loc: Location.Middle): ExpansionResult[ExpandedSteps] = {
     // Information we need to extract from a smart gcal step in order to expand
     // it into manual gcal steps.  The key is used to look up the gcal config
     // from the instrument's smart table (e.g., smart_f2).  The type is used to
     // extract the matching steps (arc vs. flat, or night vs. day baseline).
     // The instrument config is needed to create the corresponding gcal steps.
-    type SmartContext  = (SmartGcalKey, SmartGcalType, InstrumentConfig)
+    type SmartContext = (SmartGcalKey, SmartGcalType, InstrumentConfig)
 
     // Get the key, type, and instrument config from the step.  We'll need this
     // information to lookup the corresponding GcalConfig.
     val context: ExpansionResult[SmartContext] =
-      step.fold(stepNotFound(loc).left[SmartContext]) {
-        case SmartGcalStep(inst, sgType) =>
-          (inst.smartGcalKey \/> noMappingDefined).map { k => (k, sgType, inst) }
-        case _                           =>
-          notSmartGcal.left[SmartContext]
-      }
+      for {
+        s <- step.toRight(stepNotFound(loc))
+        c <- s match {
+               case SmartGcalStep(i, t) =>
+                 EitherConnectionIO.fromDisjunction {
+                   (i.smartGcalKey \/> noMappingDefined).map { k => (k, t, i) }
+                 }
+               case _                   =>
+                 EitherConnectionIO.pointLeft(notSmartGcal)
+             }
+      } yield c
+
 
     // Find the corresponding smart gcal mapping, if any.
-    context.fold(e => e.left[ExpandedSteps].point[ConnectionIO], {
-      case (k, t, i) => select(k, t).map {
-        case Nil  => noMappingDefined.left[ExpandedSteps]
-        case gcal => gcal.map { configs => GcalStep(i, configs) }.right[ExpansionError]
-      }
-    })
+    for {
+      kti  <- context
+      (k, t, i) = kti
+      gcal <- EitherConnectionIO(select(k, t).map {
+                case Nil => noMappingDefined.left
+                case cs  => cs.map(GcalStep(i, _)).right
+              })
+    } yield gcal
   }
 
   /** Lookup the corresponding `GcalStep`s for the smart step at `loc`, leaving
@@ -98,8 +108,8 @@ object SmartGcalDao {
     *         found, refers to a smart gcal step, and a mapping is defined for
     *         its instrument configuration
     */
-  def lookup(oid: Observation.Id, loc: Location.Middle): ConnectionIO[LookupResult] =
-    StepDao.selectOne(oid, loc).flatMap(lookup(_, loc))
+  def lookup(oid: Observation.Id, loc: Location.Middle): ExpansionResult[ExpandedSteps] =
+    lookup(StepDao.selectOne(oid, loc), loc)
 
   /** Expands a smart gcal step into the corresponding gcal steps so that they
     * may be executed. Updates the sequence to replace a smart gcal step with
@@ -112,7 +122,7 @@ object SmartGcalDao {
     *         found, refers to a smart gcal step, and a mapping is defined for
     *         its instrument configuration
     */
-  def expand(oid: Observation.Id, loc: Location.Middle): ConnectionIO[LookupResult] = {
+  def expand(oid: Observation.Id, loc: Location.Middle): ExpansionResult[ExpandedSteps] = {
     // Find the previous and next location for the smart gcal step that we are
     // replacing.  This is needed to generate locations for the steps that will
     // be inserted.
@@ -129,16 +139,14 @@ object SmartGcalDao {
       }.void
 
     for {
-      steps <- StepDao.selectAll(oid)
+      steps <- StepDao.selectAll(oid).right
       (locBefore, locAfter) = bounds(steps)
-      gcal  <- lookup(steps.lookup(loc), loc)
-      _     <- gcal.fold(_ => ().point[ConnectionIO], gs =>
-                 // replaces the smart gcal step with the expanded manual gcal
-                 // steps
-                 for {
-                   _ <- StepDao.delete(oid, loc)
-                   _ <- insert(locBefore, gs, locAfter)
-                 } yield ())
+      gcal  <- lookup(MaybeConnectionIO.fromOption(steps.lookup(loc)), loc)
+      _     <- for {
+                 // replaces the smart gcal step with the expanded manual gcal steps
+                 _ <- StepDao.delete(oid, loc).right[ExpansionError]
+                 _ <- insert(locBefore, gcal, locAfter).right[ExpansionError]
+               } yield ()
     } yield gcal
   }
 }

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -322,6 +322,11 @@ object StepDao {
     } yield ss.intersectionWith(is) { (s, i) => s.as(i) }
   }
 
+  /** Deletes the step at the indicated location, if any.
+    *
+    * @param oid observation whose step should be deleted
+    * @param loc location of the step to delete
+    */
   def delete(oid: Observation.Id, loc: Loc): ConnectionIO[Int] = {
     // Cascading delete takes care of the subtype steps like step_bias,
     // step_dark, etc., but will leave a step_gcal's calibration configuration

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -4,6 +4,7 @@ package dao
 import edu.gemini.spModel.core._
 import gem.Location
 import gem.config._
+import gem.config.GcalConfig.GcalLamp
 import gem.enum._
 import doobie.imports._
 
@@ -124,7 +125,7 @@ object StepDao {
             cuar <- cuarOpt
             thar <- tharOpt
             xe   <- xeOpt
-            l    <- GcalConfig.mkLamp(continuumOpt, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe)
+            l    <- GcalLamp.fromConfig(continuumOpt, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe)
             f    <- filterOpt
             d    <- diffuserOpt
             s    <- shutterOpt

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -60,10 +60,10 @@ package object dao extends MoreTupleOps with ToUserProgramRoleOps {
   }
 
   implicit class ConnectionIOOps[T](c: ConnectionIO[T]) {
-    def left[B]: EitherConnectionIO[T, B] =
+    def injectLeft[B]: EitherConnectionIO[T, B] =
       EitherConnectionIO.left[T, B](c)
 
-    def right[A]: EitherConnectionIO[A, T] =
+    def injectRight[A]: EitherConnectionIO[A, T] =
       EitherConnectionIO.right[A, T](c)
   }
 

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -14,6 +14,59 @@ import Scalaz._
 
 package object dao extends MoreTupleOps with ToUserProgramRoleOps {
 
+  type MaybeConnectionIO[A] = OptionT[ConnectionIO, A]
+
+  object MaybeConnectionIO {
+    def apply[A](coa: ConnectionIO[Option[A]]): MaybeConnectionIO[A] =
+      OptionT(coa)
+
+    def fromOption[A](oa: Option[A]): MaybeConnectionIO[A] =
+      oa.fold(OptionT.none[ConnectionIO, A]) { a =>
+        OptionT.some[ConnectionIO, A](a)
+      }
+
+    def none[A]: MaybeConnectionIO[A] =
+      OptionT.none[ConnectionIO, A]
+
+    def some[A](a: => A): MaybeConnectionIO[A] =
+      OptionT.some[ConnectionIO, A](a)
+  }
+
+  implicit class Query0Ops[A](a: Query0[A]) {
+    def maybe: MaybeConnectionIO[A] =
+      MaybeConnectionIO(a.option)
+  }
+
+  type EitherConnectionIO[A, B] = EitherT[ConnectionIO, A, B]
+
+  object EitherConnectionIO {
+    def apply[A, B](ceab: ConnectionIO[\/[A, B]]): EitherConnectionIO[A, B] =
+      EitherT(ceab)
+
+    def left[A, B](a: ConnectionIO[A]): EitherConnectionIO[A, B] =
+      EitherT.left[ConnectionIO, A, B](a)
+
+    def pointLeft[A, B](a: A): EitherConnectionIO[A, B] =
+      left(a.point[ConnectionIO])
+
+    def right[A, B](b: ConnectionIO[B]): EitherConnectionIO[A, B] =
+      EitherT.right[ConnectionIO, A, B](b)
+
+    def pointRight[A, B](b: B): EitherConnectionIO[A, B] =
+      right(b.point[ConnectionIO])
+
+    def fromDisjunction[A, B](eab: A \/ B): EitherConnectionIO[A, B] =
+      EitherT.fromDisjunction(eab)
+  }
+
+  implicit class ConnectionIOOps[T](c: ConnectionIO[T]) {
+    def left[B]: EitherConnectionIO[T, B] =
+      EitherConnectionIO.left[T, B](c)
+
+    def right[A]: EitherConnectionIO[A, T] =
+      EitherConnectionIO.right[A, T](c)
+  }
+
   // Angle mapping to signed arcseconds. NOT implicit.
   val AngleMetaAsSignedArcseconds: Meta[Angle] =
     Meta[Double].xmap(Angle.fromArcsecs, _.toSignedDegrees * 3600)

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -3,6 +3,7 @@ package gem.dao
 import gem._
 import gem.SmartGcal._
 import gem.config._
+import gem.config.GcalConfig.GcalLamp
 import gem.enum._
 import GcalLampType.{Arc, Flat}
 import GcalBaselineType.Night
@@ -119,7 +120,7 @@ object SmartGcalSpec {
   private val gcals: List[(GcalLampType, GcalBaselineType, GcalConfig)] =
     List(
       (Arc, Night, GcalConfig(
-        GcalConfig.mkLamp(GcalArc.ArArc),
+        GcalLamp.fromArcs(GcalArc.ArArc),
         GcalFilter.Nir,
         GcalDiffuser.Ir,
         GcalShutter.Closed,
@@ -127,7 +128,7 @@ object SmartGcalSpec {
         1
       )),
       (Flat, Night, GcalConfig(
-        GcalConfig.mkLamp(GcalContinuum.IrGreyBodyHigh),
+        GcalLamp.fromContinuum(GcalContinuum.IrGreyBodyHigh),
         GcalFilter.Nd20,
         GcalDiffuser.Ir,
         GcalShutter.Open,

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -1,11 +1,14 @@
 package gem.dao
 
 import gem._
+import gem.SmartGcal._
 import gem.config._
 import gem.enum._
+import GcalLampType.{Arc, Flat}
+import GcalBaselineType.Night
 
 import doobie.imports._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 import java.time.Duration
 
@@ -13,73 +16,148 @@ import scalaz.effect.IO
 
 import scalaz._, Scalaz._
 
-// TODO
-// - Unknown location
-// - Not smart gcal
-// - No mapping
-// - valid mapping, first step
-// - valid mapping, in between step
-// - mapping arc, flat, night, day
-
-
-
 class SmartGcalSpec extends FlatSpec with Matchers {
 
   import SmartGcalSpec._
 
-  "SmartGcalDao" should "expand smart gcal steps into gcal steps" in {
+  "SmartGcalDao" should "expand smart gcal arc steps" in {
+    runF2Expansion(SmartGcalType.Arc) { (_, steps) =>
+      verifySteps(GcalLampType.Arc.left, steps)
+    }
+  }
 
-    val loc = Location.unsafeMiddle(1)
-    val f2  = F2Config(
-      F2Disperser.R1200JH,
-      Duration.ofMillis(1000),
-      F2Filter.JH,
-      F2FpUnit.LongSlit1,
-      F2LyotWheel.F16,
-      mosPreimaging = true,
-      F2ReadMode.Bright,
-      F2WindowCover.Open
-    )
-    val gcal = GcalConfig(
-      GcalConfig.unsafeMkLamp(None, GcalArc.ArArc -> true),
-      GcalFilter.Nir,
-      GcalDiffuser.Ir,
-      GcalShutter.Closed,
-      Duration.ofMillis(30000),
-      1
-    )
+  it should "expand smart gcal flat steps" in {
+    runF2Expansion(SmartGcalType.Flat) { (_, steps) =>
+      verifySteps(GcalLampType.Flat.left, steps)
+    }
+  }
 
-    val steps = genSteps {
+  it should "expand smart gcal baseline steps" in {
+    runF2Expansion(SmartGcalType.NightBaseline) { (_, steps) =>
+      verifySteps(GcalBaselineType.Night.right, steps)
+    }
+  }
+
+  it should "fail when there is no corresponding mapping" in {
+    runF2Expansion(SmartGcalType.DayBaseline) { (expansion, steps) =>
+      expansion    shouldEqual noMappingDefined.left[ExpandedSteps]
+      steps.values shouldEqual List(SmartGcalStep(f2, SmartGcalType.DayBaseline))
+    }
+  }
+
+  it should "fail when the location is not found" in {
+    runF2Expansion(SmartGcalType.Arc, loc1, loc2) { (expansion, steps) =>
+      expansion shouldEqual stepNotFound(loc2).left[ExpandedSteps]
+    }
+  }
+
+  it should "fail when the location is not a smart gcal step" in {
+    val expansion = doTest {
       for {
-        _  <- StepDao.insert(oid, loc, new SmartGcalStep(f2, SmartGcalType.Arc))
-        _  <- SmartGcalDao.expand(oid, loc)
+        _  <- StepDao.insert(oid, loc1, BiasStep(f2))
+        ex <- SmartGcalDao.expand(oid, loc1)
         ss <- StepDao.selectAll(oid)
+        _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
+      } yield ex
+    }
+
+    expansion shouldEqual notSmartGcal.left[ExpandedSteps]
+  }
+
+  it should "expand intermediate smart gcal steps" in {
+    val steps = doTest {
+      for {
+        _  <- StepDao.insert(oid, loc1, BiasStep(f2))
+        _  <- StepDao.insert(oid, loc2, SmartGcalStep(f2, SmartGcalType.NightBaseline))
+        _  <- StepDao.insert(oid, loc9, DarkStep(f2))
+        _  <- SmartGcalDao.expand(oid, loc2)
+        ss <- StepDao.selectAll(oid)
+        _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
       } yield ss
     }
 
-    steps.values shouldEqual List(GcalStep(f2, gcal))
+    val exp = gcals.filter(_._2 == GcalBaselineType.Night).map { case (_, _, config) => GcalStep(f2, config) }
+    steps.values shouldEqual (BiasStep(f2) :: exp) :+ DarkStep(f2)
+  }
+
+  private def verifySteps(m: GcalLampType \/ GcalBaselineType, ss: Location.Middle ==>> Step[InstrumentConfig]): Assertion = {
+    def lookup(m: GcalLampType \/ GcalBaselineType): List[GcalConfig] =
+      gcals.filter(t => m.fold(_ == t._1, _ == t._2)).map(_._3)
+
+    ss.values shouldEqual lookup(m).map(GcalStep(f2, _))
   }
 }
 
 object SmartGcalSpec {
-  val pid = Program.Id.parse("GS-2345A-Q-1")
-  val oid = Observation.Id(pid, 1)
+  private val pid = Program.Id.parse("GS-2345A-Q-1")
+  private val oid = Observation.Id(pid, 1)
 
-  val xa  = DriverManagerTransactor[IO](
+  private val xa  = DriverManagerTransactor[IO](
     "org.postgresql.Driver",
     "jdbc:postgresql:gem",
     "postgres",
     ""
   )
 
-  def genSteps(test: ConnectionIO[Location.Middle ==>> Step[InstrumentConfig]]): Location.Middle ==>> Step[InstrumentConfig] =
+  private val loc1: Location.Middle = Location.unsafeMiddle(1)
+  private val loc2: Location.Middle = Location.unsafeMiddle(2)
+  private val loc9: Location.Middle = Location.unsafeMiddle(9)
+
+  private val f2: F2Config =
+    F2Config(
+      /* Disperser             */ F2Disperser.R1200JH,
+      Duration.ofMillis(1000),
+      /* Filter                */ F2Filter.JH,
+      /* FPU                   */ F2FpUnit.LongSlit1,
+      F2LyotWheel.F16,
+      mosPreimaging = true,
+      F2ReadMode.Bright,
+      F2WindowCover.Open)
+
+
+  private val gcals: List[(GcalLampType, GcalBaselineType, GcalConfig)] =
+    List(
+      (Arc, Night, GcalConfig(
+        GcalConfig.mkLamp(GcalArc.ArArc),
+        GcalFilter.Nir,
+        GcalDiffuser.Ir,
+        GcalShutter.Closed,
+        Duration.ofMillis(30000),
+        1
+      )),
+      (Flat, Night, GcalConfig(
+        GcalConfig.mkLamp(GcalContinuum.IrGreyBodyHigh),
+        GcalFilter.Nd20,
+        GcalDiffuser.Ir,
+        GcalShutter.Open,
+        Duration.ofMillis(20000),
+        1
+      ))
+    )
+
+  private def runF2Expansion(t: SmartGcalType)(verify: (LookupResult, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion =
+    runF2Expansion(t, loc1, loc1)(verify)
+
+  private def runF2Expansion(t: SmartGcalType, insertionLoc: Location.Middle, searchLoc: Location.Middle)(verify: (LookupResult, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion = {
+    val (expansion, steps) = doTest {
+      for {
+        _  <- StepDao.insert(oid, insertionLoc, SmartGcalStep(f2, t))
+        ex <- SmartGcalDao.expand(oid, searchLoc)
+        ss <- StepDao.selectAll(oid)
+        _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
+      } yield (ex, ss)
+    }
+
+    verify(expansion, steps)
+  }
+
+  private def doTest[A](test: ConnectionIO[A]): A =
     (for {
-      _  <- ProgramDao.insert(Program(pid, "SmartGcalSpec Prog", List.empty[Step[Nothing]]))
-      _  <- ObservationDao.insert(Observation(oid, "SmartGcalSpec Obs", Some(Instrument.Flamingos2), List.empty[Step[Nothing]]))
-      ss <- test
-      _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
-      _  <- sql"""DELETE FROM observation WHERE observation_id = $oid""".update.run
-      _  <- sql"""DELETE FROM program     WHERE program_id     = $pid""".update.run
-    } yield ss).transact(xa).unsafePerformIO()
+      _ <- ProgramDao.insert(Program(pid, "SmartGcalSpec Prog", List.empty[Step[Nothing]]))
+      _ <- ObservationDao.insert(Observation(oid, "SmartGcalSpec Obs", Some(Instrument.Flamingos2), List.empty[Step[Nothing]]))
+      a <- test
+      _ <- sql"""DELETE FROM observation WHERE observation_id = $oid""".update.run
+      _ <- sql"""DELETE FROM program     WHERE program_id     = $pid""".update.run
+    } yield a).transact(xa).unsafePerformIO()
 
 }

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -57,7 +57,7 @@ class SmartGcalSpec extends FlatSpec with Matchers {
     val expansion = doTest {
       for {
         _  <- StepDao.insert(oid, loc1, BiasStep(f2))
-        ex <- SmartGcalDao.expand(oid, loc1)
+        ex <- SmartGcalDao.expand(oid, loc1).run
         ss <- StepDao.selectAll(oid)
         _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
       } yield ex
@@ -72,7 +72,7 @@ class SmartGcalSpec extends FlatSpec with Matchers {
         _  <- StepDao.insert(oid, loc1, BiasStep(f2))
         _  <- StepDao.insert(oid, loc2, SmartGcalStep(f2, SmartGcalType.NightBaseline))
         _  <- StepDao.insert(oid, loc9, DarkStep(f2))
-        _  <- SmartGcalDao.expand(oid, loc2)
+        _  <- SmartGcalDao.expand(oid, loc2).run
         ss <- StepDao.selectAll(oid)
         _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
       } yield ss
@@ -137,14 +137,14 @@ object SmartGcalSpec {
       ))
     )
 
-  private def runF2Expansion(t: SmartGcalType)(verify: (LookupResult, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion =
+  private def runF2Expansion(t: SmartGcalType)(verify: (ExpansionError \/ ExpandedSteps, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion =
     runF2Expansion(t, loc1, loc1)(verify)
 
-  private def runF2Expansion(t: SmartGcalType, insertionLoc: Location.Middle, searchLoc: Location.Middle)(verify: (LookupResult, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion = {
+  private def runF2Expansion(t: SmartGcalType, insertionLoc: Location.Middle, searchLoc: Location.Middle)(verify: (ExpansionError \/ ExpandedSteps, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion = {
     val (expansion, steps) = doTest {
       for {
         _  <- StepDao.insert(oid, insertionLoc, SmartGcalStep(f2, t))
-        ex <- SmartGcalDao.expand(oid, searchLoc)
+        ex <- SmartGcalDao.expand(oid, searchLoc).run
         ss <- StepDao.selectAll(oid)
         _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
       } yield (ex, ss)

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -48,6 +48,7 @@ class SmartGcalSpec extends FlatSpec with Matchers {
   it should "fail when the location is not found" in {
     runF2Expansion(SmartGcalType.Arc, loc1, loc2) { (expansion, steps) =>
       expansion shouldEqual stepNotFound(loc2).left[ExpandedSteps]
+      steps.values shouldEqual List(SmartGcalStep(f2, SmartGcalType.Arc))
     }
   }
 

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -1,0 +1,85 @@
+package gem.dao
+
+import gem._
+import gem.config._
+import gem.enum._
+
+import doobie.imports._
+import org.scalatest.{FlatSpec, Matchers}
+
+import java.time.Duration
+
+import scalaz.effect.IO
+
+import scalaz._, Scalaz._
+
+// TODO
+// - Unknown location
+// - Not smart gcal
+// - No mapping
+// - valid mapping, first step
+// - valid mapping, in between step
+// - mapping arc, flat, night, day
+
+
+
+class SmartGcalSpec extends FlatSpec with Matchers {
+
+  import SmartGcalSpec._
+
+  "SmartGcalDao" should "expand smart gcal steps into gcal steps" in {
+
+    val loc = Location.unsafeMiddle(1)
+    val f2  = F2Config(
+      F2Disperser.R1200JH,
+      Duration.ofMillis(1000),
+      F2Filter.JH,
+      F2FpUnit.LongSlit1,
+      F2LyotWheel.F16,
+      mosPreimaging = true,
+      F2ReadMode.Bright,
+      F2WindowCover.Open
+    )
+    val gcal = GcalConfig(
+      GcalConfig.unsafeMkLamp(None, GcalArc.ArArc -> true),
+      GcalFilter.Nir,
+      GcalDiffuser.Ir,
+      GcalShutter.Closed,
+      Duration.ofMillis(30000),
+      1
+    )
+
+    val steps = genSteps {
+      for {
+        _  <- StepDao.insert(oid, loc, new SmartGcalStep(f2, SmartGcalType.Arc))
+        _  <- SmartGcalDao.expand(oid, loc)
+        ss <- StepDao.selectAll(oid)
+      } yield ss
+    }
+
+    steps.values shouldEqual List(GcalStep(f2, gcal))
+  }
+}
+
+object SmartGcalSpec {
+  val pid = Program.Id.parse("GS-2345A-Q-1")
+  val oid = Observation.Id(pid, 1)
+
+  val xa  = DriverManagerTransactor[IO](
+    "org.postgresql.Driver",
+    "jdbc:postgresql:gem",
+    "postgres",
+    ""
+  )
+
+  def genSteps(test: ConnectionIO[Location.Middle ==>> Step[InstrumentConfig]]): Location.Middle ==>> Step[InstrumentConfig] =
+    (for {
+      _  <- ProgramDao.insert(Program(pid, "SmartGcalSpec Prog", List.empty[Step[Nothing]]))
+      _  <- ObservationDao.insert(Observation(oid, "SmartGcalSpec Obs", Some(Instrument.Flamingos2), List.empty[Step[Nothing]]))
+      ss <- test
+      _  <- ss.keys.traverseU { StepDao.delete(oid, _) }
+      _  <- sql"""DELETE FROM observation WHERE observation_id = $oid""".update.run
+      _  <- sql"""DELETE FROM program     WHERE program_id     = $pid""".update.run
+    } yield ss).transact(xa).unsafePerformIO()
+
+}

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -1,12 +1,12 @@
 package gem.dao
 
-import gem.{Observation, Step}
+import gem.{Location, Observation, Step}
 import gem.config.InstrumentConfig
 
 import doobie.imports._
 
 object StepDaoSample extends TimedSample {
-  type Result = List[Step[InstrumentConfig]]
+  type Result = List[(Location.Middle, Step[InstrumentConfig])]
 
   val oid = Observation.Id.unsafeFromString("GS-2016A-Q-102-108")
 

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -5,8 +5,10 @@ import gem.config.InstrumentConfig
 
 import doobie.imports._
 
+import scalaz.==>>
+
 object StepDaoSample extends TimedSample {
-  type Result = List[(Location.Middle, Step[InstrumentConfig])]
+  type Result = Location.Middle ==>> Step[InstrumentConfig]
 
   val oid = Observation.Id.unsafeFromString("GS-2016A-Q-102-108")
 
@@ -14,5 +16,5 @@ object StepDaoSample extends TimedSample {
     StepDao.selectAll(oid)
 
   override def format(r: Result): String =
-    r.mkString(", \n")
+    r.toAscList.map { case (l, s) => f"$l%10s -> $s" }.mkString(", \n")
 }

--- a/modules/importer/src/main/scala/ConfigReader.scala
+++ b/modules/importer/src/main/scala/ConfigReader.scala
@@ -4,7 +4,6 @@ import edu.gemini.spModel.core._
 import edu.gemini.spModel.`type`.SequenceableSpType
 import edu.gemini.spModel.data.YesNoType
 
-import gem.config._
 import gem.config.GcalConfig.GcalLamp
 import gem.enum._
 
@@ -262,7 +261,7 @@ object ConfigReader {
             val (oldC, oldA) = oldLamps.partition(_.`type` == OldGcal.LampType.flat)
             val newC         = oldC.map(lampToContinuum)
             val newA         = oldA.map(lampToArc)
-            GcalConfig.unsafeMkLamp(newC.headOption, newA.strengthR(true): _*)
+            GcalLamp.unsafeFromConfig(newC.headOption, newA.strengthR(true): _*)
         }
       }
 


### PR DESCRIPTION
The goal of this work-in-progress PR is to implement a simple smart gcal expansion API like:

````scala
  def lookup(oid: Observation.Id, loc: Location.Middle): ConnectionIO[LookupResult]

  def expand(oid: Observation.Id, loc: Location.Middle): ConnectionIO[LookupResult]
````

where `LookupResult` is a disjunction: error code if it fails or `List[GcalStep[InstrumentConfig]]` if successful.  `lookup` just finds the gcal configuration matching the smart gcal step at the given location if there is one and `expand` actually replaces the smart gcal step with the gcal config.

The PR also changes the `StepDao.selectAll` methods to return Scalaz maps `Location ==>> Step[A]` in order to have access to the location information.  In order to expand the smart gal step, we have to create locations that fall between the previous and next steps.

I'm not quite ready to merge this yet:

- [x] Document, comment
- [x] Complete test cases
- [ ] Decide whether `SmartGcalDao` is really the right place for this higher-level API. If not, where?

Presumably at some point, this can be cleaned up with SQL fragments in a newer version of doobie.  As is, there is a bit of duplication in some of the queries. 