### PR TITLE
Ignore Vim .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ smartgcal
 *.ipr
 *.iws
 
+*.swp


### PR DESCRIPTION
Sorry for the tiny PR but I was ready to stop seeing this in `git status` output.