### PR TITLE
initial static config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val commonSettings = Seq(
     "-encoding", "UTF-8",
     "-feature",
     "-language:higherKinds",
+    "-language:existentials",
     "-unchecked",
     // "-Xfatal-warnings",
     "-Xlint",

--- a/modules/core/src/main/scala/gem/Observation.scala
+++ b/modules/core/src/main/scala/gem/Observation.scala
@@ -1,14 +1,12 @@
 package gem
 
-import gem.enum.Instrument
-
 import scalaz._, Scalaz._
 
-case class Observation[S](
+case class Observation[S, D](
   id: Observation.Id,
   title: String,
-  instrument: Option[Instrument], // redundant? this is on the steps too
-  steps: List[S])
+  staticConfig: S,
+  steps: List[D])
 
 object Observation {
 
@@ -32,10 +30,10 @@ object Observation {
 
   }
 
-  implicit def ObservationTraverse[T]: Traverse[Observation[?]] =
-    new Traverse[Observation[?]] {
-      def traverseImpl[G[_]: Applicative, A, B](fa: Observation[A])(f: A => G[B]): G[Observation[B]] =
-        fa.steps.traverse(f).map(ss => fa.copy(steps = ss))
-    }
+  // implicit def ObservationTraverse[T]: Traverse[Observation[?]] =
+  //   new Traverse[Observation[?]] {
+  //     def traverseImpl[G[_]: Applicative, A, B](fa: Observation[A])(f: A => G[B]): G[Observation[B]] =
+  //       fa.steps.traverse(f).map(ss => fa.copy(steps = ss))
+  //   }
 
 }

--- a/modules/core/src/main/scala/gem/Observation.scala
+++ b/modules/core/src/main/scala/gem/Observation.scala
@@ -30,10 +30,10 @@ object Observation {
 
   }
 
-  // implicit def ObservationTraverse[T]: Traverse[Observation[?]] =
-  //   new Traverse[Observation[?]] {
-  //     def traverseImpl[G[_]: Applicative, A, B](fa: Observation[A])(f: A => G[B]): G[Observation[B]] =
-  //       fa.steps.traverse(f).map(ss => fa.copy(steps = ss))
-  //   }
+  implicit val ObservationBitraverse: Bitraverse[Observation] =
+    new Bitraverse[Observation] {
+      def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: Observation[A,B])(f: A => G[C], g: B => G[D]): G[Observation[C,D]] =
+        (f(fab.staticConfig) |@| fab.steps.traverse(g))((c, d) => fab.copy(staticConfig = c, steps = d))
+    }
 
 }

--- a/modules/core/src/main/scala/gem/SmartGcal.scala
+++ b/modules/core/src/main/scala/gem/SmartGcal.scala
@@ -1,12 +1,12 @@
 package gem
 
-import gem.config.InstrumentConfig
+import gem.config.DynamicConfig
 
 object SmartGcal {
 
   sealed trait ExpansionError extends Product with Serializable
 
-  type ExpandedSteps      = List[GcalStep[InstrumentConfig]]
+  type ExpandedSteps      = List[GcalStep[DynamicConfig]]
 
   final case class StepNotFound(loc: Location.Middle) extends ExpansionError
   case object      NotSmartGcal                       extends ExpansionError

--- a/modules/core/src/main/scala/gem/Step.scala
+++ b/modules/core/src/main/scala/gem/Step.scala
@@ -6,14 +6,14 @@ import gem.enum.SmartGcalType
 import scalaz.Functor
 
 sealed abstract class Step[A] extends Product with Serializable {
-  def instrument: A
+  def dynamicConfig: A
 }
 
-final case class BiasStep     [A](instrument: A)                               extends Step[A]
-final case class DarkStep     [A](instrument: A)                               extends Step[A]
-final case class GcalStep     [A](instrument: A, gcal:      GcalConfig)        extends Step[A]
-final case class ScienceStep  [A](instrument: A, telescope: TelescopeConfig)   extends Step[A]
-final case class SmartGcalStep[A](instrument: A, smartGcalType: SmartGcalType) extends Step[A]
+final case class BiasStep     [A](dynamicConfig: A)                               extends Step[A]
+final case class DarkStep     [A](dynamicConfig: A)                               extends Step[A]
+final case class GcalStep     [A](dynamicConfig: A, gcal:      GcalConfig)        extends Step[A]
+final case class ScienceStep  [A](dynamicConfig: A, telescope: TelescopeConfig)   extends Step[A]
+final case class SmartGcalStep[A](dynamicConfig: A, smartGcalType: SmartGcalType) extends Step[A]
 
 object Step {
   implicit val FunctorStep: Functor[Step] = new Functor[Step] {

--- a/modules/core/src/main/scala/gem/config/StaticConfig.scala
+++ b/modules/core/src/main/scala/gem/config/StaticConfig.scala
@@ -1,0 +1,32 @@
+package gem
+package config
+
+import gem.enum.Instrument
+
+sealed abstract class StaticConfig {
+  type I <: Instrument with Singleton
+  def instrument: I
+}
+
+object StaticConfig {
+  type Aux[I0] = StaticConfig { type I = I0 }
+  sealed abstract class Impl[I0 <: Instrument with Singleton](val instrument: I0) extends StaticConfig {
+    type I = I0
+  }
+}
+
+final case class PhoenixStaticConfig()    extends StaticConfig.Impl(Instrument.Phoenix)
+final case class MichelleStaticConfig()   extends StaticConfig.Impl(Instrument.Michelle)
+final case class GnirsStaticConfig()      extends StaticConfig.Impl(Instrument.Gnirs)
+final case class NiriStaticConfig()       extends StaticConfig.Impl(Instrument.Niri)
+final case class TrecsStaticConfig()      extends StaticConfig.Impl(Instrument.Trecs)
+final case class NiciStaticConfig()       extends StaticConfig.Impl(Instrument.Nici)
+final case class NifsStaticConfig()       extends StaticConfig.Impl(Instrument.Nifs)
+final case class GpiStaticConfig()        extends StaticConfig.Impl(Instrument.Gpi)
+final case class GsaoiStaticConfig()      extends StaticConfig.Impl(Instrument.Gsaoi)
+final case class GmosSStaticConfig()      extends StaticConfig.Impl(Instrument.GmosS)
+final case class AcqCamStaticConfig()     extends StaticConfig.Impl(Instrument.AcqCam)
+final case class GmosNStaticConfig()      extends StaticConfig.Impl(Instrument.GmosN)
+final case class BhrosStaticConfig()      extends StaticConfig.Impl(Instrument.Bhros)
+final case class VisitorStaticConfig()    extends StaticConfig.Impl(Instrument.Visitor)
+final case class Flamingos2StaticConfig() extends StaticConfig.Impl(Instrument.Flamingos2)

--- a/modules/core/src/main/scala/gem/enum/package.scala
+++ b/modules/core/src/main/scala/gem/enum/package.scala
@@ -1,20 +1,9 @@
 package gem
 
-import gem.config._
-
 // The members of this package are generated from database tables, which are the source of truth.
 // See project/gen2.scala for details. Associations with other model types, as needed, are provided
 // here as implicit classes wrapping the generated companion objects.
 package object enum {
-
-  /** Add mapping from InstrumentConfig to Instrument. */
-  implicit class InstrumentCompanionOps(companion: Instrument.type) {
-    def forConfig(c: InstrumentConfig): Instrument =
-      c match {
-        case F2Config(_, _, _, _, _, _, _, _) => Instrument.Flamingos2
-        case GenericConfig(i)                 => i
-      }
-  }
 
   /** Add mapping from Step to StepType. */
   implicit class StepTypeCompanionOps(companion: StepType.type) {

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -1,6 +1,8 @@
 package gem
 package dao
 
+import gem.config.StaticConfig
+
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.ProgramId._
 
@@ -41,7 +43,7 @@ object ProgramDao {
     Statements.selectFlat(pid).option
 
   /** Select a program by id, with full Observation information. */
-  def selectFull(pid: Program.Id): ConnectionIO[Option[Program[Observation[Step[_]]]]] =
+  def selectFull(pid: Program.Id): ConnectionIO[Option[Program[Observation[StaticConfig, Step[_]]]]] =
     for {
       opn <- selectFlat(pid)
       os  <- ObservationDao.selectAll(pid)

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -33,13 +33,13 @@ object SmartGcalDao {
 
   type ExpansionResult[A] = EitherConnectionIO[ExpansionError, A]
 
-  private def lookup(step: MaybeConnectionIO[Step[InstrumentConfig]], loc: Location.Middle): ExpansionResult[ExpandedSteps] = {
+  private def lookup(step: MaybeConnectionIO[Step[DynamicConfig]], loc: Location.Middle): ExpansionResult[ExpandedSteps] = {
     // Information we need to extract from a smart gcal step in order to expand
     // it into manual gcal steps.  The key is used to look up the gcal config
     // from the instrument's smart table (e.g., smart_f2).  The type is used to
     // extract the matching steps (arc vs. flat, or night vs. day baseline).
     // The instrument config is needed to create the corresponding gcal steps.
-    type SmartContext = (SmartGcalKey, SmartGcalType, InstrumentConfig)
+    type SmartContext = (SmartGcalKey, SmartGcalType, DynamicConfig)
 
     // Get the key, type, and instrument config from the step.  We'll need this
     // information to lookup the corresponding GcalConfig.
@@ -97,7 +97,7 @@ object SmartGcalDao {
     // Find the previous and next location for the smart gcal step that we are
     // replacing.  This is needed to generate locations for the steps that will
     // be inserted.
-    def bounds(steps: Location.Middle ==>> Step[InstrumentConfig]): (Location, Location) =
+    def bounds(steps: Location.Middle ==>> Step[DynamicConfig]): (Location, Location) =
       steps.split(loc) match {
         case (prev, next) => (prev.findMax.map(_._1).widen[Location] | Location.beginning,
                               next.findMin.map(_._1).widen[Location] | Location.end)

--- a/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
@@ -1,0 +1,39 @@
+package gem
+package dao
+
+// import doobie.imports._
+
+import gem.enum.Instrument
+import gem.config._
+
+
+object StaticConfigDao {
+
+  // this is just a placeholder … right now the obs table just contains an instrument tag which we
+  // use to construct an empty static config
+
+  def forInstrument(i: Instrument): StaticConfig.Aux[i.type] =
+    (i match {
+      case Instrument.Phoenix    => PhoenixStaticConfig()
+      case Instrument.Michelle   => MichelleStaticConfig()
+      case Instrument.Gnirs      => GnirsStaticConfig()
+      case Instrument.Niri       => NiriStaticConfig()
+      case Instrument.Trecs      => TrecsStaticConfig()
+      case Instrument.Nici       => NiciStaticConfig()
+      case Instrument.Nifs       => NifsStaticConfig()
+      case Instrument.Gpi        => GpiStaticConfig()
+      case Instrument.Gsaoi      => GsaoiStaticConfig()
+      case Instrument.GmosS      => GmosSStaticConfig()
+      case Instrument.AcqCam     => AcqCamStaticConfig()
+      case Instrument.GmosN      => GmosNStaticConfig()
+      case Instrument.Bhros      => BhrosStaticConfig()
+      case Instrument.Visitor    => VisitorStaticConfig()
+      case Instrument.Flamingos2 => Flamingos2StaticConfig()
+    }).asInstanceOf[StaticConfig.Aux[i.type]] // Scala isn't smart enough to know this
+
+
+  object Statements {
+    // todo
+  }
+
+}

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -82,7 +82,7 @@ class SmartGcalSpec extends FlatSpec with Matchers {
     steps.values shouldEqual (BiasStep(f2) :: exp) :+ DarkStep(f2)
   }
 
-  private def verifySteps(m: GcalLampType \/ GcalBaselineType, ss: Location.Middle ==>> Step[InstrumentConfig]): Assertion = {
+  private def verifySteps(m: GcalLampType \/ GcalBaselineType, ss: Location.Middle ==>> Step[DynamicConfig]): Assertion = {
     def lookup(m: GcalLampType \/ GcalBaselineType): List[GcalConfig] =
       gcals.filter(t => m.fold(_ == t._1, _ == t._2)).map(_._3)
 
@@ -137,10 +137,10 @@ object SmartGcalSpec {
       ))
     )
 
-  private def runF2Expansion(t: SmartGcalType)(verify: (ExpansionError \/ ExpandedSteps, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion =
+  private def runF2Expansion(t: SmartGcalType)(verify: (ExpansionError \/ ExpandedSteps, Location.Middle ==>> Step[DynamicConfig]) => Assertion): Assertion =
     runF2Expansion(t, loc1, loc1)(verify)
 
-  private def runF2Expansion(t: SmartGcalType, insertionLoc: Location.Middle, searchLoc: Location.Middle)(verify: (ExpansionError \/ ExpandedSteps, Location.Middle ==>> Step[InstrumentConfig]) => Assertion): Assertion = {
+  private def runF2Expansion(t: SmartGcalType, insertionLoc: Location.Middle, searchLoc: Location.Middle)(verify: (ExpansionError \/ ExpandedSteps, Location.Middle ==>> Step[DynamicConfig]) => Assertion): Assertion = {
     val (expansion, steps) = doTest {
       for {
         _  <- StepDao.insert(oid, insertionLoc, SmartGcalStep(f2, t))
@@ -156,7 +156,7 @@ object SmartGcalSpec {
   private def doTest[A](test: ConnectionIO[A]): A =
     (for {
       _ <- ProgramDao.insert(Program(pid, "SmartGcalSpec Prog", List.empty[Step[Nothing]]))
-      _ <- ObservationDao.insert(Observation(oid, "SmartGcalSpec Obs", Some(Instrument.Flamingos2), List.empty[Step[Nothing]]))
+      _ <- ObservationDao.insert(Observation(oid, "SmartGcalSpec Obs", Flamingos2StaticConfig(), List.empty[Step[Nothing]]))
       a <- test
       _ <- sql"""DELETE FROM observation WHERE observation_id = $oid""".update.run
       _ <- sql"""DELETE FROM program     WHERE program_id     = $pid""".update.run

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -1,14 +1,14 @@
 package gem.dao
 
 import gem.{Location, Observation, Step}
-import gem.config.InstrumentConfig
+import gem.config.DynamicConfig
 
 import doobie.imports._
 
 import scalaz.==>>
 
 object StepDaoSample extends TimedSample {
-  type Result = Location.Middle ==>> Step[InstrumentConfig]
+  type Result = Location.Middle ==>> Step[DynamicConfig]
 
   val oid = Observation.Id.unsafeFromString("GS-2016A-Q-102-108")
 

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -45,7 +45,7 @@ trait Check extends FlatSpec with Matchers with QueryChecker {
     val gcalShutter      = GcalShutter.Open
     val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, 0)
     val user             = User[Nothing]("", "", "", "", false, Map.empty)
-    val observation      = Observation[Nothing](observationId, "", None, Nil)
+    val observation      = Observation[StaticConfig, Nothing](observationId, "", Flamingos2StaticConfig(), Nil)
     val program          = Program(programId, "", Nil)
     val f2SmartGcalKey   = F2SmartGcalKey(F2Disperser.NoDisperser, F2Filter.Dark, F2FpUnit.LongSlit1)
     val gcalLampType     = GcalLampType.Arc

--- a/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
@@ -6,8 +6,6 @@ class StepCheck extends Check {
   "StepDao.Statements" should
             "delete (1)"           in check(delete(Dummy.observationId, Dummy.locationMiddle))
   it should "delete (2)"           in check(delete(Dummy.observationId))
-  it should "allGenericOnly"       in check(allGenericOnly(Dummy.observationId))
-  it should "oneGenericOnly"       in check(oneGenericOnly(Dummy.observationId, Dummy.locationMiddle))
   it should "allF2Only"            in check(allF2Only(Dummy.observationId))
   it should "selectAllEmpty"       in check(selectAllEmpty(Dummy.observationId))
   it should "selectOneEmpty"       in check(selectOneEmpty(Dummy.observationId, Dummy.locationMiddle))

--- a/modules/json/src/test/scala/gem/json/CompilationTest.scala
+++ b/modules/json/src/test/scala/gem/json/CompilationTest.scala
@@ -1,7 +1,7 @@
 package gem
 package json
 
-import gem.config.InstrumentConfig
+import gem.config.{ StaticConfig, DynamicConfig } 
 
 import argonaut._, Argonaut._, ArgonautShapeless._
 
@@ -12,7 +12,7 @@ trait CompilatonTests {
 
   // Sanity check
   // TODO: this, better
-  implicitly[EncodeJson[Program[Observation[Step[InstrumentConfig]]]]]
-  implicitly[DecodeJson[Program[Observation[Step[InstrumentConfig]]]]]
+  implicitly[EncodeJson[Program[Observation[StaticConfig, Step[DynamicConfig]]]]]
+  implicitly[DecodeJson[Program[Observation[StaticConfig, Step[DynamicConfig]]]]]
 
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
@@ -2,7 +2,7 @@ package gem.ocs2
 
 import doobie.imports._
 import gem.{Dataset, Log, Observation, Program, Step, User}
-import gem.config.InstrumentConfig
+import gem.config.{ StaticConfig, DynamicConfig }
 import gem.dao.UserDao
 import gem.ocs2.Decoders._
 import gem.ocs2.pio.PioDecoder
@@ -22,7 +22,7 @@ import scalaz.effect._
   */
 object FileImporter extends SafeApp with DoobieClient {
 
-  type Obs  = Observation[Step[InstrumentConfig]]
+  type Obs  = Observation[StaticConfig, Step[DynamicConfig]]
   type Prog = Program[Obs]
 
   val dir = new File("archive")
@@ -46,7 +46,7 @@ object FileImporter extends SafeApp with DoobieClient {
   def read(f: File): IO[Elem] =
     IO(XML.loadFile(f))
 
-  def insert(u: User[_], p: Program[Observation[Step[InstrumentConfig]]], ds: List[Dataset], log: Log[ConnectionIO]): ConnectionIO[Unit] =
+  def insert(u: User[_], p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset], log: Log[ConnectionIO]): ConnectionIO[Unit] =
     Importer.writeProgram(p, ds)(u, log)
 
   def readAndInsert(u: User[_], f: File, log: Log[ConnectionIO]): IO[Unit] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -2,10 +2,10 @@ package gem.ocs2
 
 import doobie.imports._
 
-import gem.config.InstrumentConfig
 import gem.dao._
 
 import gem.{Dataset, Location, Log, Observation, Program, Step, User}
+import gem.config.{ StaticConfig, DynamicConfig }
 
 import scalaz.Scalaz._
 import scalaz.concurrent.Task
@@ -14,7 +14,7 @@ import scalaz.concurrent.Task
   */
 object Importer extends DoobieClient {
 
-  def writeObservation(o: Observation[Step[InstrumentConfig]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
+  def writeObservation(o: Observation[StaticConfig, Step[DynamicConfig]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
 
     val rmObservation: ConnectionIO[Unit] =
       sql"DELETE FROM observation WHERE observation_id = ${o.id}".update.run.void
@@ -48,7 +48,7 @@ object Importer extends DoobieClient {
       } yield ()
   }
 
-  def writeProgram(p: Program[Observation[Step[InstrumentConfig]]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
+  def writeProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
     val rmProgram: ConnectionIO[Unit] =
       sql"DELETE FROM program WHERE program_id = ${p.id}".update.run.void
 
@@ -71,9 +71,9 @@ object Importer extends DoobieClient {
       _ <- l.shutdown(5 * 1000).transact(lxa) // if we're not done soon something is wrong
     } yield ()
 
-  def importObservation(o: Observation[Step[InstrumentConfig]], ds: List[Dataset]): Task[Unit] =
+  def importObservation(o: Observation[StaticConfig, Step[DynamicConfig]], ds: List[Dataset]): Task[Unit] =
     doImport(writeObservation(o, ds))
 
-  def importProgram(p: Program[Observation[Step[InstrumentConfig]]], ds: List[Dataset]): Task[Unit] =
+  def importProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset]): Task[Unit] =
     doImport(writeProgram(p, ds))
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
@@ -17,7 +17,7 @@ import Scalaz._
 
 /** Decoder for the OCS2 sequence XML.
   */
-object SequenceDecoder extends PioDecoder[List[Step[InstrumentConfig]]] {
+object SequenceDecoder extends PioDecoder[List[Step[DynamicConfig]]] {
 
   // Clean up classnames in toString, which tells you the type of the key, which should be
   // helpful for debugging.
@@ -98,7 +98,7 @@ object SequenceDecoder extends PioDecoder[List[Step[InstrumentConfig]]] {
     }
   }
 
-  def parseInstConfig(i: Instrument, cm: ConfigMap): PioError \/ InstrumentConfig =
+  def parseInstConfig(i: Instrument, cm: ConfigMap): PioError \/ DynamicConfig =
     i match {
       case Instrument.Flamingos2 =>
         import Legacy.Instrument.Flamingos2._
@@ -113,11 +113,11 @@ object SequenceDecoder extends PioDecoder[List[Step[InstrumentConfig]]] {
           w <- WindowCover.cparseOrElse(cm, F2WindowCover.Close)
         } yield F2Config(d, e, f, u, l, p, r, w)
 
-      case _ => GenericConfig(i).right
+      case _ => sys.error(s"Can't decode config $i, $cm")
     }
 
-  def parseStep(cm: ConfigMap): PioError \/ Step[InstrumentConfig] = {
-    def go(observeType: String, instrument: InstrumentConfig): PioError \/ Step[InstrumentConfig] =
+  def parseStep(cm: ConfigMap): PioError \/ Step[DynamicConfig] = {
+    def go(observeType: String, instrument: DynamicConfig): PioError \/ Step[DynamicConfig] =
       observeType match {
         case "BIAS" =>
           BiasStep(instrument).right
@@ -154,7 +154,7 @@ object SequenceDecoder extends PioDecoder[List[Step[InstrumentConfig]]] {
     } yield s
   }
 
-  def decode(n: Node): PioError \/ List[Step[InstrumentConfig]] = {
+  def decode(n: Node): PioError \/ List[Step[DynamicConfig]] = {
 
     def extractSystem(cm: ConfigMap, sys: Node): ConfigMap = {
       val sysName = (sys \ "@name").text

--- a/modules/sql/src/main/resources/db/migration/V011__Observation_Instrument_NotNull.sql
+++ b/modules/sql/src/main/resources/db/migration/V011__Observation_Instrument_NotNull.sql
@@ -1,0 +1,2 @@
+ALTER TABLE observation
+  ALTER COLUMN instrument SET NOT NULL


### PR DESCRIPTION
Initial implementation of static config. This adds a second type parameter to `Observation`, intended for a `StaticConfig` value. OCS2 import and Gem db stuff are all stubbed out; `StaticConfig` is isomorphic to `Instrument` right now.

We can represent an observation with "matching" static and dynamic configurations thus, where the existential ensures that they line up.

```scala
type RealizedObservation =
  Observation[StaticConfig.Aux[A], Step[DynamicConfig.Aux[A]]] forSome { type A }
```
