### PR TITLE
Fix failing test case in coreJS

### DIFF
--- a/modules/core/src/test/scala/gem/LocationSpec.scala
+++ b/modules/core/src/test/scala/gem/LocationSpec.scala
@@ -70,14 +70,15 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
     }
   }
 
-  ignore should "produce a sorted list of Location.Middle" in {
+  it should "produce a sorted list of Location.Middle" in {
     forAll { (i: Int, l0: Location, l1: Location) =>
       val count = (i % 10000).abs + 1
       val res   = Order[Location].order(l0, l1) match {
         case LT => l0 +: Location.find(count, l0, l1).widen[Location] :+ l1
         case _  => l1 +: Location.find(count, l1, l0).widen[Location] :+ l0
       }
-      res.sorted shouldEqual res
+
+      assert(Equal[IList[Location]].equal(res.sorted, res))
     }
   }
 


### PR DESCRIPTION
This is a fix for the failing test case that was marked `ignore` in #98.  It turns out the issue was in the comparison of the two (long) `IList` instances.  If we explicitly use the scalaz `===` definition instead, it works as expected.

