### PR TITLE
Fix daily program id bug

### DIFF
--- a/modules/core/src/main/scala/gem/ProgramId.scala
+++ b/modules/core/src/main/scala/gem/ProgramId.scala
@@ -96,11 +96,11 @@ object ProgramId {
 
     /** The first moment of this observing day, 2pm the day before `localDate`. */
     lazy val start: ZonedDateTime =
-      ZonedDateTime.of(localDate, LocalTime.MIDNIGHT, site.timezone).minusHours(10)
+      ZonedDateTime.of(localDate.minusDays(1), LocalTime.of(14,0,0), site.timezone)
 
     /** The last moment of this observing day, just before 2pm on 'localDate'. */
     lazy val end: ZonedDateTime =
-      ZonedDateTime.of(localDate.minusDays(1), LocalTime.MAX, site.timezone).plusHours(14)
+      ZonedDateTime.of(localDate, LocalTime.of(14,0,0).minusNanos(1), site.timezone)
 
     /** True if the given instant falls within the observing day defined by `start` and `end`. */
     def includes(i: Instant): Boolean =


### PR DESCRIPTION
There is an [issue](https://github.com/gemini-hlsw/gem/issues/71) in the way that `Daily` program ids start and end times are calculated.  It doesn't account for daylight savings.  For example, at GS daylight savings starts and ends on a random, different day each year.  In the case of GS-ENG20160814, the old method for calculating the end date would take the last nanosecond of 8/13

```
2016-08-13T23:59:59.999999999-04:00[America/Santiago]
```

and add 14 hours, which usually produces the nanosecond before 2 PM on 8/14.  Because of the daylight savings event though we instead get:

```
2016-08-14T14:59:59.999999999-03:00[America/Santiago]
```

This update just makes the start and end times more explicit.
