### PR TITLE
Fix smart_f2 constraints

### DIFF
--- a/modules/sql/src/main/resources/db/migration/V023__F2_SmartF2_Constraints.sql
+++ b/modules/sql/src/main/resources/db/migration/V023__F2_SmartF2_Constraints.sql
@@ -1,0 +1,7 @@
+--
+-- Fix constraints in smart_f2, since disperser and fpu are now optional.
+--
+
+ALTER TABLE smart_f2
+      ALTER COLUMN disperser DROP NOT NULL,
+      ALTER COLUMN fpu       DROP NOT NULL;


### PR DESCRIPTION
F2 disperser and FPU are now optional, so the `smart_f2` constraints need to be adjusted to match.

(I'll rebase and merge this after the cats update is merged.)