### PR TITLE
Fix (occasionally) broken test case

### DIFF
--- a/modules/core/src/main/scala/gem/config/Gmos.scala
+++ b/modules/core/src/main/scala/gem/config/Gmos.scala
@@ -182,7 +182,7 @@ object Gmos {
     detector:      GmosDetector,
     mosPreImaging: MosPreImaging,
     nodAndShuffle: Option[GmosNodAndShuffle],
-    customRois:    List[GmosCustomRoiEntry]
+    customRois:    Set[GmosCustomRoiEntry]
   )
 
   object GmosCommonStaticConfig extends GmosCommonStaticConfigLenses {
@@ -191,12 +191,12 @@ object Gmos {
         GmosDetector.HAMAMATSU,
         MosPreImaging.IsNotMosPreImaging,
         None,
-        Nil
+        Set.empty[GmosCustomRoiEntry]
       )
   }
 
   trait GmosCommonStaticConfigLenses {
-    val CustomRois: GmosCommonStaticConfig @> List[GmosCustomRoiEntry] =
+    val CustomRois: GmosCommonStaticConfig @> Set[GmosCustomRoiEntry] =
       Lens.lensu((a, b) => a.copy(customRois = b), _.customRois)
 
     val NodAndShuffle: GmosCommonStaticConfig @> Option[GmosNodAndShuffle] =

--- a/modules/core/src/main/scala/gem/config/StaticConfig.scala
+++ b/modules/core/src/main/scala/gem/config/StaticConfig.scala
@@ -65,7 +65,7 @@ object StaticConfig {
     val Common: GmosNorth @> GmosCommonStaticConfig =
       Lens.lensu((a, b) => a.copy(common = b), _.common)
 
-    val CustomRois: GmosNorth @> List[GmosCustomRoiEntry] =
+    val CustomRois: GmosNorth @> Set[GmosCustomRoiEntry] =
       Common >=> GmosCommonStaticConfig.CustomRois
 
     val NodAndShuffle: GmosNorth @> Option[GmosNodAndShuffle] =
@@ -89,7 +89,7 @@ object StaticConfig {
     val Common: GmosSouth @> GmosCommonStaticConfig =
       Lens.lensu((a, b) => a.copy(common = b), _.common)
 
-    val CustomRois: GmosSouth @> List[GmosCustomRoiEntry] =
+    val CustomRois: GmosSouth @> Set[GmosCustomRoiEntry] =
       Common >=> GmosCommonStaticConfig.CustomRois
 
     val NodAndShuffle: GmosSouth @> Option[GmosNodAndShuffle] =

--- a/modules/core/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/config/Arbitraries.scala
@@ -103,7 +103,7 @@ trait Arbitraries {
         n <- arbitrary[Option[Gmos.GmosNodAndShuffle]]
         c <- Gen.choose(1, 5)
         r <- Gen.listOfN(c, arbitrary[Gmos.GmosCustomRoiEntry])
-      } yield Gmos.GmosCommonStaticConfig(d, p, n, r)
+      } yield Gmos.GmosCommonStaticConfig(d, p, n, r.toSet)
     )
 
   implicit val arbGmosNorthStatic =

--- a/modules/ocs2/src/main/scala/gem/ocs2/StaticDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/StaticDecoder.scala
@@ -66,8 +66,8 @@ object StaticDecoder extends PioDecoder[StaticConfig] {
       } yield GmosCustomRoiEntry.unsafeFromDescription(xMin, yMin, xRng, yRng)).run
     }
 
-    def parseCustomRoiEntries(cm: ConfigMap): PioError \/ List[GmosCustomRoiEntry] =
-      (1 to 5).toList.traverseU(parseCustomRoiEntry(cm, _)).map(_.flatMap(_.toList))
+    def parseCustomRoiEntries(cm: ConfigMap): PioError \/ Set[GmosCustomRoiEntry] =
+      (1 to 5).toList.traverseU(parseCustomRoiEntry(cm, _)).map(_.flatMap(_.toList).toSet)
 
     def parseNodAndShuffle(cm: ConfigMap): PioError \/ Option[GmosNodAndShuffle] = {
       import Legacy.Instrument.Gmos._


### PR DESCRIPTION
The addition of GMOS custom ROIs introduced an occasional bug in tests that produce, write, and then read back observations.  Namely ROIs were stored in a `List[GmosCustomRoiEntry]` but there is no guarantee what order the entries will be in when selected from the database.  In reality the order is irrelevant and ultimately I want to replace the `List[GmosCustomRoiEntry]` with a proper `RegionsOfInterest` type of some sort as @tpolecat suggested.  For now I just switched this to a `Set[GmosCustomRoiEntry]` to work around the issue and keep it from interfering with anybody else's work.