### PR TITLE
update doobie version for build build, switch to coursier for lib resolution

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,8 +1,12 @@
+resolvers in ThisBuild +=
+  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+
+lazy val doobieVersion = "0.4.2-SNAPSHOT"
 
 // The build build, for codegen
 libraryDependencies ++= Seq(
-  "org.tpolecat" %% "doobie-core"               % "0.3.0",
-  "org.tpolecat" %% "doobie-contrib-postgresql" % "0.3.0"
+  "org.tpolecat" %% "doobie-core"     % doobieVersion,
+  "org.tpolecat" %% "doobie-postgres" % doobieVersion
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("org.flywaydb"     % "flyway-sbt"            % "4.0.3")
 addSbtPlugin("org.scalastyle"  %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager"   % "1.1.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git"               % "0.8.5")
+addSbtPlugin("io.get-coursier"  % "sbt-coursier"          % "1.0.0-RC4")
 
 // To silence SLF4J warnings
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,2 @@
+// So the build build will use it
+addSbtPlugin("io.get-coursier"  % "sbt-coursier" % "1.0.0-RC4")


### PR DESCRIPTION
This does two things
- Updates the build build to use doobie 0.4.2-SNAPSHOT just so we're consistent with the main build.
- Updates the main build and the build build to use coursier for library management, which seems to speed things up. First time building it will have to re-download the internet but thereafter it's much faster.

