### PR TITLE
move ctl module to cats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,10 @@ lazy val http4sVersion            = "0.15.2a"
 lazy val scalaXmlVerson           = "1.0.6"
 lazy val scalaParsersVersion      = "1.0.4"
 lazy val tucoVersion              = "0.1.1"
+lazy val catsVersion              = "0.9.0"
+lazy val catsEffectVersion        = "0.3"
+lazy val declineVersion           = "0.2.2"
+lazy val mouseVersion             = "0.9"
 
 enablePlugins(GitVersioning)
 
@@ -255,11 +259,12 @@ lazy val ctl = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings (
-    resolvers += "bmjames Bintray Repo" at "https://dl.bintray.com/bmjames/maven",
+    resolvers += Resolver.bintrayRepo("bkirwi", "maven"),
     libraryDependencies ++= Seq(
-      "org.scalaz"  %% "scalaz-core"   % scalazVersion,
-      "org.scalaz"  %% "scalaz-effect" % scalazVersion,
-      "net.bmjames" %% "scala-optparse-applicative" % "0.5"
+      "org.typelevel"           %% "cats"        % catsVersion,
+      "org.typelevel"           %% "cats-effect" % catsEffectVersion,
+      "com.monovore"            %% "decline"     % declineVersion,
+      "com.github.benhutchison" %% "mouse"       % mouseVersion
     ),
     addCommandAlias("gemctl", "ctl/runMain gem.ctl.main")
   )

--- a/modules/ctl/src/main/scala/command.scala
+++ b/modules/ctl/src/main/scala/command.scala
@@ -37,7 +37,7 @@ object Command {
   def parse[A](progName: String, args: List[String]): IO[Option[Command]] =
     mainParser(progName).parse(args) match {
       case Right(c) => c.some.pure[IO]
-      case Left(h) => IO(Console.println(Console.BLUE + h.toString + Console.RESET)).as(none[Command])
+      case Left(h) => IO(Console.println(Console.BLUE + h.toString + Console.RESET)).as(none[Command]) // scalastyle:ignore
     }
 
   // Opts implementation below

--- a/modules/ctl/src/main/scala/command.scala
+++ b/modules/ctl/src/main/scala/command.scala
@@ -39,21 +39,6 @@ object Command {
       case Right(c) => c.some.pure[IO]
       case Left(h) => IO(Console.println(Console.BLUE + h.toString + Console.RESET)).as(none[Command])
     }
-    // execParserPure(prefs(idm[PrefsMod]), mainParser, args) match {
-    //   case Success(c) => IO(Some(c))
-    //   case Failure(f) =>
-    //     import Predef._
-    //     val (msg, exit) = renderFailure(f, progName)
-    //     IO.putStr(Console.BLUE) *>
-    //     IO.putStrLn(msg) *>
-    //     IO.putStrLn("")  *>
-    //     IO.putStrLn(s"""
-    //       |Hints:
-    //       |  $progName --help            To see available commands.
-    //       |  $progNage COMMAND --help    To see help on a specific command.
-    //      """.trim.stripMargin) *>
-    //      IO.putStr(Console.RESET) as None
-    // }
 
   // Opts implementation below
 

--- a/modules/ctl/src/main/scala/command.scala
+++ b/modules/ctl/src/main/scala/command.scala
@@ -3,11 +3,9 @@
 
 package gem.ctl
 
-import net.bmjames.opts._
-import net.bmjames.opts.types.{ Success, Failure }
-import net.bmjames.opts.builder.internal.{ Mod, CommandFields }
+import com.monovore.decline.{ Command => Cmd, _ }
 
-import scalaz._, Scalaz._, scalaz.effect._
+import cats.implicits._, cats.effect.IO
 
 import gem.ctl.free.ctl.{ Server, Host }
 import gem.ctl.free.interpreter.Config
@@ -37,116 +35,134 @@ object Command {
    * name of the executable ("gemctl" for example).
    */
   def parse[A](progName: String, args: List[String]): IO[Option[Command]] =
-    execParserPure(prefs(idm[PrefsMod]), mainParser, args) match {
-      case Success(c) => IO(Some(c))
-      case Failure(f) =>
-        import Predef._
-        val (msg, exit) = renderFailure(f, progName)
-        IO.putStr(Console.BLUE) *>
-        IO.putStrLn(msg) *>
-        IO.putStrLn("")  *>
-        IO.putStrLn(s"""
-          |Hints:
-          |  $progName --help            To see available commands.
-          |  $progName COMMAND --help    To see help on a specific command.
-         """.trim.stripMargin) *>
-         IO.putStr(Console.RESET) as None
+    mainParser(progName).parse(args) match {
+      case Right(c) => c.some.pure[IO]
+      case Left(h) => IO(Console.println(Console.BLUE + h.toString + Console.RESET)).as(none[Command])
     }
+    // execParserPure(prefs(idm[PrefsMod]), mainParser, args) match {
+    //   case Success(c) => IO(Some(c))
+    //   case Failure(f) =>
+    //     import Predef._
+    //     val (msg, exit) = renderFailure(f, progName)
+    //     IO.putStr(Console.BLUE) *>
+    //     IO.putStrLn(msg) *>
+    //     IO.putStrLn("")  *>
+    //     IO.putStrLn(s"""
+    //       |Hints:
+    //       |  $progName --help            To see available commands.
+    //       |  $progNage COMMAND --help    To see help on a specific command.
+    //      """.trim.stripMargin) *>
+    //      IO.putStr(Console.RESET) as None
+    // }
 
-  // Parser implementation below
+  // Opts implementation below
 
-  private lazy val machine: Parser[Boolean] =
-    switch(
-      short('m'), long("machine"),
-      help("Use docker machine. Use with -H to specify a machine other than 'default'.")
-    )
+  private lazy val machine: Opts[Boolean] =
+    Opts.flag(
+      short = "m",
+      long  = "machine",
+      help  = "Use docker machine. Use with -H to specify a machine other than 'default'."
+    ).orFalse
 
-  private lazy val host: Parser[Option[String]] =
-    optional(
-      strOption(
-        short('H'), long("host"), metavar("HOST"),
-        help("Use the specified docker host (machine when given with -m).")
-      )
-    )
+  private lazy val host: Opts[Option[String]] =
+    Opts.option[String](
+      short   = "H",
+      long    = "host",
+      metavar = "HOST",
+      help    = "Use the specified docker host (machine when given with -m)."
+    ).orNone
 
-  private lazy val server: Parser[Server] =
-    (machine |@| host |@| user) {
+  private lazy val server: Opts[Server] =
+    (machine |@| host |@| user) map {
       case (true,  oh,      ou) => Server.Remote(Host.Machine(oh.getOrElse("default")), ou)
       case (false, Some(h), ou) => Server.Remote(Host.Network(h), ou)
       case (false, None,    _ ) => Server.Local
     }
 
-  private lazy val user: Parser[Option[String]] =
-    optional(
-      strOption(
-        short('u'), long("user"), metavar("USER"),
-        help("Server user. Default value is 'docker' with -m, otherwise current user, ignored if neither -H nor -m is specified.")
-      )
-    )
+  private lazy val user: Opts[Option[String]] =
+    Opts.option[String](
+      short = "u",
+      long  = "user",
+      metavar = "USER",
+      help = "Server user. Default value is 'docker' with -m, otherwise current user, ignored if neither -H nor -m is specified."
+    ).orNone
 
-  private lazy val deployRevision: Parser[String] =
-    strOption(
-      short('d'), long("deploy"), metavar("REVISION"), value("HEAD"),
-      help("Revision to deploy, HEAD if unspecified.")
-    )
+  private lazy val deployRevision: Opts[String] =
+    Opts.option[String](
+      short   = "d",
+      long    = "deploy",
+      metavar = "REVISION",
+      help    = "Revision to deploy, HEAD if unspecified."
+    ).withDefault("HEAD")
 
-  private lazy val standalone: Parser[Boolean] =
-    switch(
-      short('s'), long("standalone"),
-      help("Deploy standalone; do not attempt an upgrade. Cannot be specified with --base")
-    )
+  private lazy val standalone: Opts[Boolean] =
+    Opts.flag(
+      short = "s",
+      long  = "standalone",
+      help  = "Deploy standalone; do not attempt an upgrade. Cannot be specified with --base"
+    ).orFalse
 
-  private lazy val force: Parser[Boolean] =
-    switch(
-      short('f'), long("force"),
-      help("Force an upgrade, even if base and deploy revisions are identical.")
-    )
+  private lazy val force: Opts[Boolean] =
+    Opts.flag(
+      short = "f",
+      long  = "force",
+      help  = "Force an upgrade, even if base and deploy revisions are identical."
+    ).orFalse
 
-  private lazy val verbose: Parser[Boolean] =
-    switch(
-      short('v'), long("verbose"),
-      help("Show details about what we're doing under the hood.")
-    )
+  private lazy val verbose: Opts[Boolean] =
+    Opts.flag(
+      short = "v",
+      long  = "verbose",
+      help  = "Show details about what we're doing under the hood."
+    ).orFalse
 
-  private lazy val deploy: Parser[Deploy] =
-    (server |@| deployRevision |@| standalone |@| verbose |@| force)(Deploy.apply)
+  private lazy val deploy: Opts[Deploy] =
+    (server |@| deployRevision |@| standalone |@| verbose |@| force) map Deploy.apply
 
-  private lazy val lines: Parser[Int] = {
+  private lazy val lines: Opts[Int] = {
     val DefaultLines = 50
-    intOption(
-      short('n'), metavar("LINES"), value(DefaultLines),
-      help(s"Number of lines to show from tail of log (default $DefaultLines)")
-    )
+    Opts.option[Int](
+      short   = "n",
+      long    = "lines",
+      metavar = "LINES",
+      help    = s"Number of lines to show from tail of log (default $DefaultLines)"
+    ).withDefault(DefaultLines)
   }
 
-  private lazy val configCommand: Mod[CommandFields, Command] =
-    command("deploy", info(deploy.widen[Command] <* helper,
-      progDesc("Deploy an application."))
-    )
+  private lazy val configCommand: Opts[Command] =
+    Opts.subcommand(
+      name = "deploy",
+      help = "Deploy an application."
+    )(deploy.widen[Command])
 
-  private lazy val psCommand: Mod[CommandFields, Command] =
-    command("ps", info((server |@| verbose)(Ps).widen[Command] <* helper,
-      progDesc("Get the status of a gem deployment."))
-    )
+  private lazy val psCommand: Opts[Command] =
+    Opts.subcommand(
+      name = "ps",
+      help = "Get the status of a gem deployment."
+    )((server |@| verbose).map(Ps).widen[Command])
 
-  private lazy val stopCommand: Mod[CommandFields, Command] =
-    command("stop", info((server |@| verbose)(Stop).widen[Command] <* helper,
-      progDesc("Stop a gem deployment."))
-    )
+  private lazy val stopCommand: Opts[Command] =
+    Opts.subcommand(
+      name = "stop",
+      help = "Stop a gem deployment."
+    )((server |@| verbose).map(Stop).widen[Command])
 
-  private lazy val logCommand: Mod[CommandFields, Command] =
-    command("log", info((server |@| verbose |@| lines)(Log).widen[Command] <* helper,
-      progDesc("Show the Gem server log."))
-    )
+  private lazy val logCommand: Opts[Command] =
+    Opts.subcommand(
+      name = "log",
+      help = "Show the Gem server log."
+    )((server |@| verbose |@| lines).map(Log).widen[Command])
 
-  private lazy val rollbackCommand: Mod[CommandFields, Command] =
-    command("rollback", info((server |@| verbose)(Rollback).widen[Command] <* helper,
-      progDesc("Roll the current gem deployment back to the previous one, if possible."))
-    )
+  private lazy val rollbackCommand: Opts[Command] =
+    Opts.subcommand(
+      name = "rollback",
+      help = "Roll the current gem deployment back to the previous one, if possible."
+    )((server |@| verbose).map(Rollback).widen[Command])
 
-  private lazy val mainParser: ParserInfo[Command] =
-    info(
-      subparser(configCommand, psCommand, stopCommand, logCommand, rollbackCommand) <*>
-      helper, progDesc("Deploy and control gem."))
+  private def mainParser(progName: String): Cmd[Command] =
+    Cmd(
+      name   = progName,
+      header = "Deploy and control gem."
+    )(List(configCommand, psCommand, stopCommand, logCommand, rollbackCommand).foldRight(Opts.never: Opts[Command])(_ orElse _))
 
 }

--- a/modules/ctl/src/main/scala/free/interp.scala
+++ b/modules/ctl/src/main/scala/free/interp.scala
@@ -4,8 +4,8 @@
 package gem.ctl
 package free
 
-import scalaz._, Scalaz._
-import scalaz.effect._
+import cats._, cats.data._, cats.implicits._
+import cats.effect._
 
 import gem.ctl.low.io._
 import gem.ctl.free.ctl._
@@ -45,11 +45,11 @@ object interpreter {
           }
 
         case Server.Remote(Host.Network(h), u) =>
-          doRemoteShell(u.foldRight(h)((u, h) => s"$u@$h"), cmd, c, state)
+          doRemoteShell(u.map(u =>  s"$u@$h").getOrElse(h), cmd, c, state)
 
       }
-    case CtlOp.Exit(exitCode)    => EitherT.left(exitCode.point[IO])
-    case CtlOp.GetConfig         => c.point[EitherT[IO, Int, ?]]
+    case CtlOp.Exit(exitCode)    => EitherT.left(exitCode.pure[IO])
+    case CtlOp.GetConfig         => c.pure[EitherT[IO, Int, ?]]
     case CtlOp.Gosub(level, msg, fa) =>
       for {
         _ <- doLog(level, msg, state)
@@ -75,7 +75,7 @@ object interpreter {
     val messageColor = color // if (level == Shell) color else Console.BLUE
     for {
       i <- state.read.map(_.indentation).map("  " * _)
-      _ <- IO.putStrLn(f"$color$pre%-7s $messageColor$i$msg${Console.RESET}")
+      _ <- IO(Console.println(f"$color$pre%-7s $messageColor$i$msg${Console.RESET}"))
     } yield ()
   }
 
@@ -89,9 +89,9 @@ object interpreter {
   /** Machine name to IP-address. */
   private def machineHost(machine: Host.Machine, verbose: Boolean, state: IORef[InterpreterState]): EitherT[IO, Int, String] =
     EitherT.right(state.read.map(_.machineHostCache.get(machine))).flatMap {
-      case Some(s) => s.point[EitherT[IO, Int, ?]]
+      case Some(s) => s.pure[EitherT[IO, Int, ?]]
       case None =>
-        doShell(List("docker-machine", "ip", machine.name).right, verbose, state).flatMap {
+        doShell(Right(List("docker-machine", "ip", machine.name)), verbose, state).flatMap {
           case Output(0, s :: Nil) =>
             doLog(Level.Info, s"Address of docker machine '${machine.name}' is $s." , state) *>
             EitherT.right {
@@ -99,28 +99,29 @@ object interpreter {
             }
           case _ =>
             doLog(Level.Error, "couldn't get ip-address for machine ", state) *>
-            EitherT.left(-1.point[IO])
+            EitherT.left(-1.pure[IO])
         }
     }
 
-  private def doRemoteShell(uh: String, cmd: String \/ List[String], c: Config, state: IORef[InterpreterState]): EitherT[IO, Int, Output] =
+  private def doRemoteShell(uh: String, cmd: Either[String, List[String]], c: Config, state: IORef[InterpreterState]): EitherT[IO, Int, Output] =
     doShell(cmd.bimap(s => s"ssh $uh $s", "ssh" :: uh :: _), c.verbose, state)
 
   /**
    * Construct a program to perform a shell operation, optionally logging the output (if verbose),
    * and gathering the result as an `Output`.
    */
-  private def doShell(cmd: String \/ List[String], verbose: Boolean, state: IORef[InterpreterState]): EitherT[IO, Int, Output] = {
+  private def doShell(cmd: Either[String, List[String]], verbose: Boolean, state: IORef[InterpreterState]): EitherT[IO, Int, Output] = {
 
     def handler(s: String): IO[Unit] =
       if (verbose) doLogʹ(Level.Shell, s, state)
-      else IO.putStr(".")
+      else IO(Console.print("."))
 
     for {
-      _ <- verbose.whenM(doLog(Level.Shell, s"$$ ${cmd.fold(identity, _.mkString(" "))}", state))
+      // N.B. unlessA and whenA are merged and will be available post 0.9.0
+      _ <- if (verbose) doLog(Level.Shell, s"$$ ${cmd.fold(identity, _.mkString(" "))}", state) else ().pure[EitherT[IO, Int, ?]]
       o <- EitherT.right(exec(cmd, handler))
-      _ <- verbose.whenM(doLog(Level.Shell, s"exit(${o.exitCode})", state))
-      - <- verbose.unlessM(EitherT.right[IO, Int, Unit](IO.putStr("\u001B[1G\u001B[K")))
+      _ <- if (verbose) doLog(Level.Shell, s"exit(${o.exitCode})", state) else ().pure[EitherT[IO, Int, ?]]
+      - <- if (!verbose) EitherT.right[IO, Int, Unit](IO(Console.print("\u001B[1G\u001B[K"))) else ().pure[EitherT[IO, Int, ?]]
     } yield o
 
   }

--- a/modules/ctl/src/main/scala/free/interp.scala
+++ b/modules/ctl/src/main/scala/free/interp.scala
@@ -75,7 +75,7 @@ object interpreter {
     val messageColor = color // if (level == Shell) color else Console.BLUE
     for {
       i <- state.read.map(_.indentation).map("  " * _)
-      _ <- IO(Console.println(f"$color$pre%-7s $messageColor$i$msg${Console.RESET}"))
+      _ <- IO(Console.println(f"$color$pre%-7s $messageColor$i$msg${Console.RESET}")) // scalastyle:ignore
     } yield ()
   }
 

--- a/modules/ctl/src/main/scala/hi/Common.scala
+++ b/modules/ctl/src/main/scala/hi/Common.scala
@@ -7,14 +7,14 @@ import gem.ctl.free.ctl._
 import gem.ctl.low.git._
 import gem.ctl.low.docker._
 
-import scalaz._, Scalaz._
+import cats.implicits._
 
 /** Constructors for some common `CtlIO` operations that are shared by other commands. */
 object common {
 
   def getUniqueRunningContainerWithLabel(label: String): CtlIO[Container] =
     findRunningContainersWithLabel(label) flatMap {
-      case c :: Nil => c.point[CtlIO]
+      case c :: Nil => c.pure[CtlIO]
       case Nil      => error("No running container found.")       *> exit(-1)
       case _        => error("Multiple running container found.") *> exit(-1)
     }

--- a/modules/ctl/src/main/scala/hi/log.scala
+++ b/modules/ctl/src/main/scala/hi/log.scala
@@ -8,7 +8,7 @@ import gem.ctl.low.io.Output
 import gem.ctl.low.docker.docker
 import gem.ctl.hi.common.getRunningGemContainer
 
-import scalaz._, Scalaz._
+import cats.implicits._
 
 /** Constructors for `CtlIO` operations related to the `log` command. */
 object log {

--- a/modules/ctl/src/main/scala/hi/ps.scala
+++ b/modules/ctl/src/main/scala/hi/ps.scala
@@ -7,7 +7,7 @@ import gem.ctl.free.ctl._
 import gem.ctl.low.io._
 import gem.ctl.low.docker._
 
-import scalaz._, Scalaz._
+import cats.implicits._
 
 /** Constructors for `CtlIO` operations related to the `ps` command. */
 object ps {

--- a/modules/ctl/src/main/scala/hi/rollback.scala
+++ b/modules/ctl/src/main/scala/hi/rollback.scala
@@ -8,7 +8,7 @@ import gem.ctl.low.docker._
 import gem.ctl.hi.common._
 import gem.ctl.hi.deploy._
 
-import scalaz._, Scalaz._
+import cats.implicits._
 
 /** Constructors for `CtlIO` operations related to the `rollback` command. */
 object rollback {

--- a/modules/ctl/src/main/scala/hi/stop.scala
+++ b/modules/ctl/src/main/scala/hi/stop.scala
@@ -6,7 +6,7 @@ package gem.ctl.hi
 import gem.ctl.free.ctl._
 import gem.ctl.low.docker._
 
-import scalaz._, Scalaz._
+import cats.implicits._
 
 /** Constructors for `CtlIO` operations related to the `stop` command. */
 object stop {

--- a/modules/ctl/src/main/scala/ioref.scala
+++ b/modules/ctl/src/main/scala/ioref.scala
@@ -4,14 +4,16 @@
 package gem.ctl
 
 import cats.effect.IO
+import java.util.concurrent.atomic.AtomicReference
 
-// N.B. this isn't in cats-effect yet
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
-final class IORef[A] private (var value: A) {
-  def mod(f: A => A): IO[Unit] = IO(value = f(value))
-  def read: IO[A] = IO(value)
+/** A threadsafe mutable cell. Note that there is no notion of atomicity; all oprations race. */
+final class IORef[A] private (ref: AtomicReference[A]) {
+  // N.B. can't compare and swap here because
+  def mod(f: A => A): IO[Unit] = IO(ref.set(f(ref.get)))
+  def set(a: A): IO[Unit] = IO(ref.set(a))
+  def read: IO[A] = IO(ref.get)
 }
 object IORef {
   def apply[A](a: A): IO[IORef[A]] =
-    IO(new IORef(a))
+    IO(new IORef(new AtomicReference(a)))
 }

--- a/modules/ctl/src/main/scala/ioref.scala
+++ b/modules/ctl/src/main/scala/ioref.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+
+import cats.effect.IO
+
+// N.B. this isn't in cats-effect yet
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
+final class IORef[A] private (var value: A) {
+  def mod(f: A => A): IO[Unit] = IO(value = f(value))
+  def read: IO[A] = IO(value)
+}
+object IORef {
+  def apply[A](a: A): IO[IORef[A]] =
+    IO(new IORef(a))
+}

--- a/modules/ctl/src/main/scala/low/docker.scala
+++ b/modules/ctl/src/main/scala/low/docker.scala
@@ -7,7 +7,7 @@ package low
 import gem.ctl.free.ctl._
 import io._
 
-import scalaz._, Scalaz._
+import cats.implicits._
 
 /** Low-level constructors for `CtlIO` operations related to docker. */
 object docker {
@@ -45,7 +45,7 @@ object docker {
       case Output(0, s :: ss) if (s :: ss).last.contains("not found") => None
       case Output(0, _) => Some(nameAndVersion)
     } .flatMap {
-      case None                 => none[Image].point[CtlIO]
+      case None                 => none[Image].pure[CtlIO]
       case Some(nameAndVersion) => findImage(nameAndVersion)
     }
 

--- a/modules/ctl/src/main/scala/low/git.scala
+++ b/modules/ctl/src/main/scala/low/git.scala
@@ -4,7 +4,7 @@
 package gem.ctl
 package low
 
-import scalaz._, Scalaz._
+import cats._, cats.implicits._
 import scala.util.matching.Regex
 
 import gem.ctl.free.ctl._
@@ -15,7 +15,7 @@ object git {
 
   final case class Commit(hash: String)
   object Commit {
-    implicit val OrderCommit: Order[Commit] = Order.orderBy(_.hash)
+    implicit val OrderCommit: Order[Commit] = Order.by(_.hash)
   }
 
   final case class Tag(tag: String)
@@ -32,7 +32,7 @@ object git {
       case Output(0, List(s)) => Some(Commit(s))
       case Output(128, _)     => None
     } .flatMap {
-      case Some(c) => c.point[CtlIO]
+      case Some(c) => c.pure[CtlIO]
       case None    => error(s"No such revsion: $rev") *> exit[Commit](128)
     }
 

--- a/modules/ctl/src/main/scala/low/io.scala
+++ b/modules/ctl/src/main/scala/low/io.scala
@@ -4,8 +4,7 @@
 package gem.ctl
 package low
 
-import scalaz._
-import scalaz.effect._
+import cats.effect.IO
 
 /** Low-level constructors for `CtlIO` operations related to system I/O. */
 object io {
@@ -13,13 +12,13 @@ object io {
   final case class Output(exitCode: Int, lines: List[String])
 
   @SuppressWarnings(Array("org.wartremover.warts.MutableDataStructures"))
-  def exec(cmd: String \/ List[String], f: String => IO[Unit]): IO[Output] =
+  def exec(cmd: Either[String, List[String]], f: String => IO[Unit]): IO[Output] =
     IO {
       import scala.sys.process._
       import collection.mutable.ListBuffer
       val b = ListBuffer[String]()
       val x = cmd.fold(_.cat, _.cat).run(ProcessLogger { s =>
-        f(s).unsafePerformIO // shh
+        f(s).unsafeRunSync // shh
         b.append(s) // side-effect
       }).exitValue
       Output(x, b.toList)

--- a/modules/ctl/src/main/scala/main.scala
+++ b/modules/ctl/src/main/scala/main.scala
@@ -3,8 +3,8 @@
 
 package gem.ctl
 
-import scalaz._, Scalaz._
-import scalaz.effect._
+import cats.implicits._
+import cats.effect._
 
 import gem.ctl.free.ctl._
 import gem.ctl.free.interpreter.{ interpreter, InterpreterState }
@@ -15,7 +15,7 @@ import gem.ctl.hi.stop.stop
 import gem.ctl.hi.deploy.deploy
 import gem.ctl.hi.rollback.rollback
 
-object main extends SafeApp {
+object main {
 
   /** Map a `Command` to a corresponding program in `CtlIO`. */
   def command(c: Command): CtlIO[Unit] =
@@ -28,16 +28,19 @@ object main extends SafeApp {
     }
 
   /** Entry point. Parse the commandline args and do what's asked, if possible. */
-  override def runl(args: List[String]): IO[Unit] =
+  def mainʹ(args: List[String]): IO[Unit] =
     for {
-      _  <- IO.putStrLn("")
+      _  <- IO(Console.println)
       c  <- Command.parse("gemctl", args)
       _  <- c.traverse { c =>
-              IO.newIORef(InterpreterState.initial)
+              IORef(InterpreterState.initial)
                 .map(interpreter(c, _))
-                .flatMap(command(c).foldMap(_).run)
+                .flatMap(command(c).foldMap(_).value)
             }
-      _  <- IO.putStrLn("")
+      _  <- IO(Console.println)
     } yield ()
+
+  def main(args: Array[String]): Unit =
+    mainʹ(args.toList).unsafeRunSync
 
 }

--- a/modules/ctl/src/main/scala/main.scala
+++ b/modules/ctl/src/main/scala/main.scala
@@ -30,14 +30,14 @@ object main {
   /** Entry point. Parse the commandline args and do what's asked, if possible. */
   def mainʹ(args: List[String]): IO[Unit] =
     for {
-      _  <- IO(Console.println)
+      _  <- IO(Console.println) // scalastyle:ignore
       c  <- Command.parse("gemctl", args)
       _  <- c.traverse { c =>
               IORef(InterpreterState.initial)
                 .map(interpreter(c, _))
                 .flatMap(command(c).foldMap(_).value)
             }
-      _  <- IO(Console.println)
+      _  <- IO(Console.println) // scalastyle:ignore
     } yield ()
 
   def main(args: Array[String]): Unit =


### PR DESCRIPTION
This is the first PR in a series to move gem to cats. Since the `ctl` module is a standalone thing it can be done independently. Notable changes:

- Replace `optparse-applicative` with `decline`, which uses cats and is also much simpler.
- `whenM` and `unlessM` don't exist in cats 0.9.0 but are merged and will be in the next version as `whenA` and `unlessA`. For now they're rewritten in terms of `if`.
- `IO.putStrLn`, etc., aren't provided so these are done as `IO(Console.println(...))` etc.
- `IORef` isn't provided so a simple version is included.
- `a.point[F]` is now `a.pure[F]` everywhere.
- All uses of `\/` are now `Either`, which is right-biased now.

Nothing major. 