### PR TITLE
Add semester to daily program id

### DIFF
--- a/modules/core/src/main/scala/gem/ProgramId.scala
+++ b/modules/core/src/main/scala/gem/ProgramId.scala
@@ -90,7 +90,7 @@ object ProgramId {
     localDate:        LocalDate
   ) extends ProgramId(
     Some(site),
-    None,
+    Some(Semester.fromLocalDate(localDate)),
     Some(dailyProgramType.toProgramType)
   ) {
 

--- a/modules/core/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/src/test/scala/gem/ProgramIdSpec.scala
@@ -75,6 +75,18 @@ class ProgramIdSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
+  it should "have a consistent program type and daily program type" in {
+    forAll { (did: Daily) =>
+      did.dailyProgramType.toProgramType shouldEqual did.programType
+    }
+  }
+
+  it should "have a consistent date and semester" in {
+    forAll { (did: Daily) =>
+      Semester.fromLocalDate(did.localDate) shouldEqual did.semester
+    }
+  }
+
   "Nonstandard" should "reparse" in {
     forAll { (nid: Nonstandard) =>
       Nonstandard.fromString(nid.format) shouldEqual Some(nid)


### PR DESCRIPTION
I noticed that the `Daily` program id was missing its `Semester`.  I imagine there is a reason but I wasn't sure why so I thought I'd open a PR to find out.  At any rate, we associate semesters with daily program ids in the old core `ProgramId` and make use of it when filtering programs in the OT open dialog.