### PR TITLE
add scalastyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - psql -c 'create database gem' -U postgres
 
 script:
-  - sbt sql/flywayMigrate compile test
+  - sbt scalastyle sql/flywayMigrate compile test
 
 cache:
   directories:

--- a/modules/core/src/main/scala/gem/Enumerated.scala
+++ b/modules/core/src/main/scala/gem/Enumerated.scala
@@ -29,7 +29,5 @@ trait Obsoletable[A] {
 trait Display[A] {
   def name(a:A): String         // short name, for labels
   def elaboration(a:A): Option[String]  // an elaboration on the name, used for computing longname
-  def longName(a: A) = name(a) + elaboration(a).fold("")(n => s" ($n)")
+  def longName(a: A): String = name(a) + elaboration(a).fold("")(n => s" ($n)")
 }
-
-

--- a/modules/core/src/main/scala/gem/Location.scala
+++ b/modules/core/src/main/scala/gem/Location.scala
@@ -177,7 +177,7 @@ object Location {
     case (l0,         l1        )                =>
       l0.positions.zip(l1.positions)
         .find { case (a, b) => a =/= b }
-        .fold[Ordering](EQ) { case (a, b) => (a < b) ?[Ordering] LT | GT }
+        .fold[Ordering](EQ) { case (a, b) => if (a < b) LT else GT }
   })
 
   implicit val OrderMiddle: Order[Location.Middle] =

--- a/modules/core/src/main/scala/gem/User.scala
+++ b/modules/core/src/main/scala/gem/User.scala
@@ -24,7 +24,7 @@ trait UserProgramRoleOps extends Ops[User[ProgramRole]] {
   def programRoles(pid: Program.Id): Set[ProgramRole] =
     self.allProgramRoles.get(pid).orZero
 
-  def hasProgramRole(pid: Program.Id, role: ProgramRole) =
+  def hasProgramRole(pid: Program.Id, role: ProgramRole): Boolean =
     programRoles(pid).contains(role)
 
 }

--- a/modules/core/src/main/scala/gem/config/DynamicConfig.scala
+++ b/modules/core/src/main/scala/gem/config/DynamicConfig.scala
@@ -59,7 +59,7 @@ final case class F2DynamicConfig(
 ) extends DynamicConfig {
 
   type I = Instrument.Flamingos2.type
-  def instrument = valueOf[I]
+  def instrument: I = valueOf[I]
 
   def key: F2SmartGcalKey =
     F2SmartGcalKey(disperser, filter, fpu)

--- a/modules/ctl/src/main/scala/free/interp.scala
+++ b/modules/ctl/src/main/scala/free/interp.scala
@@ -17,8 +17,8 @@ object interpreter {
   }
 
   case class InterpreterState(indentation: Int, machineHostCache: Map[Host.Machine, String]) {
-    def indent  = copy(indentation = indentation + 1)
-    def outdent = copy(indentation = indentation - 1)
+    def indent: InterpreterState = copy(indentation = indentation + 1)
+    def outdent:InterpreterState = copy(indentation = indentation - 1)
   }
   object InterpreterState {
     val initial = InterpreterState(0, Map.empty)
@@ -28,7 +28,7 @@ object interpreter {
    * Construct an interpreter of `CtlIO` given a `Config` and an `IORef` for the initial state. We
    * carry our state in an `IORef` because it needs to be visible from multiple threads.
    */
-  def interpreter(c: Config, state: IORef[InterpreterState]) = λ[CtlOp ~> EitherT[IO, Int, ?]] {
+  def interpreter(c: Config, state: IORef[InterpreterState]): CtlOp ~> EitherT[IO, Int, ?] = λ[CtlOp ~> EitherT[IO, Int, ?]] {
     case CtlOp.Shell(false, cmd) => doShell(cmd, c.verbose, state)
     case CtlOp.Shell(true,  cmd) =>
       c.server match {

--- a/modules/ctl/src/main/scala/hi/Common.scala
+++ b/modules/ctl/src/main/scala/hi/Common.scala
@@ -39,7 +39,7 @@ object common {
     }
 
   case class DeployCommit(commit: Commit, uncommitted: Boolean) {
-    def imageVersion = if (uncommitted) s"${commit.hash}-UNCOMMITTED" else commit.hash
+    def imageVersion: String = if (uncommitted) s"${commit.hash}-UNCOMMITTED" else commit.hash
   }
 
 }

--- a/modules/ctl/src/main/scala/hi/deploy.scala
+++ b/modules/ctl/src/main/scala/hi/deploy.scala
@@ -169,7 +169,7 @@ object deploy {
       } yield kDb
     }
 
-  def createGemContainer(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, kPrev: Option[Container]) =
+  def createGemContainer(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, kPrev: Option[Container]): CtlIO[Container] =
     gosub(s"Creating Gem container from image ${iDeploy.hash}") {
       for {
         k  <- docker("run",
@@ -203,7 +203,7 @@ object deploy {
       }
     }
 
-  def deployGem(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, kPrev: Option[Container]) =
+  def deployGem(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, kPrev: Option[Container]): CtlIO[Container] =
     gosub("Deploying Gem.") {
       for {
         kGem <- createGemContainer(nDeploy, cDeploy, iDeploy, kPrev)
@@ -225,7 +225,7 @@ object deploy {
       }
     }
 
-  def deployStandalone(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, iPg: Image) =
+  def deployStandalone(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, iPg: Image): CtlIO[Unit] =
     gosub("Performing STANDALONE deployment") {
       for {
         _   <- ensureNoRunningDeployments
@@ -234,7 +234,7 @@ object deploy {
       } yield ()
     }
 
-  def deployUpgrade(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, iPg: Image, force: Boolean) =
+  def deployUpgrade(nDeploy: Int, cDeploy: DeployCommit, iDeploy: Image, iPg: Image, force: Boolean): CtlIO[Unit] =
     gosub("Performing UPGRADE deployment") {
       for {
         kGem  <- getRunningGemContainer
@@ -253,7 +253,7 @@ object deploy {
       } yield ()
     }
 
-  def deploy(deploy: String, standalone: Boolean, force: Boolean) =
+  def deploy(deploy: String, standalone: Boolean, force: Boolean): CtlIO[Unit] =
     for {
       nDeploy  <- getDeployNumber
       cDeploy  <- getDeployCommit(deploy)

--- a/modules/ctl/src/main/scala/hi/rollback.scala
+++ b/modules/ctl/src/main/scala/hi/rollback.scala
@@ -23,7 +23,7 @@ object rollback {
       ks.toList.traverse_(stopContainer)
     }
 
-  def rollback =
+  val rollback: CtlIO[Unit] =
     gosub("Attempting rollback to previous version.") {
       for {
         kGemC <- getRunningGemContainer

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -36,5 +36,5 @@ trait DoobieClient {
       s <- HC.setSavepoint
       n <- fa.onUniqueViolation(HC.rollback(s).as(0)) ensuring HC.releaseSavepoint(s)
     } yield n
-    
+
 }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,75 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <!-- <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check> -->
+ <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Za-z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][a-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <!-- <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check> -->
+ <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+<!--  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check> -->
+<!--  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check> -->
+<!--  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check> -->
+ <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <!-- <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check> -->
+ <!-- <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check> -->
+ <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="ignoreOverride">true</parameter>
+  </parameters>
+ </check>
+
+  <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"/>
+  <!-- <check level="error" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"/> -->
+  <!-- <check level="error" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true"/> -->
+  <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+  <!-- <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/> -->
+  <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"/>
+  <!-- <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/> -->
+  <!-- <check level="error" class="org.scalastyle.scalariform.TodoCommentChecker" enabled="true"/> -->
+  <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"/>
+
+</scalastyle>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,7 +1,7 @@
 <scalastyle>
  <name>Scalastyle standard configuration</name>
  <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
- <!-- <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check> -->
+ <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
@@ -26,17 +26,17 @@
  <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
  <!-- <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check> -->
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
-<!--  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[println]]></parameter>
   </parameters>
- </check> -->
-<!--  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
    <parameter name="maxTypes"><![CDATA[30]]></parameter>
   </parameters>
- </check> -->
-<!--  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+ </check>
+ <!-- <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
   <parameters>
    <parameter name="maximum"><![CDATA[10]]></parameter>
   </parameters>


### PR DESCRIPTION
This adds [Scalastyle](http://www.scalastyle.org/) which gives some lightweight checking for stylistic things like return type annotations (I had to add a few). It's very fast so I put it first in the CI build. There's a lot of room to improve/extend the default configuration.