### PR TITLE
fix offset serialization

### DIFF
--- a/modules/core/src/main/scala/gem/Observation.scala
+++ b/modules/core/src/main/scala/gem/Observation.scala
@@ -12,7 +12,7 @@ import scalaz._, Scalaz._
  * minimally-specified Observation.
  * @group Program Model
  */
-final case class Observation[S, D](
+final case class Observation[+S, +D](
   id: Observation.Id,
   title: String,
   staticConfig: S,

--- a/modules/core/src/main/scala/gem/Program.scala
+++ b/modules/core/src/main/scala/gem/Program.scala
@@ -11,7 +11,7 @@ import scalaz._, Scalaz._
  * or `Nothing` for a minimally-specified program.
  * @group Program Model
  */
-final case class Program[A](id: Program.Id, title: String, observations: List[A])
+final case class Program[+A](id: Program.Id, title: String, observations: List[A])
 
 object Program {
 

--- a/modules/core/src/main/scala/gem/Step.scala
+++ b/modules/core/src/main/scala/gem/Step.scala
@@ -14,7 +14,7 @@ import scalaz.Functor
  * for a step without instrument-specific configuration information.
  * @group Sequence Model
  */
-sealed abstract class Step[A] extends Product with Serializable {
+sealed abstract class Step[+A] extends Product with Serializable {
   def dynamicConfig: A
 }
 

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -82,7 +82,7 @@ package object dao extends MoreTupleOps {
     Meta[java.math.BigDecimal]
       .xmap[Angle](
         b => Angle.fromMicroarcseconds(b.movePointRight(6).longValue),
-        a => new java.math.BigDecimal(a.toMicroarcseconds).movePointLeft(6)
+        a => new java.math.BigDecimal(a.toSignedMicroarcseconds).movePointLeft(6)
       )
 
   // OffsetP maps to a signed angle in arcseconds

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -13,7 +13,7 @@ import scalaz.effect.IO
 trait DaoTest extends gem.Arbitraries {
   val pid = Program.Id.unsafeFromString("GS-1234A-Q-1")
 
-  private val xa = Transactor.after.set(
+  protected val xa = Transactor.after.set(
     DriverManagerTransactor[IO](
       "org.postgresql.Driver",
       "jdbc:postgresql:gem",
@@ -25,7 +25,7 @@ trait DaoTest extends gem.Arbitraries {
 
   def withProgram[A](test: ConnectionIO[A]): A =
     (for {
-      _ <- ProgramDao.insert(Program(pid, "Test Prog", List.empty[Step[Nothing]]))
+      _ <- ProgramDao.insertFlat(Program(pid, "Test Prog", List.empty[Step[Nothing]]))
       a <- test
     } yield a).transact(xa).unsafePerformIO()
 }

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import doobie.imports._
+import gem._
+import gem.config._
+import gem.enum._
+import gem.math._
+import java.time.Duration
+import org.scalatest._
+
+class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
+
+  "StepDao" should "serialize telescope configurations properly" in {
+
+    // We specifically want to test round-tripping of telescope offsets.
+    val pid  = Program.Id.unsafeFromString("GS-1234A-Q-1")
+    val orig = Program(
+      pid,
+      "Untitled Prog",
+      List(
+        Observation(
+          Observation.Id(pid, 1),
+          "Untitled Obs",
+          StaticConfig.F2(MosPreImaging.IsNotMosPreImaging),
+          List(
+            Step.Science(
+              DynamicConfig.F2(
+                F2Disperser.NoDisperser,
+                Duration.ZERO,
+                F2Filter.Dark,
+                F2FpUnit.LongSlit1,
+                F2LyotWheel.F16,
+                F2ReadMode.Bright,
+                F2WindowCover.Close
+              ),
+              TelescopeConfig(
+                Offset.P(Angle.fromMilliarcseconds( 1250)), // 1.25 arcseconds
+                Offset.Q(Angle.fromMilliarcseconds(-2750))
+              )
+            )
+          )
+        )
+      )
+    )
+
+    // We should be able to round=trip the program.
+    import ProgramDao._
+    val rted = (insert(orig) >>= selectFull).transact(xa).unsafePerformIO
+    rted shouldEqual Some(orig)
+
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -38,7 +38,7 @@ object Importer extends DoobieClient {
 
     (u: User[_], l: Log[ConnectionIO]) =>
       for {
-        _ <- ignoreUniqueViolation(ProgramDao.insert(Program[Nothing](o.id.pid, "", Nil)))
+        _ <- ignoreUniqueViolation(ProgramDao.insertFlat(Program[Nothing](o.id.pid, "", Nil)).as(1))
         _ <- l.log(u, s"remove observation ${o.id}"   )(rmObservation           )
         _ <- l.log(u, s"insert new version of ${o.id}")(ObservationDao.insert(o))
         _ <- l.log(u, s"write datasets for ${o.id}"   )(writeDatasets           )


### PR DESCRIPTION
Ok this re-resolves #79 … the output value needed to be signed because small negative values ended up being 359:59:58.875 which is a huge number of arcseconds.

In order to test this I needed an easy way to insert a whole program, so I went ahead and implemented that. As a side-effect it turns out that `Program`, `Observation`, and `Step` need to be covariant in all their type parameters in order to allow us to pass a type like `Program[Observation[StaticConfig.F2, Step.Science[DynamicConfig.F2]]` to a method that wants a more general type like `Program[Observation[StaticConfig, Step[DynamicConfig]]`. Otherwise we have to gradually widen the type, which is a pain.