### PR TITLE
enumerated ordering

### DIFF
--- a/modules/core/src/main/scala/gem/Enumerated.scala
+++ b/modules/core/src/main/scala/gem/Enumerated.scala
@@ -21,7 +21,7 @@ trait Enumerated[A] extends Order[A] {
   /** Select the member of this enumeration with the given tag, throwing if absent. */
   def unsafeFromTag(tag: String): A = fromTag(tag).getOrElse(sys.error("Invalid tag: " + tag))
 
-  /** Relative order of `a` and `b` in `all`;. */
+  /** Relative order of `a` and `b` in `all`. */
   def order(a: A, b: A): Ordering =
     Order[Int].order(indexOfTag(tag(a)), indexOfTag(tag(b)))
 

--- a/modules/core/src/test/scala/gem/EnumeratedSpec.scala
+++ b/modules/core/src/test/scala/gem/EnumeratedSpec.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.enum._
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ FlatSpec, Matchers }
+import scala.reflect.ClassTag
+
+class EnumeratedSpec extends FlatSpec with Matchers with PropertyChecks {
+
+  def checkEnumeration[A](
+    implicit en: Enumerated[A],
+             ct: ClassTag[A]
+  ): Unit =
+    s"Ordering for ${ct.runtimeClass.getName}" should "be canonical" in {
+      val sorted   = en.all
+      val shuffled = util.Random.shuffle(sorted)
+      shuffled.sorted(en.toScalaOrdering) shouldEqual sorted
+    }
+
+  // Check a handful of enums.
+  checkEnumeration[EventType]
+  checkEnumeration[F2Disperser]
+  checkEnumeration[GcalArc]
+  checkEnumeration[GmosAdc]
+  checkEnumeration[Half]
+  checkEnumeration[Instrument]
+  checkEnumeration[MosPreImaging]
+  checkEnumeration[ProgramRole]
+  checkEnumeration[ProgramType]
+  checkEnumeration[Site]
+  checkEnumeration[SmartGcalType]
+  checkEnumeration[StepType]
+
+}


### PR DESCRIPTION
This fixes the ordering of enumerated types to respect the order of the `all` collection. In practice what this means is that the sort order for generated enumerated types will now match the order in which they members are selected from the database by the code generator, and coincidentally the order in which they are declared in the generated code.