### PR TITLE
Remove step foreign key from gcal table

### DIFF
--- a/modules/db/src/main/scala/gem/dao/GcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GcalDao.scala
@@ -13,8 +13,8 @@ import java.time.Duration
 
 object GcalDao {
 
-  def insert(gcal: GcalConfig, step: Option[Int]): ConnectionIO[Int] =
-    Statements.insert(gcal, step).withUniqueGeneratedKeys[Int]("gcal_id") // janky, hm
+  def insert(gcal: GcalConfig): ConnectionIO[Int] =
+    Statements.insert(gcal).withUniqueGeneratedKeys[Int]("gcal_id") // janky, hm
 
   def select(id: Int): ConnectionIO[Option[GcalConfig]] =
     Statements.select(id).option.map(_.flatten)
@@ -29,10 +29,10 @@ object GcalDao {
         Distinct.short("coadds").xmap(CoAdds(_), _.toShort)
     }
 
-    def insert(gcal: GcalConfig, step: Option[Int]): Update0 = {
+    def insert(gcal: GcalConfig): Update0 = {
       val arcs: GcalArc => Boolean = gcal.arcs.member
-      sql"""INSERT INTO gcal (step_id, continuum, ar_arc, cuar_arc, thar_arc, xe_arc, filter, diffuser, shutter, exposure_time, coadds)
-            VALUES ($step, ${gcal.continuum}, ${arcs(ArArc)}, ${arcs(CuArArc)}, ${arcs(ThArArc)}, ${arcs(XeArc)}, ${gcal.filter}, ${gcal.diffuser}, ${gcal.shutter}, ${gcal.exposureTime}, ${CoAdds(gcal.coadds)})
+      sql"""INSERT INTO gcal (continuum, ar_arc, cuar_arc, thar_arc, xe_arc, filter, diffuser, shutter, exposure_time, coadds)
+            VALUES (${gcal.continuum}, ${arcs(ArArc)}, ${arcs(CuArArc)}, ${arcs(ThArArc)}, ${arcs(XeArc)}, ${gcal.filter}, ${gcal.diffuser}, ${gcal.shutter}, ${gcal.exposureTime}, ${CoAdds(gcal.coadds)})
          """.update
     }
 

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -27,7 +27,7 @@ object SmartGcalDao {
 
   def insert(l: GcalLampType, b: GcalBaselineType, k: SmartGcalKey, g: GcalConfig): ConnectionIO[Int] =
     for {
-      id <- GcalDao.insert(g, None)
+      id <- GcalDao.insert(g)
       r  <-
         k match {
           case f2: F2SmartGcalKey => Statements.insertSmartF2(l, b, id, f2).run

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -36,7 +36,7 @@ object StepDao {
               case DarkStep(_)         => Statements.insertDarkSlice(id).run
               case ScienceStep(_, t)   => Statements.insertScienceSlice(id, t).run
               case SmartGcalStep(_, t) => Statements.insertSmartGcalSlice(id, t).run
-              case GcalStep(_, g)      => GcalDao.insert(g, Some(id)) >>= (Statements.insertGcalStep(id, _).run)
+              case GcalStep(_, g)      => GcalDao.insert(g) >>= (Statements.insertGcalStep(id, _).run)
             }
       _  <- insertConfigSlice(id, s.dynamicConfig)
     } yield id

--- a/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
@@ -7,6 +7,6 @@ package check
 class GcalCheck extends Check {
   import GcalDao.Statements._
   "GcalDao.Statements" should
-            "insert" in check(insert(Dummy.gcalConfig, None))
+            "insert" in check(insert(Dummy.gcalConfig))
   it should "select" in check(select(0))
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
@@ -41,9 +41,10 @@ object FileImporter extends SafeApp with DoobieClient {
 
   val clean: ConnectionIO[Unit] =
     for {
-      _ <- sql"truncate program cascade".update.run
-      _ <- sql"truncate log".update.run
-      _ <- sql"delete from semester".update.run
+      _ <- sql"DELETE FROM gcal USING step_gcal WHERE gcal.gcal_id = step_gcal.gcal_id".update.run
+      _ <- sql"TRUNCATE program, static_config CASCADE".update.run
+      _ <- sql"TRUNCATE log".update.run
+      _ <- sql"DELETE FROM semester".update.run
     } yield ()
 
   def read(f: File): IO[Elem] =

--- a/modules/sql/src/main/resources/db/migration/V015__Remove_Step_FK_From_Gcal.sql
+++ b/modules/sql/src/main/resources/db/migration/V015__Remove_Step_FK_From_Gcal.sql
@@ -1,0 +1,21 @@
+--
+-- Remove step_id from gcal.  step_gcal is used to tie gcal to step.  The
+-- step_id was added to make deletion of step_gcal cascade through to the
+-- gcal table.  When truncating the program table though, the truncate
+-- unfortunately trickles down to gcal which also contains gcal configs
+-- for smart_gcal.
+--
+
+ALTER TABLE gcal
+  DROP COLUMN step_id CASCADE;
+
+-- Delete the corresponding gcal row when a step_gcal row is removed.
+CREATE FUNCTION delete_gcal() RETURNS trigger AS $delete_gcal$
+  BEGIN
+    DELETE FROM gcal WHERE gcal_id = OLD.gcal_id;
+    RETURN OLD;
+  END;
+$delete_gcal$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_gcal AFTER DELETE ON step_gcal
+  FOR EACH ROW EXECUTE PROCEDURE delete_gcal();


### PR DESCRIPTION
This PR is half a request for ideas and half proposal. I noticed that after importing programs via `ocs2/run` suddenly the Smart Gcal tests would stop working. The issue is that the `smart_f2` table is truncated by the cleanup performed by the `FileImporter` before reading programs. 

```scala
val clean: ConnectionIO[Unit] =
  for {
    _ <- sql"TRUNCATE program CASCADE".update.run
    ...
  } yield ()
```

In particular `TRUNCATE program CASCADE` ultimately truncates the `smart_f2` table needed by F2 Smart Gcal.  This is because `smart_f2` has a foreign key to the `gcal` table, which in turn has a foreign key to `step` which references `observation` which references `program`. 

One way to fix this would be to delete all rows from program with `DELETE FROM program` instead of using `TRUNCATE`.  That would take advantage of normal delete cascading which would cull associated `gcal` table rows but not remove those required by `smart_f2`.  Unfortunately it is very slow, even for a database with just a single semester of queue programs loaded.  Maybe that's okay though because we can always use `flywayClean` before importing?

Another option is to remove the foreign key reference from `gcal` to `step` and thus stop the cascading truncates.  The foreign key reference was only added to make automatic cleanup of `gcal` rows happen when the corresponding `step` row is deleted.  I've taken that approach in this PR.  Now a trigger is required to clean `gcal` rows when the associated step is removed.

Also, I noticed that `static_config`, which has no foreign key references to observation is not touched by the `TRUNCATE program CASCADE` cleanup, so I explicitly listed it in `FileImporter.clean`

```scala
  val clean: ConnectionIO[Unit] =
    for {
      _ <- sql"DELETE FROM gcal USING step_gcal WHERE gcal.gcal_id = step_gcal.gcal_id".update.run
      _ <- sql"TRUNCATE program, static_config CASCADE".update.run
      _ <- sql"TRUNCATE log".update.run
      _ <- sql"DELETE FROM semester".update.run
    } yield ()
```