### PR TITLE
wavelength

### DIFF
--- a/modules/core/src/main/scala/gem/math/Wavelength.scala
+++ b/modules/core/src/main/scala/gem/math/Wavelength.scala
@@ -40,7 +40,7 @@ object Wavelength {
 
   /** Construct a wavelength from integral angstroms, if non-negative. */
   def fromAngstroms(angstroms: Int): Option[Wavelength] =
-    Some(angstroms).filter(_ > 0).map(new Wavelength(_))
+    Some(angstroms).filter(_ >= 0).map(new Wavelength(_))
 
   /** Construct a wavelength from integral angstroms, raising an exception if negative. */
   def unsafeFromAngstroms(angstroms: Int): Wavelength =

--- a/modules/core/src/main/scala/gem/math/Wavelength.scala
+++ b/modules/core/src/main/scala/gem/math/Wavelength.scala
@@ -23,13 +23,13 @@ final class Wavelength private (val toAngstroms: Int) {
     f"Wavelength($toAngstroms Å)"
 
   /** Wavelengths are equal if their magnitudes are equal. */
-  override final def equals(a: Any) =
+  override def equals(a: Any) =
     a match {
       case a: Wavelength => a.toAngstroms === toAngstroms
-      case _        => false
+      case _             => false
     }
 
-  override final def hashCode =
+  override def hashCode =
     toAngstroms
 
 }

--- a/modules/core/src/main/scala/gem/math/Wavelength.scala
+++ b/modules/core/src/main/scala/gem/math/Wavelength.scala
@@ -8,9 +8,9 @@ import scalaz.std.anyVal.intInstance
 import scalaz.syntax.equal._
 
 /**
- * Exact wavelengths represented as unsigned integral Angstroms in the range [0 .. Int.MaxValue]
+ * Exact wavelengths represented as unsigned integral angstroms in the range [0 .. Int.MaxValue]
  * which means the largest representable wavelength is 214.7483647 mm.
- * @param toAngstroms This wavelengths in integral angstroms (10^-10).
+ * @param toAngstroms This wavelength in integral angstroms (10^-10 of a meter).
  */
 sealed class Wavelength private (val toAngstroms: Int) {
 
@@ -22,7 +22,7 @@ sealed class Wavelength private (val toAngstroms: Int) {
   override def toString =
     f"Wavelength($toAngstroms Å)"
 
-  /** Angles are equal if their magnitudes are equal. */
+  /** Wavelengths are equal if their magnitudes are equal. */
   override final def equals(a: Any) =
     a match {
       case a: Wavelength => a.toAngstroms === toAngstroms
@@ -30,7 +30,7 @@ sealed class Wavelength private (val toAngstroms: Int) {
     }
 
   override final def hashCode =
-    toAngstroms.toInt
+    toAngstroms
 
 }
 
@@ -43,9 +43,8 @@ object Wavelength {
     Some(angstroms).filter(_ > 0).map(new Wavelength(_))
 
   /** Construct a wavelength from integral angstroms, raising an exception if negative. */
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def unsafeFromAngstroms(angstroms: Int): Wavelength =
-    fromAngstroms(angstroms).getOrElse(throw new ArithmeticException(s"Wavelength: overflow: $angstroms"))
+    fromAngstroms(angstroms).getOrElse(sys.error(s"Negative wavelength: $angstroms"))
 
   /** @group Typeclass Instances */
   implicit val WavelengthShow: Show[Wavelength] =

--- a/modules/core/src/main/scala/gem/math/Wavelength.scala
+++ b/modules/core/src/main/scala/gem/math/Wavelength.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import scalaz.{ Order, Show }
+import scalaz.std.anyVal.intInstance
+import scalaz.syntax.equal._
+
+/**
+ * Exact wavelengths represented as unsigned integral Angstroms in the range [0 .. Int.MaxValue]
+ * which means the largest representable wavelength is 214.7483647 mm.
+ * @param toAngstroms This wavelengths in integral angstroms (10^-10).
+ */
+sealed class Wavelength private (val toAngstroms: Int) {
+
+  // Sanity checks … should be correct via the companion constructor.
+  assert(toAngstroms >= 0, s"Invariant violated. $toAngstroms is negative.")
+  assert(toAngstroms <= Int.MaxValue, s"Invariant violated. $toAngstroms is larger than Int.MaxValue.")
+
+  /** String representation of this Wavelength, for debugging purposes only. */
+  override def toString =
+    f"Wavelength($toAngstroms Å)"
+
+  /** Angles are equal if their magnitudes are equal. */
+  override final def equals(a: Any) =
+    a match {
+      case a: Wavelength => a.toAngstroms === toAngstroms
+      case _        => false
+    }
+
+  override final def hashCode =
+    toAngstroms.toInt
+
+}
+
+object Wavelength {
+
+  final lazy val ZeroAngstroms = unsafeFromAngstroms(0)
+
+  /** Construct a wavelength from integral angstroms, if non-negative. */
+  def fromAngstroms(angstroms: Int): Option[Wavelength] =
+    Some(angstroms).filter(_ > 0).map(new Wavelength(_))
+
+  /** Construct a wavelength from integral angstroms, raising an exception if negative. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromAngstroms(angstroms: Int): Wavelength =
+    fromAngstroms(angstroms).getOrElse(throw new ArithmeticException(s"Wavelength: overflow: $angstroms"))
+
+  /** @group Typeclass Instances */
+  implicit val WavelengthShow: Show[Wavelength] =
+    Show.showA
+
+  /** @group Typeclass Instances */
+  implicit val WavelengthOrd: Order[Wavelength] =
+    Order.orderBy(_.toAngstroms)
+
+}

--- a/modules/core/src/main/scala/gem/math/Wavelength.scala
+++ b/modules/core/src/main/scala/gem/math/Wavelength.scala
@@ -12,7 +12,7 @@ import scalaz.syntax.equal._
  * which means the largest representable wavelength is 214.7483647 mm.
  * @param toAngstroms This wavelength in integral angstroms (10^-10 of a meter).
  */
-sealed class Wavelength private (val toAngstroms: Int) {
+final class Wavelength private (val toAngstroms: Int) {
 
   // Sanity checks … should be correct via the companion constructor.
   assert(toAngstroms >= 0, s"Invariant violated. $toAngstroms is negative.")

--- a/modules/core/src/test/scala/gem/arb/Wavelength.scala
+++ b/modules/core/src/test/scala/gem/arb/Wavelength.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.Wavelength
+import org.scalacheck._
+import org.scalacheck.Gen._
+
+trait ArbWavelength {
+
+  implicit def arbWavelength: Arbitrary[Wavelength] =
+    Arbitrary(choose(0, Int.MaxValue).map(Wavelength.unsafeFromAngstroms(_)))
+
+}
+object ArbWavelength extends ArbWavelength

--- a/modules/core/src/test/scala/gem/math/WavelengthSpec.scala
+++ b/modules/core/src/test/scala/gem/math/WavelengthSpec.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.arb._
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scalaz.{ Equal, Order, Show }
+import scalaz.std.anyVal._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+class WavelengthSpec extends FlatSpec with Matchers with PropertyChecks {
+  import ArbWavelength._
+
+  "Equality" must "be natural" in {
+    forAll { (a: Wavelength, b: Wavelength) =>
+      a.equals(b) shouldEqual Equal[Wavelength].equal(a, b)
+    }
+  }
+
+  "Order" must "be consistent with .toAngstroms" in {
+    forAll { (a: Wavelength, b: Wavelength) =>
+      Order[Int].order(a.toAngstroms, b.toAngstroms) shouldEqual
+      Order[Wavelength].order(a, b)
+    }
+  }
+
+  "Show" must "be natural" in {
+    forAll { (a: Wavelength) =>
+      a.toString shouldEqual Show[Wavelength].shows(a)
+    }
+  }
+
+  "Conversion to angstroms" must "be invertable" in {
+    forAll { (a: Wavelength) =>
+      Wavelength.fromAngstroms(a.toAngstroms) shouldEqual Some(a)
+    }
+  }
+
+  "Construction from an arbitrary Int" must "not allow negative values" in {
+    forAll { (n: Int) =>
+      Wavelength.fromAngstroms(n).isDefined shouldEqual n >= 0
+    }
+  }
+
+}


### PR DESCRIPTION
This adds a `Wavelength` class that just wraps a positive `Int` (for integral angstroms) and doesn't support operations other than comparison. It's minimal but I'm not sure what else we need immediately so I'd prefer to leave it simple and wait until more use cases arise.