### PR TITLE
Add GMOS SmartGcal WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,12 @@ There are no other instrument-specific slices for science steps yet.
 
 #### Importing Smart Gcal Configuration
 
-Smart Gcal configuration is stored in database tables like everything else instead of in `.csv` files downloaded from SVN as in OCS2.  The `.csv` files can be imported though much like old program `.xml` files.  First, make a symlink to a directory containing the `.csv` files. 
+Smart Gcal configuration is stored in database tables instead of in `.csv` files downloaded from SVN as in OCS2.  The `.csv` files can be imported, though much like old program `.xml` files, we use a modified format.  To obtain compatible Smart Gcal `.csv` files from OCS2, start the ODB and use the `exportSmartGcal` shell command providing the name of a directory into which to write the files.
+
+Next, make a symlink to the directory containing the `.csv` files that were exported:
 
 ```
 ln -s /path/to/old/smart/gcal/csv smartgcal
-```
-
-If you've ever used the old OT or ODB, you will likely have downloaded the `.csv` files for Smart Gcal. For example, for the production OT you can find them in your home directory:
-
-```
-~/.ocs15/Gemini\ OT\ 2017A.1.1.2_mac/data/jsky.app.ot/smartgcal
 ```
 
 Having created the symlink, you can then import from the `sbt` prompt:

--- a/modules/core/src/main/scala/gem/config/Gmos.scala
+++ b/modules/core/src/main/scala/gem/config/Gmos.scala
@@ -6,6 +6,8 @@ package gem.config
 import gem.enum._
 import java.time.Duration
 
+import scalaz._, Scalaz._
+
 /**
  * Additional type hierarchy over the low-level GMOS enums.
  * @group Instrument-Specific Models
@@ -81,9 +83,16 @@ object Gmos {
   )
 
   /** GMOS grating central wavelength.  For now, just a value class wrapper
-    * around a BigDecimal.  This should be switched to Fixed / squants?
+    * around an integer.
+    * TODO: wavelength. This class needs to be converted to a generic Wavelength
+    * class and built out.
     */
-  final case class GmosCentralWavelength(val nm: BigDecimal) extends AnyVal
+  final case class GmosCentralWavelength(val toAngstroms: Int) extends AnyVal
+
+  object GmosCentralWavelength {
+    implicit val OrderGmosCentralWavelength: Order[GmosCentralWavelength] =
+      Order.orderBy(_.toAngstroms)
+  }
 
   /** GMOS grating configuration, parameterized on the disperser type.  These
     * are grouped because they only apply when using a grating.  That is, all

--- a/modules/core/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/config/Arbitraries.scala
@@ -159,7 +159,7 @@ trait Arbitraries {
 
   implicit val arbGmosCentralWavelength =
     Arbitrary {
-      Gen.const(Gmos.GmosCentralWavelength(0.0)) // for now ...
+      Gen.choose(3000, 12000).map(Gmos.GmosCentralWavelength(_))
     }
 
   implicit val arbGmosNorthGrating =

--- a/modules/db/src/main/scala/gem/dao/GcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GcalDao.scala
@@ -9,66 +9,109 @@ import doobie.imports._
 import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
 import gem.enum.GcalArc.{ArArc, CuArArc, ThArArc, XeArc}
 
+import scalaz._, Scalaz._
+
 import java.time.Duration
 
 object GcalDao {
+  def insertGcal(stepId: Int, gcal: GcalConfig): ConnectionIO[Int] =
+    Statements.insertGcal(stepId, gcal).withUniqueGeneratedKeys[Int]("gcal_id") // janky, hm
 
-  def insert(gcal: GcalConfig, step: Option[Int]): ConnectionIO[Int] =
-    Statements.insert(gcal, step).withUniqueGeneratedKeys[Int]("gcal_id") // janky, hm
+  def bulkInsertSmartGcal(gs: Vector[GcalConfig]): scalaz.stream.Process[ConnectionIO, Int] =
+    Statements.bulkInsertSmartGcal.updateManyWithGeneratedKeys[Int]("smart_id")(gs.map(Statements.GcalRow.fromGcalConfig))
 
-  def select(id: Int): ConnectionIO[Option[GcalConfig]] =
-    Statements.select(id).option.map(_.flatten)
+  def selectGcal(id: Int): ConnectionIO[Option[GcalConfig]] =
+    Statements.selectGcal(id).option.map(_.flatten)
+
+  def selectSmartGcal(id: Int): ConnectionIO[Option[GcalConfig]] =
+    Statements.selectSmartGcal(id).option.map(_.flatten)
 
   object Statements {
 
     // CoAdds has a DISTINCT type due to its check constraint so we need a fine-grained mapping
     // here to satisfy the query checker.
-    private final case class CoAdds(toShort: Short)
-    private object CoAdds {
-      implicit val StepIdMeta: Meta[CoAdds] =
+    final case class CoAdds(toShort: Short)
+    object CoAdds {
+      implicit val MetaCoAdds: Meta[CoAdds] =
         Distinct.short("coadds").xmap(CoAdds(_), _.toShort)
     }
 
-    def insert(gcal: GcalConfig, step: Option[Int]): Update0 = {
+    final case class GcalRow(
+      continuum:    Option[GcalContinuum],
+      ar:           Boolean,
+      cuar:         Boolean,
+      thar:         Boolean,
+      xe:           Boolean,
+      filter:       GcalFilter,
+      diffuser:     GcalDiffuser,
+      shutter:      GcalShutter,
+      exposureTime: Duration,
+      coadds:       CoAdds)
+    {
+      def toGcalConfig: Option[GcalConfig] =
+        GcalLamp.fromConfig(continuum, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe).map { lamp =>
+          GcalConfig(lamp, filter, diffuser, shutter, exposureTime, coadds.toShort)
+        }
+    }
+
+    object GcalRow {
+      def fromGcalConfig(c: GcalConfig): GcalRow = {
+        val arcs: GcalArc => Boolean =
+          c.arcs.member
+
+        GcalRow(c.continuum, arcs(ArArc), arcs(CuArArc), arcs(ThArArc), arcs(XeArc), c.filter, c.diffuser, c.shutter, c.exposureTime, CoAdds(c.coadds))
+      }
+    }
+
+    val bulkInsertSmartGcal: Update[GcalRow] = {
+      val sql =
+        """
+          INSERT INTO smartgcal (continuum,
+                                 ar_arc,
+                                 cuar_arc,
+                                 thar_arc,
+                                 xe_arc,
+                                 filter,
+                                 diffuser,
+                                 shutter,
+                                 exposure_time,
+                                 coadds)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+      Update[GcalRow](sql)
+    }
+
+    def insertGcal(stepId: Int, gcal: GcalConfig): Update0 = {
       val arcs: GcalArc => Boolean = gcal.arcs.member
       sql"""INSERT INTO gcal (step_id, continuum, ar_arc, cuar_arc, thar_arc, xe_arc, filter, diffuser, shutter, exposure_time, coadds)
-            VALUES ($step, ${gcal.continuum}, ${arcs(ArArc)}, ${arcs(CuArArc)}, ${arcs(ThArArc)}, ${arcs(XeArc)}, ${gcal.filter}, ${gcal.diffuser}, ${gcal.shutter}, ${gcal.exposureTime}, ${CoAdds(gcal.coadds)})
+            VALUES ($stepId, ${gcal.continuum}, ${arcs(ArArc)}, ${arcs(CuArArc)}, ${arcs(ThArArc)}, ${arcs(XeArc)}, ${gcal.filter}, ${gcal.diffuser}, ${gcal.shutter}, ${gcal.exposureTime}, ${CoAdds(gcal.coadds)})
          """.update
     }
 
-    def select(id: Int): Query0[Option[GcalConfig]] =
-      sql"""
-        SELECT continuum,
-               ar_arc,
-               cuar_arc,
-               thar_arc,
-               xe_arc,
-               filter,
-               diffuser,
-               shutter,
-               exposure_time,
-               coadds
-          FROM gcal
-         WHERE gcal_id =$id
-      """.query[GcalKernel].map(_.toGcalConfig)
+    private def selectFragment(table: String): Fragment =
+      Fragment.const(
+        s"""
+           SELECT continuum,
+                  ar_arc,
+                  cuar_arc,
+                  thar_arc,
+                  xe_arc,
+                  filter,
+                  diffuser,
+                  shutter,
+                  exposure_time,
+                  coadds
+             FROM $table
+         """
+      )
 
-      private final case class GcalKernel(
-        continuum: Option[GcalContinuum],
-        ar_arc:    Boolean,
-        cuar_arc:  Boolean,
-        thar_arc:  Boolean,
-        xe_arc:    Boolean,
-        filter:    GcalFilter,
-        diffuser:  GcalDiffuser,
-        shutter:   GcalShutter,
-        expTime:   Duration,
-        coadds:    Short)
-      {
-        def toGcalConfig: Option[GcalConfig] =
-          GcalLamp.fromConfig(continuum, ArArc -> ar_arc, CuArArc -> cuar_arc, ThArArc -> thar_arc, XeArc -> xe_arc).map { lamp =>
-            GcalConfig(lamp, filter, diffuser, shutter, expTime, coadds)
-          }
-      }
+    def selectGcal(id: Int): Query0[Option[GcalConfig]] =
+      (selectFragment("gcal") ++
+        fr"""WHERE gcal_id = $id""").query[GcalRow].map(_.toGcalConfig)
+
+    def selectSmartGcal(id: Int): Query0[Option[GcalConfig]] =
+      (selectFragment("smartgcal") ++
+        fr"""WHERE smart_id = $id""").query[GcalRow].map(_.toGcalConfig)
   }
 
 }

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -166,7 +166,7 @@ object SmartGcalDao {
 
     def selectF2ByLamp(k: SmartGcalKey.F2)(l: GcalLampType): Query0[Int] =
       sql"""
-          SELECT smart_id
+          SELECT gcal_id
             FROM smart_f2
            WHERE lamp      = $l :: gcal_lamp_type
              AND disperser = ${k.disperser}
@@ -176,7 +176,7 @@ object SmartGcalDao {
 
     def selectF2ByBaseline(k: SmartGcalKey.F2)(b: GcalBaselineType): Query0[Int] =
       sql"""
-          SELECT smart_id
+          SELECT gcal_id
             FROM smart_f2
            WHERE baseline  = $b :: gcal_baseline_type
              AND disperser = ${k.disperser}
@@ -194,7 +194,7 @@ object SmartGcalDao {
                                 disperser,
                                 filter,
                                 fpu,
-                                smart_id)
+                                gcal_id)
                VALUES (? :: gcal_lamp_type, ? :: gcal_baseline_type, ?, ?, ?, ?)
         """
       Update[F2Row](sql)
@@ -222,7 +222,7 @@ object SmartGcalDao {
 
     private def selectGmosNorth(k: SmartGcalKey.GmosNorthSearch, searchType: Fragment): Fragment =
       Fragment.const(
-        s"""SELECT smart_id
+        s"""SELECT gcal_id
                FROM smart_gmos_north
               WHERE """) ++ searchType ++
         fr"""
@@ -257,7 +257,7 @@ object SmartGcalDao {
                                         amp_gain,
                                         min_wavelength,
                                         max_wavelength,
-                                        smart_id)
+                                        gcal_id)
                VALUES (? :: gcal_lamp_type, ? :: gcal_baseline_type, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
       Update[GmosNorthRow](sql)

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -36,7 +36,7 @@ object StepDao {
               case Step.Dark(_)         => Statements.insertDarkSlice(id).run
               case Step.Science(_, t)   => Statements.insertScienceSlice(id, t).run
               case Step.SmartGcal(_, t) => Statements.insertSmartGcalSlice(id, t).run
-              case Step.Gcal(_, g)      => GcalDao.insert(g, Some(id)) >>= (Statements.insertGcalStep(id, _).run)
+              case Step.Gcal(_, g)      => GcalDao.insertGcal(id, g) >>= (Statements.insertGcalStep(id, _).run)
             }
       _  <- insertConfigSlice(id, s.dynamicConfig)
     } yield id
@@ -287,7 +287,7 @@ object StepDao {
     final case class GmosGratingBuilder[D](
       disperser:      Option[D],
       disperserOrder: Option[GmosDisperserOrder],
-      wavelength:     Option[BigDecimal]
+      wavelength:     Option[Int]
     ) {
       import Gmos._
 
@@ -296,7 +296,7 @@ object StepDao {
           d <- disperser
           o <- disperserOrder
           w <- wavelength
-        } yield GmosGrating(d, o, GmosCentralWavelength(w.toDouble))
+        } yield GmosGrating(d, o, GmosCentralWavelength(w))
     }
 
     final case class GmosFpuBuilder[U](
@@ -485,7 +485,7 @@ object StepDao {
           $id,
           ${g.grating.map(_.disperser)},
           ${g.grating.map(_.order)},
-          ${g.grating.map(_.wavelength.nm)},
+          ${g.grating.map(_.wavelength.toAngstroms)},
           ${g.filter},
           ${g.fpu.flatMap(_.swap.toOption.map(_.maskDefinitionFilename))},
           ${g.fpu.flatMap(_.swap.toOption.map(_.slitWidth))},
@@ -502,7 +502,7 @@ object StepDao {
           $id,
           ${g.grating.map(_.disperser)},
           ${g.grating.map(_.order)},
-          ${g.grating.map(_.wavelength.nm)},
+          ${g.grating.map(_.wavelength.toAngstroms)},
           ${g.filter},
           ${g.fpu.flatMap(_.swap.toOption.map(_.maskDefinitionFilename))},
           ${g.fpu.flatMap(_.swap.toOption.map(_.slitWidth))},

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -36,7 +36,7 @@ object StepDao {
               case Step.Dark(_)         => Statements.insertDarkSlice(id).run
               case Step.Science(_, t)   => Statements.insertScienceSlice(id, t).run
               case Step.SmartGcal(_, t) => Statements.insertSmartGcalSlice(id, t).run
-              case Step.Gcal(_, g)      => GcalDao.insertGcal(id, g) >>= (Statements.insertGcalStep(id, _).run)
+              case Step.Gcal(_, g)      => GcalDao.insertStepGcal(id, g)
             }
       _  <- insertConfigSlice(id, s.dynamicConfig)
     } yield id
@@ -401,10 +401,8 @@ object StepDao {
                sc.offset_q,
                ss.type
           FROM step s
-               LEFT OUTER JOIN step_gcal sg
-                  ON sg.step_gcal_id       = s.step_id
-               LEFT OUTER JOIN gcal gc
-                  ON gc.gcal_id            = sg.gcal_id
+               LEFT OUTER JOIN step_gcal gc
+                  ON gc.step_gcal_id       = s.step_id
                LEFT OUTER JOIN step_science sc
                   ON sc.step_science_id    = s.step_id
                LEFT OUTER JOIN step_smart_gcal ss
@@ -430,10 +428,8 @@ object StepDao {
                sc.offset_q,
                ss.type
           FROM step s
-               LEFT OUTER JOIN step_gcal sg
-                  ON sg.step_gcal_id       = s.step_id
-               LEFT OUTER JOIN gcal gc
-                  ON gc.gcal_id            = sg.gcal_id
+               LEFT OUTER JOIN step_gcal gc
+                  ON gc.step_gcal_id       = s.step_id
                LEFT OUTER JOIN step_science sc
                   ON sc.step_science_id    = s.step_id
                LEFT OUTER JOIN step_smart_gcal ss
@@ -519,12 +515,6 @@ object StepDao {
       sql"""
         INSERT INTO step_smart_gcal (step_smart_gcal_id, type)
         VALUES ($id, $t :: smart_gcal_type)
-      """.update
-
-    def insertGcalStep(id: Int, gcal_id: Int): Update0 =
-      sql"""
-        INSERT into step_gcal (step_gcal_id, gcal_id)
-        VALUES ($id, $gcal_id)
       """.update
 
     def insertDarkSlice(id: Int): Update0 =

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -3,48 +3,47 @@
 
 package gem.dao
 
+import gem.arb.ArbEnumerated._
 import gem.config.GcalConfig
-import gem.config.DynamicConfig.SmartGcalKey
-import gem.enum.{F2Disperser, F2Filter, F2FpUnit, SmartGcalType}
+import gem.config.DynamicConfig
+import gem.config.DynamicConfig.SmartGcalSearchKey
+import gem.enum.SmartGcalType
 
 import doobie.imports._
 
-import scala.util.Random
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
+
 import scalaz._, Scalaz._
 
 // Sample code that exercises SmartGcalDao.select.
-object SmartGcalSample extends TimedSample {
+object SmartGcalSample extends TimedSample with gem.config.Arbitraries {
 
-  type Result = List[(SmartGcalKey, SmartGcalType, List[GcalConfig])]
+  type Result = List[(SmartGcalSearchKey, SmartGcalType, List[GcalConfig])]
 
-  val allF2: Vector[SmartGcalKey] =
-    (for {
-      d <- F2Disperser.all
-      f <- F2Filter.all
-      u <- F2FpUnit.all
-    } yield SmartGcalKey.F2(d, f, u)).toVector
+  private def nextType(): Option[SmartGcalType] =
+    arbitrary[SmartGcalType].sample
 
-  val rand: Random = new Random(0)
+  private def nextDynamicConfig(): Option[DynamicConfig] =
+    Gen.oneOf(
+      arbitrary[DynamicConfig.F2       ],
+      arbitrary[DynamicConfig.GmosNorth]
+    ).sample
 
-  def nextType(): SmartGcalType =
-    SmartGcalType.all(rand.nextInt(4))
+  private def nextKey(): Option[SmartGcalSearchKey] =
+    nextDynamicConfig.flatMap(_.smartGcalKey)
 
-  def nextKey(): SmartGcalKey =
-    allF2(rand.nextInt(allF2.size))
+  private def nextTest(): Option[(SmartGcalSearchKey, SmartGcalType)] =
+    for {
+      k <- nextKey()
+      t <- nextType()
+    } yield (k, t)
 
   override def runl(args: List[String]): ConnectionIO[Result] =
-    ((1 to 1000).toList.map(_ => (nextKey, nextType))).traverseU { case (k, t) =>
+    ((1 to 1000).toList.as(nextTest().toList).flatten).traverseU { case (k, t) =>
       SmartGcalDao.select(k, t).map { g => (k, t, g) }
     }
 
   override def format(r: Result): String =
     r.mkString(", \n")
-
-  //
-  // A bit less than 1.6 seconds ...  adding indices doesn't seem to make a
-  // difference:
-  //
-  //    "smart_f2_baseline_disperser_filter_fpu_idx" btree (baseline, disperser, filter, fpu)
-  //    "smart_f2_lamp_disperser_filter_fpu_idx" btree (lamp, disperser, filter, fpu)
-  //
 }

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -7,6 +7,7 @@ package check
 import gem._
 import gem.enum._
 import gem.config._
+import gem.config.DynamicConfig.SmartGcalKey
 import gem.math.Offset
 
 import doobie.imports._
@@ -52,16 +53,26 @@ trait Check extends FlatSpec with Matchers with IOLiteChecker {
     val user             = User[Nothing]("", "", "", "", false, Map.empty)
     val observation      = Observation[StaticConfig, Nothing](observationId, "", StaticConfig.F2.Default, Nil)
     val program          = Program(programId, "", Nil)
-    val f2SmartGcalKey   = DynamicConfig.SmartGcalKey.F2(F2Disperser.NoDisperser, F2Filter.Dark, F2FpUnit.LongSlit1)
+    val f2SmartGcalKey   = DynamicConfig.F2.Default.key
     val gcalLampType     = GcalLampType.Arc
     val gcalBaselineType = GcalBaselineType.Day
     val locationMiddle   = Location.unsafeMiddle(1)
-    val f2Config         = DynamicConfig.F2(F2Disperser.NoDisperser, duration, F2Filter.Dark, F2FpUnit.LongSlit1,
-      F2LyotWheel.F16, F2ReadMode.Bright, F2WindowCover.Close)
+    val f2Config         = DynamicConfig.F2.Default
     val telescopeConfig  = TelescopeConfig(Offset.P.Zero, Offset.Q.Zero)
     val smartGcalType    = SmartGcalType.Arc
     val instrumentConfig = f2Config
     val stepType         = StepType.Science
+
+    val gmosNorthSmartGcalSearchKey     =
+      DynamicConfig.GmosNorth.Default.key
+
+    val gmosNorthSmartGcalDefinitionKey = {
+      val sk = DynamicConfig.GmosNorth.Default.key
+      SmartGcalKey.GmosNorthDefinition(
+        sk.gmos,
+        (Gmos.GmosCentralWavelength(0), Gmos.GmosCentralWavelength(1))
+      )
+    }
   }
 
 

--- a/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
@@ -7,6 +7,8 @@ package check
 class GcalCheck extends Check {
   import GcalDao.Statements._
   "GcalDao.Statements" should
-            "insert" in check(insert(Dummy.gcalConfig, None))
-  it should "select" in check(select(0))
+            "insertGcal"          in check(insertGcal(0, Dummy.gcalConfig))
+  it should "selectGcal"          in check(selectGcal(0))
+  it should "selectSmartGcal"     in check(selectSmartGcal(0))
+  it should "bulkInsertSmartGcal" in check(bulkInsertSmartGcal)
 }

--- a/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
@@ -7,8 +7,8 @@ package check
 class GcalCheck extends Check {
   import GcalDao.Statements._
   "GcalDao.Statements" should
-            "insertGcal"          in check(insertGcal(0, Dummy.gcalConfig))
-  it should "selectGcal"          in check(selectGcal(0))
+            "insertStepGcal"      in check(insertStepGcal(0, Dummy.gcalConfig))
+  it should "selectStepGcal"      in check(selectStepGcal(0))
   it should "selectSmartGcal"     in check(selectSmartGcal(0))
   it should "bulkInsertSmartGcal" in check(bulkInsertSmartGcal)
 }

--- a/modules/db/src/test/scala/gem/dao/check/SmartGcalCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/SmartGcalCheck.scala
@@ -7,7 +7,13 @@ package check
 class SmartGcalCheck extends Check {
   import SmartGcalDao.Statements._
   "SmartGcalDao.Statements" should
-            "selectF2byLamp"     in check(selectF2byLamp(Dummy.f2SmartGcalKey)(Dummy.gcalLampType))
-  it should "selectF2byBaseline" in check(selectF2byBaseline(Dummy.f2SmartGcalKey)(Dummy.gcalBaselineType))
-  it should "insertSmartF2"      in check(insertSmartF2(Dummy.gcalLampType, Dummy.gcalBaselineType, 0, Dummy.f2SmartGcalKey))
+            "selectF2byLamp"            in check(selectF2ByLamp(Dummy.f2SmartGcalKey)(Dummy.gcalLampType))
+  it should "selectF2byBaseline"        in check(selectF2ByBaseline(Dummy.f2SmartGcalKey)(Dummy.gcalBaselineType))
+  it should "createIndexF2"             in check(createIndexF2)
+  it should "dropIndexF2"               in check(dropIndexF2)
+  it should "selectGmosNorthByLamp"     in check(selectGmosNorthByLamp(Dummy.gmosNorthSmartGcalSearchKey)(Dummy.gcalLampType))
+  it should "selectGmosNorthByBaseline" in check(selectGmosNorthByBaseline(Dummy.gmosNorthSmartGcalSearchKey)(Dummy.gcalBaselineType))
+  it should "bulkInsertGmosNorth"       in check(bulkInsertGmosNorth)
+  it should "createIndexGmosNorth"      in check(createIndexGmosNorth)
+  it should "dropIndexGmosNorth"        in check(dropIndexGmosNorth)
 }

--- a/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
@@ -22,7 +22,6 @@ class StepCheck extends Check {
   it should "insertGmosSouthConfig" in check(insertGmosSouthConfig(0, gem.config.DynamicConfig.GmosSouth.Default))
   it should "insertScienceSlice"    in check(insertScienceSlice(0, Dummy.telescopeConfig))
   it should "insertSmartGcalSlice"  in check(insertSmartGcalSlice(0, Dummy.smartGcalType))
-  it should "insertGcalStep"        in check(insertGcalStep(0, 0))
   it should "insertDarkSlice"       in check(insertDarkSlice(0))
   it should "insertBiasSlice"       in check(insertBiasSlice(0))
   it should "insertBaseSlice"       in check(insertBaseSlice(Dummy.observationId, Dummy.locationMiddle, Dummy.instrumentConfig, Dummy.stepType))

--- a/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
@@ -19,7 +19,7 @@ import Scalaz._
 object Legacy {
   sealed abstract class System(val system: String) {
 
-    final class Key[A](val name: String, val p: PioParse[A])(implicit ev: TypeTag[A]) {
+    final class Key[A](val name: String, val parseString: PioParse[A])(implicit ev: TypeTag[A]) {
 
       val path: String = s"$system:$name"
 
@@ -30,7 +30,7 @@ object Legacy {
         cm.lookup(path) \/> missingKey(name)
 
       def parse(cm: ConfigMap): PioError \/ A =
-        rawValue(cm).flatMap { s => p(s) \/> parseError(s, tpe) }
+        rawValue(cm).flatMap { s => parseString(s) \/> parseError(s, tpe) }
 
       def cparse(cm: ConfigMap): PioError \/ Option[A] =
         parse(cm) match {
@@ -80,51 +80,56 @@ object Legacy {
     val MosPreImaging = Key("mosPreimaging")(Parsers.mosPreImaging)
 
     object Flamingos2 {
-      val Disperser   = Key("disperser"  )(Parsers.Flamingos2.disperser  )
-      val Filter      = Key("filter"     )(Parsers.Flamingos2.filter     )
-      val Fpu         = Key("fpu"        )(Parsers.Flamingos2.fpu        )
-      val LyotWheel   = Key("lyotWheel"  )(Parsers.Flamingos2.lyotWheel  )
-      val ReadMode    = Key("readMode"   )(Parsers.Flamingos2.readMode   )
-      val WindowCover = Key("windowCover")(Parsers.Flamingos2.windowCover)
+      import Parsers.Flamingos2._
+      val Disperser   = Key("disperser"  )(disperser  )
+      val Filter      = Key("filter"     )(filter     )
+      val Fpu         = Key("fpu"        )(fpu        )
+      val LyotWheel   = Key("lyotWheel"  )(lyotWheel  )
+      val ReadMode    = Key("readMode"   )(readMode   )
+      val WindowCover = Key("windowCover")(windowCover)
     }
 
     object Gmos {
-      val Adc             = Key("adc"                 )(Parsers.Gmos.adc            )
-      val AmpCount        = Key("ampCount"            )(Parsers.Gmos.ampCount       )
-      val AmpGain         = Key("gainChoice"          )(Parsers.Gmos.ampGain        )
-      val AmpReadMode     = Key("ampReadMode"         )(Parsers.Gmos.ampReadMode    )
-      val BuiltinRoi      = Key("builtinROI"          )(Parsers.Gmos.builtinRoi     )
-      val CustomMaskMdf   = Key("fpuCustomMask"       )(PioParse.string             )
-      val CustomSlitWidth = Key("customSlitWidth"     )(Parsers.Gmos.customSlitWidth)
-      val Detector        = Key("detectorManufacturer")(Parsers.Gmos.detector       )
-      val DisperserOrder  = Key("disperserOrder"      )(Parsers.Gmos.disperserOrder )
-      val DisperserLambda = Key("disperserLambda"     )(Parsers.Gmos.disperserLambda)
-      val Dtax            = Key("dtaXOffset"          )(Parsers.Gmos.dtax           )
-      val XBinning        = Key("ccdXBinning"         )(Parsers.Gmos.xBinning       )
-      val YBinning        = Key("ccdYBinning"         )(Parsers.Gmos.yBinning       )
+      import Parsers.Gmos._
+      val Adc             = Key("adc"                 )(adc            )
+      val AmpCount        = Key("ampCount"            )(ampCount       )
+      val AmpGain         = Key("gainChoice"          )(ampGain        )
+      val AmpReadMode     = Key("ampReadMode"         )(ampReadMode    )
+      val BuiltinRoi      = Key("builtinROI"          )(builtinRoi     )
+      val CustomMaskMdf   = Key("fpuCustomMask"       )(PioParse.string)
+      val CustomSlitWidth = Key("customSlitWidth"     )(customSlitWidth)
+      val Detector        = Key("detectorManufacturer")(detector       )
+      val DisperserOrder  = Key("disperserOrder"      )(disperserOrder )
+      val DisperserLambda = Key("disperserLambda"     )(disperserLambda)
+      val Dtax            = Key("dtaXOffset"          )(dtax           )
+      val XBinning        = Key("ccdXBinning"         )(xBinning       )
+      val YBinning        = Key("ccdYBinning"         )(yBinning       )
     }
 
     object GmosNorth {
-      val Disperser       = Key("disperser")(Parsers.GmosNorth.disperser )
-      val Filter          = Key("filter"   )(Parsers.GmosNorth.filter    )
-      val Fpu             = Key("fpu"      )(Parsers.GmosNorth.fpu       )
-      val StageMode       = Key("stageMode")(Parsers.GmosNorth.stageMode )
+      import Parsers.GmosNorth._
+      val Disperser       = Key("disperser")(disperser)
+      val Filter          = Key("filter"   )(filter   )
+      val Fpu             = Key("fpu"      )(fpu      )
+      val StageMode       = Key("stageMode")(stageMode)
     }
 
     object GmosSouth {
-      val Disperser       = Key("disperser")(Parsers.GmosSouth.disperser )
-      val Filter          = Key("filter"   )(Parsers.GmosSouth.filter    )
-      val Fpu             = Key("fpu"      )(Parsers.GmosSouth.fpu       )
-      val StageMode       = Key("stageMode")(Parsers.GmosSouth.stageMode )
+      import Parsers.GmosSouth._
+      val Disperser       = Key("disperser")(disperser)
+      val Filter          = Key("filter"   )(filter   )
+      val Fpu             = Key("fpu"      )(fpu      )
+      val StageMode       = Key("stageMode")(stageMode)
     }
   }
 
   object Calibration extends System("calibration") {
-    val Lamp         = Key("lamp"        )(Parsers.Calibration.lamp    )
-    val Filter       = Key("filter"      )(Parsers.Calibration.filter  )
-    val Diffuser     = Key("diffuser"    )(Parsers.Calibration.diffuser)
-    val Shutter      = Key("shutter"     )(Parsers.Calibration.shutter )
-    val ExposureTime = Key("exposureTime")(PioParse.seconds            )
-    val Coadds       = Key("coadds"      )(PioParse.int                )
+    import Parsers.Calibration._
+    val Lamp         = Key("lamp"        )(lamp            )
+    val Filter       = Key("filter"      )(filter          )
+    val Diffuser     = Key("diffuser"    )(diffuser        )
+    val Shutter      = Key("shutter"     )(shutter         )
+    val ExposureTime = Key("exposureTime")(PioParse.seconds)
+    val Coadds       = Key("coadds"      )(PioParse.int    )
   }
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -121,81 +121,61 @@ object Parsers {
       "Closed" -> GcalShutter.Closed,
       "Open"   -> GcalShutter.Open
     )
+
+    val baseline: PioParse[GcalBaselineType] = enum(
+      "DAY"   -> GcalBaselineType.Day,
+      "NIGHT" -> GcalBaselineType.Night
+    )
   }
-
-  private def fstParser[A](table: List[(String, String, A)]): PioParse[A] =
-    enum(table.map { case (a, _, b) => (a, b) }:_*)
-
-  private def sndParser[A](table: List[(String, String, A)]): PioParse[A] =
-    enum(table.map { case (_, a, b) => (a, b) }:_*)
 
   object Flamingos2 {
 
     import F2Disperser._
 
-    val disperserTable: List[(String, String, F2Disperser)] =
-      List(
-        ("NONE",    "None",                       NoDisperser),
-        ("R1200HK", "R=1200 (H + K) grism",       R1200HK    ),
-        ("R1200JH", "R=1200 (J + H) grism",       R1200JH    ),
-        ("R3000",   "R=3000 (J or H or K) grism", R3000      )
-      )
+    val disperser: PioParse[F2Disperser] = enum(
+      "NONE"    -> NoDisperser,
+      "R1200HK" -> R1200HK,
+      "R1200JH" -> R1200JH,
+      "R3000"   -> R3000
+    )
 
-    val disperser: PioParse[F2Disperser] =
-      fstParser(disperserTable)
-
-    val disperserDisplayValue: PioParse[F2Disperser] =
-      sndParser(disperserTable)
 
     import F2Filter._
 
-    val filterTable: List[(String, String, F2Filter)] =
-      List(
-        ("OPEN",    "Open",               Open  ),
-        ("DARK",    "Dark",               Dark  ),
-        ("F1056",   "F1056 (1.056 um)",   F1056 ),
-        ("F1063",   "F1063 (1.063 um)",   F1063 ),
-        ("H",       "H (1.65 um)",        H     ),
-        ("HK",      "HK (spectroscopic)", HK    ),
-        ("J",       "J (1.25 um)",        J     ),
-        ("J_LOW",   "J-low (1.15 um)",    JLow  ),
-        ("JH",      "JH (spectroscopic)", JH    ),
-        ("K_LONG",  "K-long (2.20 um)",   KLong ),
-        ("K_SHORT", "K-short (2.15 um)",  KShort),
-        ("K_BLUE",  "K-blue (2.06 um)",   KBlue ),
-        ("K_RED",   "K-red (2.31 um)",    KRed  ),
-        ("Y",       "Y (1.02 um)",        Y     )
-      )
-
-    val filter: PioParse[F2Filter] =
-      fstParser(filterTable)
-
-    val filterDisplayValue: PioParse[F2Filter] =
-      sndParser(filterTable)
+    val filter: PioParse[F2Filter] = enum(
+      "OPEN"    -> Open,
+      "DARK"    -> Dark,
+      "F1056"   -> F1056,
+      "F1063"   -> F1063,
+      "H"       -> H,
+      "HK"      -> HK,
+      "J"       -> J,
+      "J_LOW"   -> JLow,
+      "JH"      -> JH,
+      "K_LONG"  -> KLong,
+      "K_SHORT" -> KShort,
+      "K_BLUE"  -> KBlue,
+      "K_RED"   -> KRed,
+      "Y"       -> Y
+    )
 
     import F2FpUnit._
 
-    val fpuTable: List[(String, String, F2FpUnit)] =
-      List(
-        ("PINHOLE",        "2-pix pinhole grid",  Pinhole      ),
-        ("SUBPIX_PINHOLE", "subpix pinhole grid", SubPixPinhole),
-        ("FPU_NONE",       "Imaging (none)",      None         ),
-        ("CUSTOM_MASK",    "Custom Mask",         Custom       ),
-        ("LONGSLIT_1",     "1-pix longslit",      LongSlit1    ),
-        ("LONGSLIT_2",     "2-pix longslit",      LongSlit2    ),
-        ("LONGSLIT_3",     "3-pix longslit",      LongSlit3    ),
-        ("LONGSLIT_4",     "4-pix longslit",      LongSlit4    ),
-        ("LONGSLIT_6",     "6-pix longslit",      LongSlit6    ),
-        ("LONGSLIT_8",     "8-pix longslit",      LongSlit8    )
-      )
-
-    val fpu: PioParse[F2FpUnit] =
-      fstParser(fpuTable)
-
-    val fpuDisplayValue: PioParse[F2FpUnit] =
-      sndParser(fpuTable)
+    val fpu: PioParse[F2FpUnit] = enum(
+      "PINHOLE"         -> Pinhole,
+      "SUBPIX_PINHOLE"  -> SubPixPinhole,
+      "FPU_NONE"        -> None,
+      "CUSTOM_MASK"     -> Custom,
+      "LONGSLIT_1"      -> LongSlit1,
+      "LONGSLIT_2"      -> LongSlit2,
+      "LONGSLIT_3"      -> LongSlit3,
+      "LONGSLIT_4"      -> LongSlit4,
+      "LONGSLIT_6"      -> LongSlit6,
+      "LONGSLIT_8"      -> LongSlit8
+    )
 
     import F2LyotWheel._
+
     val lyotWheel: PioParse[F2LyotWheel] = enum(
       "GEMS"       -> F33Gems,
       "GEMS_OVER"  -> GemsUnder,
@@ -230,7 +210,6 @@ object Parsers {
       "Follow During Exposure" -> Some(Follow)
     )
 
-
     import GmosAmpCount._
 
     val ampCount: PioParse[GmosAmpCount] = enum(
@@ -239,7 +218,6 @@ object Parsers {
       "Twelve" -> Twelve
     )
 
-
     import GmosAmpGain._
 
     val ampGain: PioParse[GmosAmpGain] = enum(
@@ -247,14 +225,12 @@ object Parsers {
       "High" -> High
     )
 
-
     import GmosAmpReadMode._
 
     val ampReadMode: PioParse[GmosAmpReadMode] = enum(
       "Slow" -> Slow,
       "Fast" -> Fast
     )
-
 
     import GmosBuiltinRoi._
 
@@ -267,7 +243,6 @@ object Parsers {
       "Top Spectrum"       -> Some(TopSpectrum    ),
       "Bottom Spectrum"    -> Some(BottomSpectrum )
     )
-
 
     import GmosCustomSlitWidth._
 
@@ -282,7 +257,6 @@ object Parsers {
       "CUSTOM_WIDTH_5_00" -> Some(CustomWidth_5_00)
     )
 
-
     import GmosDetector._
 
     val detector: PioParse[GmosDetector] = enum(
@@ -290,17 +264,15 @@ object Parsers {
       "HAMAMATSU" -> HAMAMATSU
     )
 
-
     val disperserOrder: PioParse[GmosDisperserOrder] = enum(
       "0" -> GmosDisperserOrder.Zero,
       "1" -> GmosDisperserOrder.One,
       "2" -> GmosDisperserOrder.Two
     )
 
-
-    val disperserLambda: PioParse[BigDecimal] =
-      bigDecimal
-
+    // TODO: wavelength - parse into generic Wavelength type directly
+    val disperserLambda: PioParse[Int] =
+      double.map(d => (d * 10.0).round.toInt)
 
     val dtax: PioParse[GmosDtax] = enum(
       "-6" -> GmosDtax.MinusSix,
@@ -318,13 +290,11 @@ object Parsers {
       "6"  -> GmosDtax.Six
     )
 
-
     val xBinning: PioParse[GmosXBinning] = enum(
       "1" -> GmosXBinning.One,
       "2" -> GmosXBinning.Two,
       "4" -> GmosXBinning.Four
     )
-
 
     val yBinning: PioParse[GmosYBinning] = enum(
       "1" -> GmosYBinning.One,
@@ -380,7 +350,6 @@ object Parsers {
       "u_G0308"                   -> Some(UPrime)
     )
 
-
     import GmosNorthFpu._
 
     val fpu: PioParse[Option[GmosNorthFpu]] = enum(
@@ -403,7 +372,6 @@ object Parsers {
       "N and S 2.00 arcsec"  -> Some(Ns5),
       "Custom Mask"          -> Option.empty[GmosNorthFpu]
     )
-
 
     import GmosNorthStageMode._
 
@@ -462,7 +430,6 @@ object Parsers {
       "Lya395_G0342"              -> Some(Lya395)
     )
 
-
     import GmosSouthFpu._
 
     val fpu: PioParse[Option[GmosSouthFpu]] = enum(
@@ -488,7 +455,6 @@ object Parsers {
       "N and S 2.00 arcsec"          -> Some(Ns5),
       "Custom Mask"                  -> Option.empty[GmosSouthFpu]
     )
-
 
     import GmosSouthStageMode._
 

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -29,7 +29,7 @@ object Parsers {
   )
 
   val arcsec: PioParse[Angle] =
-    double.map(d => Angle.fromDoubleDegrees(d * 60 * 60))
+    double.map(Angle.fromDoubleArcseconds)
 
   val instrument: PioParse[Instrument] = enum(
     "AcqCam"     -> gem.enum.Instrument.AcqCam,

--- a/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
@@ -84,7 +84,7 @@ object SequenceDecoder extends PioDecoder[List[Step[DynamicConfig]]] {
       (for {
         d <- PioOptional(Disperser.parse(cm))
         o <- PioOptional(DisperserOrder.cparse(cm))
-        w <- PioOptional(DisperserLambda.cparse(cm)).map(Gmos.GmosCentralWavelength)
+        w <- PioOptional(DisperserLambda.cparse(cm)).map(Gmos.GmosCentralWavelength(_))
       } yield Gmos.GmosGrating(d, o, w)).run
 
     for {
@@ -105,7 +105,7 @@ object SequenceDecoder extends PioDecoder[List[Step[DynamicConfig]]] {
       (for {
         d <- PioOptional(Disperser.parse(cm))
         o <- PioOptional(DisperserOrder.cparse(cm))
-        w <- PioOptional(DisperserLambda.cparse(cm)).map(Gmos.GmosCentralWavelength)
+        w <- PioOptional(DisperserLambda.cparse(cm)).map(Gmos.GmosCentralWavelength(_))
       } yield Gmos.GmosGrating(d, o, w)).run
 
     for {

--- a/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
@@ -167,7 +167,7 @@ object SmartGcalImporter extends TaskApp with DoobieClient {
       .flatMap { v => writer(v).void.transact(lxa) }
 
     for {
-      _ <- Task.delay(println(s"Importing $instFilePrefix ..."))
+      _ <- Task.delay(println(s"Importing $instFilePrefix ...")) // scalastyle:ignore
       _ <- unindexer.transact(lxa)
       _ <- prog.run
       _ <- indexer.transact(lxa)
@@ -183,6 +183,6 @@ object SmartGcalImporter extends TaskApp with DoobieClient {
       _ <- clean.transact(lxa)
       _ <- importAllInst
       _ <- l.shutdown(5 * 1000)
-      _ <- Task.delay(println("Done."))
+      _ <- Task.delay(println("Done.")) // scalastyle:ignore
     } yield ()
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
@@ -118,7 +118,7 @@ object SmartGcalImporter extends TaskApp with DoobieClient {
 
   /** Truncates all the smart gcal tables. */
   val clean: ConnectionIO[Unit] =
-    sql"TRUNCATE smartgcal CASCADE".update.run.void
+    sql"TRUNCATE gcal CASCADE".update.run.void
 
   def parseMaxWavelength(s: String): Int =
     s match {

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioParse.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioParse.scala
@@ -34,6 +34,9 @@ object PioParse {
   val double: PioParse[Double] =
     PioParse(_.parseDouble.toOption)
 
+  val short: PioParse[Short] =
+    PioParse(_.parseShort.toOption)
+
   val int: PioParse[Int] =
     PioParse(_.parseInt.toOption)
 

--- a/modules/sql/src/main/resources/db/migration/V016__Add_Gmos_SmartGcal.sql
+++ b/modules/sql/src/main/resources/db/migration/V016__Add_Gmos_SmartGcal.sql
@@ -1,0 +1,30 @@
+--
+-- Smart Gcal Tables for GMOS
+--
+
+CREATE TABLE smart_gmos_north (
+  lamp           gcal_lamp_type     NOT NULL,
+  baseline       gcal_baseline_type NOT NULL,
+  disperser      identifier                  REFERENCES e_gmos_north_disperser ON DELETE CASCADE,
+  filter         identifier                  REFERENCES e_gmos_north_filter    ON DELETE CASCADE,
+  fpu            identifier                  REFERENCES e_gmos_north_fpu       ON DELETE CASCADE,
+  x_binning      identifier         NOT NULL REFERENCES e_gmos_binning         ON DELETE CASCADE,
+  y_binning      identifier         NOT NULL REFERENCES e_gmos_binning         ON DELETE CASCADE,
+  min_wavelength int                NOT NULL CHECK (min_wavelength >= 0),
+  max_wavelength int                NOT NULL CHECK (max_wavelength >= 0),
+  amp_gain       identifier         NOT NULL REFERENCES e_gmos_amp_gain        ON DELETE CASCADE,
+  gcal_id        integer            NOT NULL REFERENCES gcal                   ON DELETE CASCADE,
+  CHECK (min_wavelength <= max_wavelength)
+);
+
+ALTER TABLE smart_gmos_north OWNER TO postgres;
+
+--
+-- Store wavelength in integer angstroms instead of double nm
+--
+
+ALTER TABLE step_gmos_north
+  ALTER COLUMN wavelength SET DATA TYPE integer USING round(wavelength * 10.0);
+
+ALTER TABLE step_gmos_south
+  ALTER COLUMN wavelength SET DATA TYPE integer USING round(wavelength * 10.0);

--- a/modules/sql/src/main/resources/db/migration/V017__Split_gcal_Table.sql
+++ b/modules/sql/src/main/resources/db/migration/V017__Split_gcal_Table.sql
@@ -1,75 +1,25 @@
--- 
--- Copies the gcal table to smartgcal.  gcal will be used with gcal steps,
--- smartgcal with lookups.
+--
+-- Currently the gcal table is used to store both manual gcal step
+-- configurations and smart gcal mappings.  In this migration we will update
+-- the step_gcal table to include all the gcal config columns instead of having
+-- a foreign key into gcal.  Then we will drop the step_id column from gcal. At
+-- that point, step_gcal will directly house gcal configurations for manual
+-- gcal steps while the gcal table only holds smart gcal values.
 --
 
--- First create the new smartgcal table matching the existing gcal table.
-CREATE TABLE smartgcal
-       (LIKE gcal INCLUDING ALL);
+ALTER TABLE step_gcal
+       DROP COLUMN     gcal_id,
+        ADD COLUMN     continuum     identifier                         REFERENCES e_gcal_continuum ON DELETE CASCADE,
+        ADD COLUMN     ar_arc        boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     cuar_arc      boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     thar_arc      boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     xe_arc        boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     filter        identifier NOT NULL                REFERENCES e_gcal_filter    ON DELETE CASCADE,
+        ADD COLUMN     diffuser      identifier NOT NULL                REFERENCES e_gcal_diffuser  ON DELETE CASCADE,
+        ADD COLUMN     shutter       identifier NOT NULL                REFERENCES e_gcal_shutter   ON DELETE CASCADE,
+        ADD COLUMN     exposure_time bigint     NOT NULL,
+        ADD COLUMN     coadds        coadds     NOT NULL,
+        ADD CONSTRAINT check_lamp CHECK ((continuum IS NULL) = (ar_arc OR cuar_arc OR thar_arc OR xe_arc));
 
--- For some reason the foreign key constraints aren't copied over, so do it
--- now.
-ALTER TABLE smartgcal
-        ADD CONSTRAINT gcal_continuum_fkey FOREIGN KEY (continuum) REFERENCES e_gcal_continuum ON DELETE CASCADE;
-
-ALTER TABLE smartgcal
-        ADD CONSTRAINT gcal_diffuser_fkey FOREIGN KEY (diffuser) REFERENCES e_gcal_diffuser ON DELETE CASCADE;
-
-ALTER TABLE smartgcal
-        ADD CONSTRAINT gcal_filter_fkey FOREIGN KEY (filter) REFERENCES e_gcal_filter ON DELETE CASCADE;
-
-ALTER TABLE smartgcal
-        ADD CONSTRAINT gcal_shutter_fkey FOREIGN KEY (shutter) REFERENCES e_gcal_shutter ON DELETE CASCADE;
-	
--- Copy over the smartgcal data that we imported earlier.
-INSERT INTO smartgcal
-     SELECT * FROM gcal;
-
--- Rename the primary key to smart_id.
-ALTER TABLE smartgcal
-     RENAME gcal_id TO smart_id;
-
--- The smartgcal table doesn't associate gcal configs with steps, so drop
--- the step_id column.
-ALTER TABLE smartgcal
+ALTER TABLE gcal
        DROP step_id;
-
--- Add a smart_id column to smart_f2 and smart_gmos_north
-ALTER TABLE smart_f2
-        ADD COLUMN smart_id integer;
-
-ALTER TABLE smart_gmos_north
-        ADD COLUMN smart_id integer;
-
--- Copy the gcal_id over to smart_id in smart_f2, since we have data for it.
-UPDATE smart_f2 
-   SET smart_id = gcal_id;
-
--- Drop the gcal_id from smart_f2 and smart_gmos_north since it will not
--- be used.
-ALTER TABLE smart_f2
-       DROP gcal_id;
-
-ALTER TABLE smart_gmos_north
-       DROP gcal_id;
-
--- Make smart_id a foreign key into smartgcal.
-ALTER TABLE smart_f2
-      ALTER smart_id SET NOT NULL;
-
-ALTER TABLE smart_gmos_north
-      ALTER smart_id SET NOT NULL;
-
-ALTER TABLE smart_f2
-        ADD CONSTRAINT smart_f2_smart_id_fkey FOREIGN KEY (smart_id) REFERENCES smartgcal ON DELETE CASCADE;
-
-ALTER TABLE smart_gmos_north
-        ADD CONSTRAINT smart_gmos_north_smart_id_fkey FOREIGN KEY (smart_id) REFERENCES smartgcal ON DELETE CASCADE;
-
--- Remove all the smartgcal data from gcal, since we've copied it over.
-TRUNCATE TABLE gcal CASCADE;
-
--- The step_id is no longer optional in the original gcal table.
-ALTER TABLE gcal 
-      ALTER step_id SET NOT NULL;
-

--- a/modules/sql/src/main/resources/db/migration/V017__Split_gcal_Table.sql
+++ b/modules/sql/src/main/resources/db/migration/V017__Split_gcal_Table.sql
@@ -1,0 +1,75 @@
+-- 
+-- Copies the gcal table to smartgcal.  gcal will be used with gcal steps,
+-- smartgcal with lookups.
+--
+
+-- First create the new smartgcal table matching the existing gcal table.
+CREATE TABLE smartgcal
+       (LIKE gcal INCLUDING ALL);
+
+-- For some reason the foreign key constraints aren't copied over, so do it
+-- now.
+ALTER TABLE smartgcal
+        ADD CONSTRAINT gcal_continuum_fkey FOREIGN KEY (continuum) REFERENCES e_gcal_continuum ON DELETE CASCADE;
+
+ALTER TABLE smartgcal
+        ADD CONSTRAINT gcal_diffuser_fkey FOREIGN KEY (diffuser) REFERENCES e_gcal_diffuser ON DELETE CASCADE;
+
+ALTER TABLE smartgcal
+        ADD CONSTRAINT gcal_filter_fkey FOREIGN KEY (filter) REFERENCES e_gcal_filter ON DELETE CASCADE;
+
+ALTER TABLE smartgcal
+        ADD CONSTRAINT gcal_shutter_fkey FOREIGN KEY (shutter) REFERENCES e_gcal_shutter ON DELETE CASCADE;
+	
+-- Copy over the smartgcal data that we imported earlier.
+INSERT INTO smartgcal
+     SELECT * FROM gcal;
+
+-- Rename the primary key to smart_id.
+ALTER TABLE smartgcal
+     RENAME gcal_id TO smart_id;
+
+-- The smartgcal table doesn't associate gcal configs with steps, so drop
+-- the step_id column.
+ALTER TABLE smartgcal
+       DROP step_id;
+
+-- Add a smart_id column to smart_f2 and smart_gmos_north
+ALTER TABLE smart_f2
+        ADD COLUMN smart_id integer;
+
+ALTER TABLE smart_gmos_north
+        ADD COLUMN smart_id integer;
+
+-- Copy the gcal_id over to smart_id in smart_f2, since we have data for it.
+UPDATE smart_f2 
+   SET smart_id = gcal_id;
+
+-- Drop the gcal_id from smart_f2 and smart_gmos_north since it will not
+-- be used.
+ALTER TABLE smart_f2
+       DROP gcal_id;
+
+ALTER TABLE smart_gmos_north
+       DROP gcal_id;
+
+-- Make smart_id a foreign key into smartgcal.
+ALTER TABLE smart_f2
+      ALTER smart_id SET NOT NULL;
+
+ALTER TABLE smart_gmos_north
+      ALTER smart_id SET NOT NULL;
+
+ALTER TABLE smart_f2
+        ADD CONSTRAINT smart_f2_smart_id_fkey FOREIGN KEY (smart_id) REFERENCES smartgcal ON DELETE CASCADE;
+
+ALTER TABLE smart_gmos_north
+        ADD CONSTRAINT smart_gmos_north_smart_id_fkey FOREIGN KEY (smart_id) REFERENCES smartgcal ON DELETE CASCADE;
+
+-- Remove all the smartgcal data from gcal, since we've copied it over.
+TRUNCATE TABLE gcal CASCADE;
+
+-- The step_id is no longer optional in the original gcal table.
+ALTER TABLE gcal 
+      ALTER step_id SET NOT NULL;
+


### PR DESCRIPTION
This PR is a work-in-process update to Smart Gcal.  The purpose is to support GMOS Smart Gcal, but that necessitated a few fundamental changes:

1. The GMOS `.csv` files from OCS2 are hyper-complex.  To simplify parsing, I created an `exportSmartGcal` ODB shell command which exports to an easier to read format.  I've updated the Smart Gcal import to use that.  Since the GMOS `.csv` file is rather large with all the wildcards and regexes expanded, it was necessary to use `scalaz.stream` and doobie bulk importing features in order to read them within a reasonable(ish) time. Even so, GMOS-N requires almost 3 minutes so there is likely room for improvement.

2. GMOS supports defining wavelength ranges in the Smart Gcal mapping.  A GMOS step has a central wavelength value but the GCal config to which it corresponds is usable for a range of wavelengths.  This required splitting the existing `SmartGcalKey` into `SmartGcalSearchKey` and `SmartGcalDefinitionKey`. In the GMOS example, the search key would include the exact wavelength of the GMOS step while the definition key includes the wavelength range.

3. Previously GCal configurations for manual gcal steps were kept together with Smart Gcal configs.  You could differentiate the two based on whether the `gcal` `step_id` was `null`.  For manual gcal steps the `step_id` would be set but for smart gcal mappings it would be `null`.   The existing `step_gcal` table has now been expanded with duplicate `gcal` configuration columns, simplifying the queries and avoiding a join.  This also makes it trivial and fast to clean the Smart Gcal mappings before importing.

So far, only GMOS-N is supported and some additional cleanup and testing is needed.  Since this PR is already so big though, I wanted a checkpoint.