### PR TITLE
Double to numeric?

### DIFF
--- a/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
+++ b/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
@@ -705,9 +705,9 @@ ALTER TABLE step_smart_gcal OWNER TO postgres;
 --
 
 CREATE TABLE step_science (
-    step_science_id integer          PRIMARY KEY REFERENCES step ON DELETE CASCADE,
-    offset_p        double precision NOT NULL,
-    offset_q        double precision NOT NULL
+    step_science_id integer      PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    offset_p        numeric(9,3) NOT NULL,
+    offset_q        numeric(9,3) NOT NULL
 );
 
 


### PR DESCRIPTION
Thinking about bringing targets over to the new model, I find myself wondering what to do about floating point values.  For example we store offsets as `double precision` values in arcsecs:

````
gem=# select * from step_science;
 step_science_id |      offset_p       |      offset_q       
-----------------+---------------------+---------------------
             281 |                   0 |                   0
             282 |    10.0000000000591 |                   0
             283 |                   0 |                   0
             284 |                   0 |                   0
             285 |                   0 |                   0
             286 |                   0 |    2.99999999999727
...
````

A query for offsets in p `<= 10` clearly misses step 282.  I’m wondering if we shouldn’t store these as `numeric` and even model them as `BigDecimal`.  It comes up in the context of targets because basically everything is floating point and it would be nice to get it (closer to) right.

````
 step_science_id | offset_p | offset_q 
-----------------+----------+----------
               1 |    0.000 |    0.000
               2 |   10.000 |    0.000
               3 |    0.000 |    0.000
               4 |    0.000 |    0.000
               5 |    0.000 |    0.000
               6 |    0.000 |    3.000
...
````

Picking the size is bothersome, I suppose.  Here I went with (9,3) thinking that in a signed angle in arcsecs the largest value possible is 648,000 which is 6 digits.  I don’t know if milliarsec is fine grained enough though.  I suppose the next step would be to update the core `Angle` to store `BigDecimal` values instead of `Double` or do we just round when we read/write the values as in this PR?
