### PR TITLE
fatal warnings and more headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - psql -c 'create database gem' -U postgres
 
 script:
-  - sbt headerCheck scalastyle sql/flywayMigrate compile test
+  - sbt headerCheck test:headerCheck scalastyle sql/flywayMigrate compile test
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val commonSettings = Seq(
     "-language:implicitConversions",     // Allow definition of implicit functions called views
     "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-    // "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
     "-Xfuture",                          // Turn on future language features.
     "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
     "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.

--- a/modules/core/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/Arbitraries.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem
 
 import gem.config.{DynamicConfig, GcalConfig, StaticConfig, TelescopeConfig}

--- a/modules/core/src/test/scala/gem/LocationSpec.scala
+++ b/modules/core/src/test/scala/gem/LocationSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem
 
 import org.scalatest.prop.PropertyChecks

--- a/modules/core/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/config/Arbitraries.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.config
 
 import gem.config.GcalConfig.{GcalArcs, GcalLamp}

--- a/modules/core/src/test/scala/gem/enum/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/enum/Arbitraries.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.enum
 
 import org.scalacheck._

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 
 import doobie.imports._

--- a/modules/db/src/test/scala/gem/dao/EventLogDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/EventLogDaoSample.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 
 import doobie.imports._

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 
 import gem.Observation

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 
 import gem.config.{GcalConfig, SmartGcalKey, F2SmartGcalKey}

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 
 import gem._

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 
 import gem.{Location, Observation, Step}

--- a/modules/db/src/test/scala/gem/dao/TimedSample.scala
+++ b/modules/db/src/test/scala/gem/dao/TimedSample.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 
 import doobie.imports._

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/DatasetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/DatasetCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/EventLogCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EventLogCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/GcalDao.scala
+++ b/modules/db/src/test/scala/gem/dao/check/GcalDao.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/LogCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/LogCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/ProgramCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/ProgramCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/SemesterCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/SemesterCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/SmartGcalCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/SmartGcalCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/StaticCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StaticCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem.dao
 package check
 

--- a/modules/json/src/test/scala/gem/json/CompilationTest.scala
+++ b/modules/json/src/test/scala/gem/json/CompilationTest.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package gem
 package json
 


### PR DESCRIPTION
This is a twofer because why not.
- turns on `-Xfatal-warnings`
- adds missing check for headers in test sources (and adds the headers)