### PR TITLE
User cleanup

### DIFF
--- a/modules/core/src/main/scala/gem/User.scala
+++ b/modules/core/src/main/scala/gem/User.scala
@@ -4,9 +4,9 @@
 package gem
 
 /**
- * A Gem user, parameterized on the type of owned program roles, typically
+ * A Gem user, parameterized on the type of granted program roles, typically
  * [[gem.enum.ProgramRole ProgramRole]] for a fully specified user, or `Nothing` for a user with
- * unstated permission information.
+ * unstated grants. Permissions are granted based on a combination of granted roles,
  * @group Application Model
  */
 final case class User[A](
@@ -15,9 +15,13 @@ final case class User[A](
   lastName:  String,
   email: String,
   isStaff: Boolean,
-  allProgramRoles: Map[Program.Id, Set[A]]
+  roles: Map[Program.Id, Set[A]]
 )
 
 object User {
   type Id = String // TODO
+  object Id {
+    /** Id of the root user, who always exists. This is a system invariant. */
+    val Root: User.Id = "root"
+  }
 }

--- a/modules/core/src/main/scala/gem/User.scala
+++ b/modules/core/src/main/scala/gem/User.scala
@@ -6,16 +6,17 @@ package gem
 /**
  * A Gem user, parameterized on the type of granted program roles, typically
  * [[gem.enum.ProgramRole ProgramRole]] for a fully specified user, or `Nothing` for a user with
- * unstated grants. Permissions are granted based on a combination of granted roles,
+ * unstated grants. Permissions are granted based on a combination of granted roles, staff status,
+ * and rootness.
  * @group Application Model
  */
 final case class User[A](
-  id: User.Id,
+  id:        User.Id,
   firstName: String,
   lastName:  String,
-  email: String,
-  isStaff: Boolean,
-  roles: Map[Program.Id, Set[A]]
+  email:     String,
+  isStaff:   Boolean,
+  roles:     Map[Program.Id, Set[A]]
 )
 
 object User {

--- a/modules/db/src/main/scala/gem/dao/UserDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserDao.scala
@@ -16,7 +16,7 @@ object UserDao {
    * raises an exception if the root user is missing.
    * @group Queries
    */
-  val selectRoot: ConnectionIO[User[ProgramRole]] =
+  val selectRootUser: ConnectionIO[User[ProgramRole]] =
     OptionT(selectUser(User.Id.Root)).getOrElse(sys.error("No root user. Cannot continue."))
 
   // Helper method to add roles to a selected user, if any.
@@ -28,14 +28,14 @@ object UserDao {
   } .run
 
   /**
-   * Select the given user, with roles.
+   * Select the given user, if any, with roles.
    * @group Queries
    */
   def selectUser(uid: User.Id): ConnectionIO[Option[User[ProgramRole]]] =
     selectUserImpl(Statements.selectUser(uid))
 
   /**
-   * Select the given user, with roles, if the id and password match a known user.
+   * Select the given user, if any, with roles, if the id and password match a known user.
    * @group Queries
    */
   def selectUserʹ(uid: User.Id, password: String): ConnectionIO[Option[User[ProgramRole]]] =
@@ -47,13 +47,6 @@ object UserDao {
    */
   def selectRoles(id: User.Id): ConnectionIO[Map[Program.Id, Set[ProgramRole]]] =
     Statements.selectRoles(id).list.map(_.foldMap { case (k, v) => Map((k -> Set(v))) })
-
-  /**
-   * Select the given user, with roles. Raises an exception if the user is not found.
-   * @group Queries
-   */
-  def selectUserWithRoles(id: User.Id): ConnectionIO[User[ProgramRole]] =
-    (Statements.selectUser(id).unique |@| selectRoles(id))((u, r) => u.copy(roles = r))
 
   /**
    * Attempts to change the specified user's password, yielding success. A cause of failure (user

--- a/modules/db/src/main/scala/gem/dao/UserDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserDao.scala
@@ -11,55 +11,76 @@ import doobie.imports._
 
 object UserDao {
 
-  /** Select the super-user, for system processes. */
-  def selectRoot: ConnectionIO[User[Nothing]] =
-    select("root")
+  /**
+   * Select the super-user, for system processes.
+   * @group Queries
+   */
+  val selectRoot: ConnectionIO[User[Nothing]] =
+    selectUser("root")
 
-  def select(id: String): ConnectionIO[User[Nothing]] =
-    Statements.select(id).unique
+  /**
+   * Select the given user, with roles, if the id and password match a known user.
+   * @group Queries
+   */
+  def tryLogin(uid: User.Id, password: String): ConnectionIO[Option[User[ProgramRole]]] =
+    (Statements.countUsers(uid, password).unique.liftM[OptionT].filter(_ == 1) *>
+     selectUserWithRoles(uid).liftM[OptionT]).run
 
-  def selectWithRoles(id: String, pass: String): ConnectionIO[Option[User[ProgramRole]]] =
-    Statements.selectWithRoles(id, pass)
-      .list
-      .map { rows =>
-        rows.headOption.map {
-          case (i, f, l, e, s, _, _) =>
-            val map = rows.collect {
-              case (_, _, _, _, _, Some(pid), Some(role)) => Map(pid -> Set(role))
-            }.suml
-            User(i, f, l, e, s, map)
-        }
-      }
+  /**
+   * Select the given user, without roles. Raises an exception if the user is not found.
+   * @group Queries
+   */
+  def selectUser(id: User.Id): ConnectionIO[User[Nothing]] =
+    Statements.selectUser(id).unique
 
+  /**
+   * Select the map of roles associated with the given user.
+   * @group Queries
+   */
+  def selectRoles(id: User.Id): ConnectionIO[Map[Program.Id, Set[ProgramRole]]] =
+    Statements.selectRoles(id).list.map(_.foldMap { case (k, v) => Map((k -> Set(v))) })
+
+  /**
+   * Select the given user, with roles. Raises an exception if the user is not found.
+   * @group Queries
+   */
+  def selectUserWithRoles(id: User.Id): ConnectionIO[User[ProgramRole]] =
+    (Statements.selectUser(id).unique |@| selectRoles(id))((u, r) => u.copy(allProgramRoles = r))
+
+  /**
+   * Attempts to change the specified user's password, yielding success. A cause of failure (user
+   * not found, old password incorrect) is not given.
+   * @group Updates
+   */
   def changePassword(uid: User.Id, oldPassword: String, newPassword: String): ConnectionIO[Boolean] =
     Statements.changePassword(uid, oldPassword, newPassword).run.map(_ === 1)
 
   object Statements {
 
-    def select(id: String): Query0[User[Nothing]] =
+    def selectUser(id: String): Query0[User[Nothing]] =
       sql"""
         SELECT id, first, last, email, staff
         FROM gem_user
         WHERE id = $id
-      """.query[(String, String, String, String, Boolean)]
-         .map { case (i, f, l, e, s) =>
-           User(i, f, l, e, s, Map.empty)
-         }
+      """.query[(String, String, String, String, Boolean)].map {
+        case (i, f, l, e, s) => User(i, f, l, e, s, Map.empty)
+      }
 
-    def selectWithRoles(id: String, pass: String): Query0[(String, String, String, String, Boolean, Option[Program.Id], Option[ProgramRole])] =
+    def selectRoles(id: User.Id): Query0[(Program.Id, ProgramRole)] =
       sql"""
-        SELECT u.id,
-               u.first,
-               u.last,
-               u.email,
-               u.staff,
-               g.program_id,
-               g.program_role
-          FROM gem_user u LEFT OUTER JOIN gem_user_program g ON g.user_id = u.id
-          WHERE id = $id
-          AND "md5" = md5($pass)
-      """
-        .query[(String, String, String, String, Boolean, Option[Program.Id], Option[ProgramRole])]
+        SELECT program_id, program_role
+        FROM gem_user_program
+        WHERE user_id = $id
+      """.query
+
+    // count the number of users with the given id and password; useful for checking passwords
+    def countUsers(uid: User.Id, password: String): Query0[Int] =
+      sql"""
+        SELECT count(*)::integer
+        FROM   gem_user
+        WHERE  id  = ${uid}
+        AND    md5 = md5($password)
+      """.query[Int]
 
     def changePassword(uid: User.Id, oldPassword: String, newPassword: String): Update0 =
       sql"""

--- a/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import doobie.imports._
+import gem._
+import org.scalatest._
+
+class UserDaoSpec extends FlatSpec with Matchers with DaoTest {
+
+  "StepDao" should "select the root user" in {
+    val r = UserDao.selectRootUser.transact(xa).unsafePerformIO
+    r.id shouldEqual User.Id.Root
+  }
+
+}

--- a/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
@@ -8,7 +8,7 @@ class UserCheck extends Check {
   import UserDao.Statements._
   "UserDao.Statements" should
             "selectUser"      in check(selectUser(""))
+  it should "selectUserʹ"     in check(selectUserʹ("", ""))
   it should "selectRoles"     in check(selectRoles(""))
-  it should "countUsers"      in check(countUsers("", ""))
   it should "changePassword"  in check(changePassword("", "", ""))
 }

--- a/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
@@ -7,7 +7,8 @@ package check
 class UserCheck extends Check {
   import UserDao.Statements._
   "UserDao.Statements" should
-            "select"          in check(select(""))
-  it should "selectWithRoles" in check(selectWithRoles("", ""))
+            "selectUser"      in check(selectUser(""))
+  it should "selectRoles"     in check(selectRoles(""))
+  it should "countUsers"      in check(countUsers("", ""))
   it should "changePassword"  in check(changePassword("", "", ""))
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
@@ -71,7 +71,7 @@ object FileImporter extends SafeApp with DoobieClient {
 
   override def runl(args: List[String]): IO[Unit] =
     for {
-      u <- UserDao.selectRoot.transact(xa)
+      u <- UserDao.selectRootUser.transact(xa)
       l <- Log.newLog[ConnectionIO]("importer", lxa).transact(xa)
       n <- IO(args.headOption.map(_.toInt).getOrElse(Int.MaxValue))
       _ <- checkArchive

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -61,7 +61,7 @@ object Importer extends DoobieClient {
 
   def doImport(write: (User[_], Log[ConnectionIO]) => ConnectionIO[Unit]): Task[Unit] =
     for {
-      u <- UserDao.selectRoot.transact(lxa)
+      u <- UserDao.selectRootUser.transact(lxa)
       l <- Log.newLog[ConnectionIO]("importer", lxa).transact(lxa)
       _ <- Task.delay(configureLogging)
       _ <- write(u, l).transact(lxa)

--- a/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
@@ -175,7 +175,7 @@ object SmartGcalImporter extends TaskApp with DoobieClient {
 
   override def runl(args: List[String]): Task[Unit] =
     for {
-      u <- UserDao.selectRoot.transact(lxa)
+      u <- UserDao.selectRootUser.transact(lxa)
       l <- Log.newLog[Task]("smartgcal importer", lxa)
       _ <- checkSmartDir
       _ <- Task.delay(configureLogging)

--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -47,7 +47,7 @@ object Service {
   def tryLogin[M[_]: Monad: Catchable: Capture](
     user: User.Id, pass: String, xa: Transactor[M,_], txa: Transactor[Task, _]
   ): M[Option[Service[M]]] =
-    xa.trans.apply(UserDao.tryLogin(user, pass)).flatMap {
+    xa.trans.apply(UserDao.selectUserʹ(user, pass)).flatMap {
       case None    => Option.empty[Service[M]].point[M]
       case Some(u) => Log.newLog[M](s"session:$u.name", txa).map(l => Some(Service[M](xa, l, u)))
     }

--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -47,7 +47,7 @@ object Service {
   def tryLogin[M[_]: Monad: Catchable: Capture](
     user: User.Id, pass: String, xa: Transactor[M,_], txa: Transactor[Task, _]
   ): M[Option[Service[M]]] =
-    xa.trans.apply(UserDao.selectWithRoles(user, pass)).flatMap {
+    xa.trans.apply(UserDao.tryLogin(user, pass)).flatMap {
       case None    => Option.empty[Service[M]].point[M]
       case Some(u) => Log.newLog[M](s"session:$u.name", txa).map(l => Some(Service[M](xa, l, u)))
     }


### PR DESCRIPTION
This cleans up some messiness in the user DAO. It's still unused other than `selectRootUser` since there's no way to create another user.