### PR TITLE
Use Flyway clean/migrate before import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,10 +206,18 @@ lazy val json = project
     )
   )
 
+lazy val sql = project
+  .in(file("modules/sql"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings ++ flywaySettings)
+  .settings(
+    libraryDependencies += "org.flywaydb" % "flyway-core" % "4.0.3"
+  )
+
 lazy val ocs2 = project
   .in(file("modules/ocs2"))
   .enablePlugins(AutomateHeaderPlugin)
-  .dependsOn(core, db)
+  .dependsOn(core, db, sql)
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
@@ -227,14 +235,6 @@ lazy val service = project
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core, db)
   .settings(commonSettings)
-
-lazy val sql = project
-  .in(file("modules/sql"))
-  .enablePlugins(AutomateHeaderPlugin)
-  .settings(commonSettings ++ flywaySettings)
-  .settings(
-    libraryDependencies += "org.flywaydb" % "flyway-core" % "4.0.3"
-  )
 
 lazy val telnetd = project
   .in(file("modules/telnetd"))

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -16,18 +16,16 @@ import scalaz.effect.IO
 /** Shared support for import applications using Doobie. */
 trait DoobieClient {
 
+  val Url  = "jdbc:postgresql:gem"
+  val User = "postgres"
+  val Pass = ""
+
   val xa = DriverManagerTransactor[IO](
-    "org.postgresql.Driver",
-    "jdbc:postgresql:gem",
-    "postgres",
-    ""
+    "org.postgresql.Driver", Url, User, Pass
   )
 
   val lxa = DriverManagerTransactor[Task](
-    "org.postgresql.Driver",
-    "jdbc:postgresql:gem",
-    "postgres",
-    ""
+    "org.postgresql.Driver", Url, User, Pass
   )
 
   def configureLogging(): Unit = List(


### PR DESCRIPTION
Following the suggestion from @tpolecat in #61, this PR switches to use Flyway for database cleaning before a file imports.