### PR TITLE
Switch to CatsSuite, add law checking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,10 +180,11 @@ lazy val core = crossProject
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel"           %%% "cats-core" % catsVersion,
-      "com.chuusai"             %%% "shapeless" % shapelessVersion,
-      "org.tpolecat"            %%% "atto-core" % attoVersion,
-      "com.github.benhutchison" %%% "mouse"     % mouseVersion
+      "org.typelevel"           %%% "cats-core"    % catsVersion,
+      "org.typelevel"           %%% "cats-testkit" % catsVersion % "test",
+      "com.chuusai"             %%% "shapeless"    % shapelessVersion,
+      "org.tpolecat"            %%% "atto-core"    % attoVersion,
+      "com.github.benhutchison" %%% "mouse"        % mouseVersion
     )
   )
   .jsSettings(

--- a/modules/core/src/main/scala/gem/Semester.scala
+++ b/modules/core/src/main/scala/gem/Semester.scala
@@ -133,7 +133,7 @@ object Semester {
    * `Ordering` instance for Scala standard library.
    * @see SemesterOrder
    */
-  implicit val SemesterOrding: scala.math.Ordering[Semester] =
+  implicit val SemesterOrdering: scala.math.Ordering[Semester] =
     SemesterOrder.toOrdering
 
   implicit val SemesterShow: Show[Semester] =

--- a/modules/core/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/src/main/scala/gem/math/Angle.scala
@@ -9,7 +9,7 @@ import cats.instances.long._
 import cats.syntax.eq._
 
 /**
- * Exact angles represented as integral microarcseconds. These values form an Abelian group over
+ * Exact angles represented as integral microarcseconds. These values form a commutative group over
  * addition, where the inverse is reflection around the 0-180° axis. The subgroup of angles where
  * integral microarcseconds correspond with clock microseconds (i.e., where they are evenly
  * divisible by 15 microarcseconds) is represented by the HourAgle subtype.
@@ -209,8 +209,8 @@ object Angle {
 
 
 /**
- * Exact hour angles represented as integral microseconds. These values form an Abelian group over
- * addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
+ * Exact hour angles represented as integral microseconds. These values form a commutative group
+ * over addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
  * integral Angles where microarcseconds are evenly divisible by 15.
  * @see The helpful [[https://en.wikipedia.org/wiki/Hour_angle Wikipedia]] article.
  */

--- a/modules/core/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/src/main/scala/gem/math/Angle.scala
@@ -3,7 +3,8 @@
 
 package gem.math
 
-import cats.{ Eq, Monoid, Show }
+import cats.{ Eq, Show }
+import cats.kernel.CommutativeGroup
 import cats.instances.long._
 import cats.syntax.eq._
 
@@ -143,11 +144,12 @@ object Angle {
   def fromDoubleRadians(rad: Double): Angle =
     fromDoubleDegrees(rad.toDegrees)
 
-  /** Angle is an Abelian group, but monoid is the best we can do for now. */
-  implicit val AngleMonoid: Monoid[Angle] =
-    new Monoid[Angle] {
+  /** Angle forms a commutative group. */
+  implicit val AngleCommutativeGroup: CommutativeGroup[Angle] =
+    new CommutativeGroup[Angle] {
       val empty: Angle = Angle0
       def combine(a: Angle, b: Angle) = a + b
+      def inverse(a: Angle) = -a
     }
 
   implicit val AngleShow: Show[Angle] =
@@ -307,11 +309,12 @@ object HourAngle {
       hours.toLong        * 1000L * 1000L * 60L * 60L
     )
 
-  /** HourAngle is an Abelian group (a subgroup of Angle), but monoid is the best we can do for now. */
-  implicit val HourAngleMonoid: Monoid[HourAngle] =
-    new Monoid[HourAngle] {
+  /** HourAngle forms a commutative group. */
+  implicit val AngleCommutativeGroup: CommutativeGroup[HourAngle] =
+    new CommutativeGroup[HourAngle] {
       val empty: HourAngle = HourAngle0
       def combine(a: HourAngle, b: HourAngle) = a + b
+      def inverse(a: HourAngle) = -a
     }
 
   implicit val HourAngleShow: Show[HourAngle] =

--- a/modules/core/src/main/scala/gem/math/Offset.scala
+++ b/modules/core/src/main/scala/gem/math/Offset.scala
@@ -4,7 +4,8 @@
 package gem
 package math
 
-import cats.{ Eq, Monoid, Show }
+import cats.{ Eq, Show }
+import cats.kernel.CommutativeGroup
 import cats.implicits._
 
 /** Angular offset with P and Q components. */
@@ -26,11 +27,12 @@ object Offset {
   val Zero: Offset =
     Offset(P.Zero, Q.Zero)
 
-  /** Offset forms an Abelian group but Monoid is the best we can do right now. */
-  implicit val MonoidOffset: Monoid[Offset] =
-    new Monoid[Offset] {
+  /** Offset forms a commutative group. */
+  implicit val CommutativeGroupOffset: CommutativeGroup[Offset] =
+    new CommutativeGroup[Offset] {
       val empty: Offset = Zero
       def combine(a: Offset, b: Offset) = a + b
+      def inverse(a: Offset) = -a
     }
 
   implicit val ShowOffset: Show[Offset] =
@@ -59,11 +61,12 @@ object Offset {
     val Zero: P =
       P(Angle.Angle0)
 
-    /** P forms an Abelian group but Monoid is the best we can do right now. */
-    implicit val MonoidP: Monoid[P] =
-      new Monoid[P] {
+    /** P forms a commutative group. */
+    implicit val CommutativeGroupP: CommutativeGroup[P] =
+      new CommutativeGroup[P] {
         val empty: P = Zero
         def combine(a: P, b: P) = a + b
+        def inverse(a: P) = -a
       }
 
     implicit val ShowP: Show[P] =
@@ -93,11 +96,12 @@ object Offset {
     val Zero: Q =
       Q(Angle.Angle0)
 
-    /** Q forms an Abelian group but Monoid is the best we can do right now. */
-    implicit val MonoidQ: Monoid[Q] =
-      new Monoid[Q] {
+    /** Q forms a commutative group. */
+    implicit val CommutativeGroupQ: CommutativeGroup[Q] =
+      new CommutativeGroup[Q] {
         val empty: Q = Zero
         def combine(a: Q, b: Q) = a + b
+        def inverse(a: Q) = -a
       }
 
     implicit val ShowQ: Show[Q] =

--- a/modules/core/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/src/test/scala/gem/Arbitraries.scala
@@ -32,6 +32,9 @@ trait Arbitraries extends gem.config.Arbitraries  {
       )
     }
 
+  implicit val cogLocation: Cogen[Location] =
+    Cogen[String].contramap(_.toString)
+
   // Generator of valid observation/program titles.  The schema doesn't support
   // titles longer than 255 characters and postgres doesn't want to see char 0.
   val genTitle: Gen[String] =

--- a/modules/core/src/test/scala/gem/DatasetLabelSpec.scala
+++ b/modules/core/src/test/scala/gem/DatasetLabelSpec.scala
@@ -3,40 +3,38 @@
 
 package gem
 
-import cats.{ Eq, Order, Show }
-import cats.implicits._
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-class DatasetLabelSpec extends FlatSpec with Matchers with PropertyChecks {
+final class DatasetLabelSpec extends CatsSuite {
   import ArbDataset._
 
-  // Compilation test
-  protected val a1 = implicitly[Order[Dataset.Label]]
-  protected val a2 = implicitly[Show[Dataset.Label]]
+  // Laws
+  checkAll("DatasetLabel", OrderLaws[Dataset.Label].order)
 
-  "Equality" must "be natural" in {
+  test("Equality must be natural") {
     forAll { (a: Dataset.Label, b: Dataset.Label) =>
       a.equals(b) shouldEqual Eq[Dataset.Label].eqv(a, b)
     }
   }
 
-  it must "operate pairwise" in {
+  test("Equality must operate pairwise") {
     forAll { (a: Dataset.Label, b: Dataset.Label) =>
       Eq[Observation.Id].eqv(a.observationId, b.observationId) &&
       Eq[Int].eqv(a.index, b.index) shouldEqual Eq[Dataset.Label].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Dataset.Label) =>
       a.toString shouldEqual Show[Dataset.Label].show(a)
     }
   }
 
-  ".format" should "reparse" in {
+  test(".format should reparse") {
     forAll { (a: Dataset.Label) =>
       Dataset.Label.fromString(a.format) shouldEqual Some(a)
     }

--- a/modules/core/src/test/scala/gem/DatasetSpec.scala
+++ b/modules/core/src/test/scala/gem/DatasetSpec.scala
@@ -3,29 +3,27 @@
 
 package gem
 
-import cats.{ Eq, Order, Show }
-import cats.implicits._
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws._
 import gem.arb._
 import gem.imp.TimeInstances._
 import java.time.Instant
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-class DatasetSpec extends FlatSpec with Matchers with PropertyChecks {
+final class DatasetSpec extends CatsSuite {
   import ArbDataset._
 
-  // Compilation test
-  protected val a1 = implicitly[Order[Dataset]]
-  protected val a2 = implicitly[Show[Dataset]]
+  // Laws
+  checkAll("DatasetLabel", OrderLaws[Dataset].order)
 
-  "Equality" must "be natural" in {
+  test("Equality must be natural") {
     forAll { (a: Dataset, b: Dataset) =>
       a.equals(b) shouldEqual Eq[Dataset].eqv(a, b)
     }
   }
 
-  it must "operate pairwise" in {
+  test("Equality must operate pairwise") {
     forAll { (a: Dataset, b: Dataset) =>
       Eq[Dataset.Label].eqv(a.label, b.label) &&
       Eq[String].eqv(a.filename, b.filename)  &&
@@ -33,7 +31,7 @@ class DatasetSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Dataset) =>
       a.toString shouldEqual Show[Dataset].show(a)
     }

--- a/modules/core/src/test/scala/gem/EnumeratedSpec.scala
+++ b/modules/core/src/test/scala/gem/EnumeratedSpec.scala
@@ -3,22 +3,27 @@
 
 package gem
 
+import gem.arb._
 import gem.enum._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
+import cats.tests.CatsSuite
+import cats.kernel.laws._
 import scala.reflect.ClassTag
 
-class EnumeratedSpec extends FlatSpec with Matchers with PropertyChecks {
+final class EnumeratedSpec extends CatsSuite {
+  import ArbEnumerated._
 
   def checkEnumeration[A](
     implicit en: Enumerated[A],
              ct: ClassTag[A]
-  ): Unit =
-    s"Ordering for ${ct.runtimeClass.getName}" should "be canonical" in {
+  ): Unit = {
+    val name = ct.runtimeClass.getSimpleName
+    checkAll(name, OrderLaws[A].order)
+    test(s"$name.enumerated.canonical") {
       val sorted   = en.all
       val shuffled = scala.util.Random.shuffle(sorted)
       shuffled.sorted(en.toOrdering) shouldEqual sorted
     }
+  }
 
   // Check a handful of enums.
   checkEnumeration[EventType]

--- a/modules/core/src/test/scala/gem/LocationSpec.scala
+++ b/modules/core/src/test/scala/gem/LocationSpec.scala
@@ -5,12 +5,8 @@ package gem
 
 import cats.{ Eq, Order }
 import cats.kernel.laws._
-import cats.tests.CatsSuite
-
-// import cats._, cats.implicits._
 import cats.kernel.Comparison.{ GreaterThan => GT, LessThan => LT, EqualTo => EQ }
-// import org.scalatest.prop.PropertyChecks
-// import org.scalatest.{FlatSpec, Matchers}
+import cats.tests.CatsSuite
 
 @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
 final class LocationSpec extends CatsSuite with Arbitraries {

--- a/modules/core/src/test/scala/gem/LocationSpec.scala
+++ b/modules/core/src/test/scala/gem/LocationSpec.scala
@@ -3,25 +3,33 @@
 
 package gem
 
-import cats._, cats.implicits._
+import cats.{ Eq, Order }
+import cats.kernel.laws._
+import cats.tests.CatsSuite
+
+// import cats._, cats.implicits._
 import cats.kernel.Comparison.{ GreaterThan => GT, LessThan => LT, EqualTo => EQ }
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+// import org.scalatest.prop.PropertyChecks
+// import org.scalatest.{FlatSpec, Matchers}
 
 @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
-class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbitraries {
-  "Construction" should "trim trailing min values from Middle" in {
+final class LocationSpec extends CatsSuite with Arbitraries {
+
+  // Laws
+  checkAll("Location", OrderLaws[Location].order)
+
+  test("Construction should trim trailing min values from Middle") {
     forAll { (l: Location.Middle) =>
       val t = l.toList
       t shouldEqual t.reverse.dropWhile(_ == Int.MinValue).reverse
     }
   }
 
-  it should "produce Beginning if given an empty list" in {
+  test("Construction should produce Beginning if given an empty list") {
     Location.fromFoldable(List.empty[Int]) shouldEqual Location.Beginning
   }
 
-  it should "produce beginning if given all Int.MinValue" in {
+  test("Construction should produce beginning if given all Int.MinValue") {
     forAll { (i: Int) =>
       val count = (i % 10).abs
       val mins  = List.fill(count)(Int.MinValue)
@@ -29,19 +37,19 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
     }
   }
 
-  "EQ" should "agree with ==" in {
+  test("EQ should agree with ==") {
     forAll { (l0: Location, l1: Location) =>
       Order[Location].eqv(l0, l1) shouldEqual (l0 == l1)
     }
   }
 
-  "Find" should "return an empty list if the two positions are the same" in {
+  test("Find should return an empty list if the two positions are the same") {
     forAll { (l: Location) =>
       Location.find(10, l, l) shouldEqual List.empty[Location.Middle]
     }
   }
 
-  it should "return an empty list if the first position is >= the second" in {
+  test("Find should return an empty list if the first position is >= the second") {
     forAll { (l0: Location, l1: Location) =>
       val res = Order[Location].comparison(l0, l1) match {
         case LT => Location.find(10, l1, l0)
@@ -51,14 +59,14 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
     }
   }
 
-  it should "find nothing if asked for a negative or 0 count" in {
+  test("Find should find nothing if asked for a negative or 0 count") {
     forAll { (i: Int, l0: Location, l1: Location) =>
       val negOrZero = -(i.abs)
       Location.find(negOrZero, l0, l1) shouldEqual List.empty[Location.Middle]
     }
   }
 
-  it should "find an arbitrary number of Locations between unequal positions" in {
+  test("Find should find an arbitrary number of Locations between unequal positions") {
     forAll { (i: Int, l0: Location, l1: Location) =>
       val count = (i % 10000).abs + 1
       Order[Location].comparison(l0, l1) match {
@@ -69,7 +77,7 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
     }
   }
 
-  it should "produce a sorted list of Location.Middle" in {
+  test("Find should produce a sorted list of Location.Middle") {
     forAll { (i: Int, l0: Location, l1: Location) =>
       val count = (i % 10000).abs + 1
       val res   = Order[Location].comparison(l0, l1) match {
@@ -81,7 +89,7 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
     }
   }
 
-  it should "grow the position list if necessary" in {
+  test("Find should grow the position list if necessary") {
     Location.find(1, Location(1, 2), Location(1,3)) match {
       case res :: Nil =>
         res.toList match {
@@ -97,7 +105,7 @@ class LocationSpec extends FlatSpec with Matchers with PropertyChecks with Arbit
     }
   }
 
-  it should "evenly space values it finds" in {
+  test("Find should evenly space values it finds") {
     val Max   = BigInt(Int.MaxValue)
     val Min   = BigInt(Int.MinValue)
     val Radix = Max + Min.abs + BigInt(1)

--- a/modules/core/src/test/scala/gem/ObservationIdSpec.scala
+++ b/modules/core/src/test/scala/gem/ObservationIdSpec.scala
@@ -4,35 +4,37 @@
 package gem
 
 import cats.{ Eq, Show }
-import cats.implicits._
+import cats.kernel.laws._
+import cats.tests.CatsSuite
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class ObservationIdSpec extends FlatSpec with Matchers with PropertyChecks {
+final class ObservationIdSpec extends CatsSuite {
   import ArbObservation._
 
-  "Equality" must "be natural" in {
+  // Laws
+  checkAll("Observation.Id", OrderLaws[Observation.Id].order)
+
+  test("Equality must be natural") {
     forAll { (a: Observation.Id, b: Observation.Id) =>
       a.equals(b) shouldEqual Eq[Observation.Id].eqv(a, b)
     }
   }
 
-  it must "act pairwise" in {
+  test("Equalty must act pairwise") {
     forAll { (a: Observation.Id, b: Observation.Id) =>
       Eq[Program.Id].eqv(a.pid, b.pid) &&
       Eq[Int].eqv(a.index, b.index) shouldEqual Eq[Observation.Id].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Observation.Id) =>
       a.toString shouldEqual Show[Observation.Id].show(a)
     }
   }
 
-  ".format" should "reparse" in {
+  test(".format must reparse") {
     forAll { (a: Observation.Id) =>
       Observation.Id.fromString(a.format) shouldEqual Some(a)
     }

--- a/modules/core/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/src/test/scala/gem/ProgramIdSpec.scala
@@ -4,56 +4,59 @@
 package gem
 
 import cats.{ Eq, Show }
+import cats.kernel.laws._
+import cats.tests.CatsSuite
 import gem.arb._
 import gem.enum.{ Site, DailyProgramType }
 import java.time._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class ProgramIdSpec extends FlatSpec with Matchers with PropertyChecks {
+final class ProgramIdSpec extends CatsSuite {
   import ProgramId._
   import ArbEnumerated._
   import ArbProgramId._
   import ArbTime._
 
-  "Equality" must "be natural" in {
+  // Laws
+  checkAll("Program.Id", OrderLaws[Program.Id].order)
+
+  test("Equality must be natural") {
     forAll { (a: ProgramId, b: ProgramId) =>
       a.equals(b) shouldEqual Eq[ProgramId].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: ProgramId) =>
       a.toString shouldEqual Show[ProgramId].show(a)
     }
   }
 
-  "Science" should "reparse" in {
+  test("Science must reparse") {
     forAll { (sid: Science) =>
       Science.fromString(sid.format) shouldEqual Some(sid)
     }
   }
 
-  it should "never reparse into a Nonstandard, even if we try" in {
+  test("Science should never reparse into a Nonstandard, even if we try") {
     forAll { (sid: Science) =>
       Nonstandard.fromString(sid.format) shouldEqual None
     }
   }
 
-  "Daily" should "reparse" in {
+  test("Daily must reparse") {
     forAll { (did: Daily) =>
       Daily.fromString(did.format) shouldEqual Some(did)
     }
   }
 
-  it should "never reparse into a Nonstandard, even if we try" in {
+  test("Daily should never reparse into a Nonstandard, even if we try") {
     forAll { (did: Science) =>
       Daily.fromString(did.format) shouldEqual None
     }
   }
 
-  it should "find the correct observing day given a site and instant" in {
+  test("Daily should find the correct observing day given a site and instant") {
     forAll { (site: Site, ldt: LocalDateTime, dpt: DailyProgramType) =>
       val zdt = ZonedDateTime.of(ldt, site.timezone)
       val did = Daily.fromSiteAndInstant(site, zdt.toInstant, dpt)
@@ -63,37 +66,37 @@ class ProgramIdSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  it should "be consistent re: .start and .fromSiteAndInstant" in {
+  test("Daily should be consistent re: .start and .fromSiteAndInstant") {
     forAll { (did: Daily) =>
       Daily.fromSiteAndInstant(did.site, did.start.toInstant, did.dailyProgramType) shouldEqual did
     }
   }
 
-  it should "be consistent re: .end and .fromSiteAndInstant" in {
+  test("Daily should be consistent re: .end and .fromSiteAndInstant") {
     forAll { (did: Daily) =>
       Daily.fromSiteAndInstant(did.site, did.end.toInstant, did.dailyProgramType) shouldEqual did
     }
   }
 
-  it should "have a consistent program type and daily program type" in {
+  test("Daily should have a consistent program type and daily program type") {
     forAll { (did: Daily) =>
       did.dailyProgramType.toProgramType shouldEqual did.programType
     }
   }
 
-  it should "have a consistent date and semester" in {
+  test("Daily should have a consistent date and semester") {
     forAll { (did: Daily) =>
       Semester.fromLocalDate(did.localDate) shouldEqual did.semester
     }
   }
 
-  "Nonstandard" should "reparse" in {
+  test("Nonstandard must reparse") {
     forAll { (nid: Nonstandard) =>
       Nonstandard.fromString(nid.format) shouldEqual Some(nid)
     }
   }
 
-  "ProgramId" should "reparse" in {
+  test("ProgramId must reparse") {
     forAll { (pid: ProgramId) =>
       ProgramId.fromString(pid.format) shouldEqual Some(pid)
     }

--- a/modules/core/src/test/scala/gem/SemesterSpec.scala
+++ b/modules/core/src/test/scala/gem/SemesterSpec.scala
@@ -4,40 +4,43 @@
 package gem
 
 import cats.{ Eq, Show }
+import cats.kernel.laws._
+import cats.tests.CatsSuite
 import gem.arb._
-import gem.imp.TimeInstances._
 import gem.enum.{ Half, Site }
+import gem.imp.TimeInstances._
 import java.time.{ Year, ZoneId }
 import java.time.format.DateTimeFormatter
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class SemesterSpec extends FlatSpec with Matchers with PropertyChecks {
+final class SemesterSpec extends CatsSuite {
   import ArbEnumerated._
   import ArbSemester._
   import ArbTime._
 
-  "Equality" must "be natural" in {
+  // Laws
+  checkAll("Semester", OrderLaws[Semester].order)
+
+  test("Equality must be natural") {
     forAll { (a: Semester, b: Semester) =>
       a.equals(b) shouldEqual Eq[Semester].eqv(a, b)
     }
   }
 
-  it must "operate pairwise" in {
+  test("Equality must operate pairwise") {
     forAll { (a: Semester, b: Semester) =>
       Eq[Year].eqv(a.year, b.year) &&
       Eq[Half].eqv(a.half, b.half) shouldEqual Eq[Semester].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Semester) =>
       a.toString shouldEqual Show[Semester].show(a)
     }
   }
 
-  ".fromString" should "be invertible via .format" in {
+  test(".fromString must be invertible via .format") {
     forAll { (y: Year, h: Half) =>
       val yʹ = DateTimeFormatter.ofPattern("yyyy").format(y)
       val hʹ = h.tag
@@ -46,7 +49,7 @@ class SemesterSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  ".unsafeFromString" should "be invertible via .format" in {
+  test(".unsafeFromString must be invertible via .format") {
     forAll { (y: Year, h: Half) =>
       val yʹ = DateTimeFormatter.ofPattern("yyyy").format(y)
       val hʹ = h.tag
@@ -55,19 +58,19 @@ class SemesterSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  ".format" should "be invertible via .fromString" in {
+  test(".format must be invertible via .fromString") {
     forAll { (s: Semester) =>
       Semester.fromString(s.format) shouldEqual Some(s)
     }
   }
 
-  it should "also be invertible via .unsafeFromString" in {
+  test(".format should also be invertible via .unsafeFromString") {
     forAll { (s: Semester) =>
       Semester.unsafeFromString(s.format) shouldEqual s
     }
   }
 
-  ".plusYears" should "result in a properly updated year" in {
+  test(".plusYears must result in a properly updated year") {
     forAll { (s: Semester, n: Short) =>
       val nʹ = n.toInt
       val sʹ = s.plusYears(nʹ)
@@ -75,7 +78,7 @@ class SemesterSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  it should "never affect the half" in {
+  test(".plusYears should never affect the half") {
     forAll { (s: Semester, n: Short) =>
       val nʹ = n.toInt
       val sʹ = s.plusYears(nʹ)
@@ -83,27 +86,27 @@ class SemesterSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  it should "have an identity" in {
+  test(".plusYears should have an identity") {
     forAll { (s: Semester) =>
       s.plusYears(0) shouldEqual s
     }
   }
 
-  it should "be invertible by negation, for reasonable values" in {
+  test(".plusYears should be invertible by negation, for reasonable values") {
     forAll { (s: Semester, n: Short) =>
       val nʹ = n.toInt
       s.plusYears(nʹ).plusYears(-nʹ) shouldEqual s
     }
   }
 
-  it should "be a homomorphism over addition, for reasonable values" in {
+  test(".plusYears should be a homomorphism over addition, for reasonable values") {
     forAll { (s: Semester, n1: Short, n2: Short) =>
       val (n1ʹ, n2ʹ) = (n1.toInt, n2.toInt)
       s.plusYears(n1ʹ).plusYears(n2ʹ) shouldEqual s.plusYears(n1ʹ + n2ʹ)
     }
   }
 
-  ".plusSemesters" should "be consistent with .plusYears, for reasonable values" in {
+  test(".plusSemesters must be consistent with .plusYears, for reasonable values") {
     forAll { (s: Semester, n: Byte, b: Boolean) =>
       val nʹ = n.toInt
       val bʹ = if (b) nʹ.signum else 0
@@ -113,141 +116,141 @@ class SemesterSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  it should "have an identity" in {
+  test(".plusSemesters should have an identity") {
     forAll { (s: Semester) =>
       s.plusSemesters(0) shouldEqual s
     }
   }
 
-  it should "be invertible by negation, for reasonable values" in {
+  test(".plusSemesters should be invertible by negation, for reasonable values") {
     forAll { (s: Semester, n: Byte) =>
       val nʹ = n.toInt
       s.plusSemesters(nʹ).plusSemesters(-nʹ) shouldEqual s
     }
   }
 
-  it should "be a homomorphism over addition, for reasonable values" in {
+  test(".plusSemesters should be a homomorphism over addition, for reasonable values") {
     forAll { (s: Semester, n1: Byte, n2: Byte) =>
       val (n1ʹ, n2ʹ) = (n1.toInt, n2.toInt)
       s.plusSemesters(n1ʹ).plusSemesters(n2ʹ) shouldEqual s.plusSemesters(n1ʹ + n2ʹ)
     }
   }
 
-  ".start round-tripping" should "be consistent for .yearMonth     ~ .fromYearMonth" in {
+  test(".start round-tripping must be consistent for .yearMonth     ~ .fromYearMonth") {
     forAll { (s: Semester) =>
       Semester.fromYearMonth(s.start.yearMonth) shouldEqual s
     }
   }
 
-  it should "be consistent for .localDate     ~ .fromLocalDate" in {
+  test(".start should be consistent for .localDate     ~ .fromLocalDate") {
     forAll { (s: Semester) =>
       Semester.fromLocalDate(s.start.localDate) shouldEqual s
     }
   }
 
-  it should "be consistent for .localDateTime ~ .fromLocalDateTime" in {
+  test(".start should be consistent for .localDateTime ~ .fromLocalDateTime") {
     forAll { (s: Semester) =>
       Semester.fromLocalDateTime(s.start.localDateTime) shouldEqual s
     }
   }
 
-  it should "be consistent for .zonedDateTime ~ .fromZonedDateTime" in {
+  test(".start should be consistent for .zonedDateTime ~ .fromZonedDateTime") {
     forAll { (s: Semester, z: ZoneId) =>
       Semester.fromZonedDateTime(s.start.zonedDateTime(z)) shouldEqual s
     }
   }
 
-  it should "be consistent for .atSite        ~ .fromSiteAndInstant" in {
+  test(".start should be consistent for .atSite        ~ .fromSiteAndInstant") {
     forAll { (s: Semester, site: Site) =>
       Semester.fromSiteAndInstant(site, s.start.atSite(site).toInstant) shouldEqual s
     }
   }
 
-  ".start precisiom" should "be correct for .yearMonth" in {
+  test(".start precision must be correct for .yearMonth") {
     forAll { (s: Semester) =>
       Semester.fromYearMonth(s.start.yearMonth.minusMonths(1)) shouldEqual s.prev
     }
   }
 
-  it should "be correct for .localDate" in {
+  test(".start should be correct for .localDate") {
     forAll { (s: Semester) =>
       Semester.fromLocalDate(s.start.localDate.minusDays(1)) shouldEqual s.prev
     }
   }
 
-  it should "be correct for .localDateTime" in {
+  test(".start should be correct for .localDateTime") {
     forAll { (s: Semester) =>
       Semester.fromLocalDateTime(s.start.localDateTime.minusNanos(1)) shouldEqual s.prev
     }
   }
 
-  it should "be correct for .zonedDateTime" in {
+  test(".start should be correct for .zonedDateTime") {
     forAll { (s: Semester, z: ZoneId) =>
       Semester.fromZonedDateTime(s.start.zonedDateTime(z).minusNanos(1)) shouldEqual s.prev
     }
   }
 
-  it should "be correct for .atSite" in {
+  test(".start should be correct for .atSite") {
     forAll { (s: Semester, site: Site) =>
       Semester.fromSiteAndInstant(site, s.start.atSite(site).minusNanos(1).toInstant) shouldEqual s.prev
     }
   }
 
-  ".end round-tripping" should "be consistent for .yearMonth     ~ .fromYearMonth" in {
+  test(".end round-tripping must be consistent for .yearMonth     ~ .fromYearMonth") {
     forAll { (s: Semester) =>
       Semester.fromYearMonth(s.end.yearMonth) shouldEqual s
     }
   }
 
-  it should "be consistent for .localDate     ~ .fromLocalDate" in {
+  test(".end should be consistent for .localDate     ~ .fromLocalDate") {
     forAll { (s: Semester) =>
       Semester.fromLocalDate(s.end.localDate) shouldEqual s
     }
   }
 
-  it should "be consistent for .localDateTime ~ .fromLocalDateTime" in {
+  test(".end should be consistent for .localDateTime ~ .fromLocalDateTime") {
     forAll { (s: Semester) =>
       Semester.fromLocalDateTime(s.end.localDateTime) shouldEqual s
     }
   }
 
-  it should "be consistent for .zonedDateTime ~ .fromZonedDateTime" in {
+  test(".end should be consistent for .zonedDateTime ~ .fromZonedDateTime") {
     forAll { (s: Semester, z: ZoneId) =>
       Semester.fromZonedDateTime(s.end.zonedDateTime(z)) shouldEqual s
     }
   }
 
-  it should "be consistent for .atSite        ~ .fromSiteAndInstant" in {
+  test(".end should be consistent for .atSite        ~ .fromSiteAndInstant") {
     forAll { (s: Semester, site: Site) =>
       Semester.fromSiteAndInstant(site, s.end.atSite(site).toInstant) shouldEqual s
     }
   }
 
-  ".end precisiom" should "be correct for .yearMonth" in {
+  test(".end precisiom must be correct for .yearMonth") {
     forAll { (s: Semester) =>
       Semester.fromYearMonth(s.end.yearMonth.plusMonths(1)) shouldEqual s.next
     }
   }
 
-  it should "be correct for .localDate" in {
+  test(".end should be correct for .localDate") {
     forAll { (s: Semester) =>
       Semester.fromLocalDate(s.end.localDate.plusDays(1)) shouldEqual s.next
     }
   }
 
-  it should "be correct for .localDateTime" in {
+  test(".end should be correct for .localDateTime") {
     forAll { (s: Semester) =>
       Semester.fromLocalDateTime(s.end.localDateTime.plusNanos(1)) shouldEqual s.next
     }
   }
 
-  it should "be correct for .zonedDateTime" in {
+  test(".end should be correct for .zonedDateTime") {
     forAll { (s: Semester, z: ZoneId) =>
       Semester.fromZonedDateTime(s.end.zonedDateTime(z).plusNanos(1)) shouldEqual s.next
     }
   }
 
-  it should "be correct for .atSite" in {
+  test(".end should be correct for .atSite") {
     forAll { (s: Semester, site: Site) =>
       Semester.fromSiteAndInstant(site, s.end.atSite(site).plusNanos(1).toInstant) shouldEqual s.next
     }

--- a/modules/core/src/test/scala/gem/arb/Angle.scala
+++ b/modules/core/src/test/scala/gem/arb/Angle.scala
@@ -7,6 +7,7 @@ package arb
 import gem.math.{ Angle, HourAngle }
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
 
 trait ArbAngle {
 
@@ -15,6 +16,12 @@ trait ArbAngle {
 
   implicit def arbHourAngle: Arbitrary[HourAngle] =
     Arbitrary(arbitrary[Double].map(HourAngle.fromDoubleHours))
+
+  implicit def cogAngle: Cogen[Angle] =
+    Cogen[Double].contramap(_.toDoubleDegrees)
+
+  implicit def cogHourAngle: Cogen[HourAngle] =
+    Cogen[Double].contramap(_.toDoubleDegrees)
 
 }
 object ArbAngle extends ArbAngle

--- a/modules/core/src/test/scala/gem/arb/Coordinates.scala
+++ b/modules/core/src/test/scala/gem/arb/Coordinates.scala
@@ -7,6 +7,7 @@ package arb
 import gem.math.{ RightAscension, Declination, Coordinates }
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
 
 trait ArbCoordinates {
   import ArbRightAscension._
@@ -19,6 +20,9 @@ trait ArbCoordinates {
         dec <- arbitrary[Declination]
       } yield Coordinates(ra, dec)
     }
+
+  implicit val cogCoordinates: Cogen[Coordinates] =
+    Cogen[(RightAscension, Declination)].contramap(cs => (cs.ra, cs.dec))
 
 }
 object ArbCoordinates extends ArbCoordinates

--- a/modules/core/src/test/scala/gem/arb/Dataset.scala
+++ b/modules/core/src/test/scala/gem/arb/Dataset.scala
@@ -21,7 +21,7 @@ trait ArbDataset {
       } yield Dataset.Label(oid, idx)
     }
 
-  implicit val adbDataset: Arbitrary[Dataset] =
+  implicit val arbDataset: Arbitrary[Dataset] =
     Arbitrary {
       for {
         lab <- arbitrary[Dataset.Label]
@@ -29,6 +29,12 @@ trait ArbDataset {
         ts  <- arbitrary[Instant]
       } yield Dataset(lab, fn, ts)
     }
+
+  implicit val cogLabel: Cogen[Dataset.Label] =
+    Cogen[(Observation.Id, Int)].contramap(l => (l.observationId, l.index))
+
+  implicit val cogDataset: Cogen[Dataset] =
+    Cogen[(Dataset.Label, String, Instant)].contramap(ds => (ds.label, ds.filename, ds.timestamp))
 
 }
 object ArbDataset extends ArbDataset

--- a/modules/core/src/test/scala/gem/arb/Declination.scala
+++ b/modules/core/src/test/scala/gem/arb/Declination.scala
@@ -7,12 +7,16 @@ package arb
 import gem.math.{ Angle, Declination }
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
 
 trait ArbDeclination {
   import ArbAngle._
 
   implicit val arbDeclination: Arbitrary[Declination] =
     Arbitrary(arbitrary[Angle].map(Declination.fromAngleWithCarry(_)._1))
+
+  implicit val cogDeclination: Cogen[Declination] =
+    Cogen[Angle].contramap(_.toAngle)
 
 }
 object ArbDeclination extends ArbDeclination

--- a/modules/core/src/test/scala/gem/arb/Enumerated.scala
+++ b/modules/core/src/test/scala/gem/arb/Enumerated.scala
@@ -12,5 +12,8 @@ trait ArbEnumerated {
   implicit def arbEnumerated[A](implicit en: Enumerated[A]): Arbitrary[A] =
     Arbitrary(oneOf(en.all))
 
+  implicit def cogEnumerated[A](implicit en: Enumerated[A]): Cogen[A] =
+    Cogen[String].contramap(en.tag)
+
 }
 object ArbEnumerated extends ArbEnumerated

--- a/modules/core/src/test/scala/gem/arb/Observation.scala
+++ b/modules/core/src/test/scala/gem/arb/Observation.scala
@@ -19,5 +19,8 @@ trait ArbObservation {
       } yield Observation.Id(pid, num)
     }
 
+  implicit val cogObservationId: Cogen[Observation.Id] =
+    Cogen[(ProgramId, Int)].contramap(oid => (oid.pid, oid.index))
+
 }
 object ArbObservation extends ArbObservation

--- a/modules/core/src/test/scala/gem/arb/Offset.scala
+++ b/modules/core/src/test/scala/gem/arb/Offset.scala
@@ -7,8 +7,11 @@ package arb
 import gem.math.{ Angle, Offset }
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
 
 trait ArbOffset {
+  import ArbAngle._
+
   implicit val arbOffsetP: Arbitrary[Offset.P] =
     Arbitrary(
       Gen.chooseNum(0, 10000).map(mas => Offset.P(Angle.fromMilliarcseconds(mas)))
@@ -26,6 +29,15 @@ trait ArbOffset {
         q <- arbitrary[Offset.Q]
       } yield Offset(p, q)
     }
+
+  implicit val cogOffsetP: Cogen[Offset.P] =
+    Cogen[Angle].contramap(_.toAngle)
+
+  implicit val cogOffsetQ: Cogen[Offset.Q] =
+    Cogen[Angle].contramap(_.toAngle)
+
+  implicit val cogOffset: Cogen[Offset] =
+    Cogen[(Offset.P, Offset.Q)].contramap(o => (o.p, o.q))
 
 }
 object ArbOffset extends ArbOffset

--- a/modules/core/src/test/scala/gem/arb/ProgramId.scala
+++ b/modules/core/src/test/scala/gem/arb/ProgramId.scala
@@ -62,5 +62,8 @@ trait ArbProgramId {
       )
     }
 
+  implicit val cogProgramId: Cogen[ProgramId] =
+    Cogen[String].contramap(_.format)
+
 }
 object ArbProgramId extends ArbProgramId

--- a/modules/core/src/test/scala/gem/arb/RightAscension.scala
+++ b/modules/core/src/test/scala/gem/arb/RightAscension.scala
@@ -7,12 +7,16 @@ package arb
 import gem.math.{ HourAngle, RightAscension }
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
 
 trait ArbRightAscension {
   import ArbAngle._
 
   implicit val arbRightAscension: Arbitrary[RightAscension] =
     Arbitrary(arbitrary[HourAngle].map(RightAscension.fromHourAngle))
+
+  implicit val cogRightAscension: Cogen[RightAscension] =
+    Cogen[HourAngle].contramap(_.toHourAngle)
 
 }
 object ArbRightAscension extends ArbRightAscension

--- a/modules/core/src/test/scala/gem/arb/Semester.scala
+++ b/modules/core/src/test/scala/gem/arb/Semester.scala
@@ -21,5 +21,8 @@ trait ArbSemester {
       } yield Semester(year, half)
     }
 
+  implicit val cogSemester: Cogen[Semester] =
+    Cogen[(Year, Half)].contramap(s => (s.year, s.half))
+
 }
 object ArbSemester extends ArbSemester

--- a/modules/core/src/test/scala/gem/arb/Time.scala
+++ b/modules/core/src/test/scala/gem/arb/Time.scala
@@ -60,5 +60,8 @@ trait ArbTime {
   implicit val arbInstant: Arbitrary[Instant] =
     Arbitrary(arbitrary[ZonedDateTime].map(_.toInstant))
 
+  implicit val cogInstant: Cogen[Instant] =
+    Cogen[(Long, Int)].contramap(t => (t.getEpochSecond, t.getNano))
+
 }
 object ArbTime extends ArbTime

--- a/modules/core/src/test/scala/gem/arb/Time.scala
+++ b/modules/core/src/test/scala/gem/arb/Time.scala
@@ -63,5 +63,8 @@ trait ArbTime {
   implicit val cogInstant: Cogen[Instant] =
     Cogen[(Long, Int)].contramap(t => (t.getEpochSecond, t.getNano))
 
+  implicit val cogYear: Cogen[Year] =
+    Cogen[Int].contramap(_.getValue)
+
 }
 object ArbTime extends ArbTime

--- a/modules/core/src/test/scala/gem/arb/Wavelength.scala
+++ b/modules/core/src/test/scala/gem/arb/Wavelength.scala
@@ -7,11 +7,15 @@ package arb
 import gem.math.Wavelength
 import org.scalacheck._
 import org.scalacheck.Gen._
+import org.scalacheck.Cogen._
 
 trait ArbWavelength {
 
-  implicit def arbWavelength: Arbitrary[Wavelength] =
+  implicit val arbWavelength: Arbitrary[Wavelength] =
     Arbitrary(choose(0, Int.MaxValue).map(Wavelength.unsafeFromAngstroms(_)))
+
+  implicit val cogWavelength: Cogen[Wavelength] =
+    Cogen[Int].contramap(_.toAngstroms)
 
 }
 object ArbWavelength extends ArbWavelength

--- a/modules/core/src/test/scala/gem/math/DeclinationSpec.scala
+++ b/modules/core/src/test/scala/gem/math/DeclinationSpec.scala
@@ -3,43 +3,45 @@
 
 package gem.math
 
+import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.implicits._
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class DeclinationSpec extends FlatSpec with Matchers with PropertyChecks {
+final class DeclinationSpec extends CatsSuite {
   import ArbDeclination._
   import ArbAngle._
 
-  "Equality" must "be natural" in {
+  // Laws
+  checkAll("Declination", OrderLaws[Declination].order)
+
+  test("Equality must be natural") {
     forAll { (a: Declination, b: Declination) =>
       a.equals(b) shouldEqual Eq[Declination].eqv(a, b)
     }
   }
 
-  "Eq" must "be consistent with .toAngle.toMicroarcseconds" in {
+  test("Eq must be consistent with .toAngle.toMicroarcseconds") {
     forAll { (a: Declination, b: Declination) =>
       Eq[Long].eqv(a.toAngle.toMicroarcseconds, b.toAngle.toMicroarcseconds) shouldEqual
       Eq[Declination].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Declination) =>
       a.toString shouldEqual Show[Declination].show(a)
     }
   }
 
-  "Conversion to Angle" must "be invertable" in {
+  test("Conversion to Angle must be invertable") {
     forAll { (a: Declination) =>
       Declination.unsafeFromAngle(a.toAngle) shouldEqual a
     }
   }
 
-  "Construction" must "be consistent between fromAngle and fromAngleWithCarry" in {
+  test("Construction must be consistent between fromAngle and fromAngleWithCarry") {
     forAll { (a: Angle) =>
       (Declination.fromAngle(a), Declination.fromAngleWithCarry(a)) match {
         case (Some(d), (dʹ, false)) => d shouldEqual dʹ
@@ -49,13 +51,13 @@ class DeclinationSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  "Offsetting" must "have an identity" in {
+  test("Offsetting must have an identity") {
     forAll { (a: Declination) =>
       a.offset(Angle.Angle0).shouldEqual((a, false))
     }
   }
 
-  it must "be invertible" in {
+  test("Offsetting must be invertible") {
     forAll { (a: Declination, b: Angle) =>
       a.offset(b) match {
         case (aʹ, false) => aʹ.offset(-b).shouldEqual((a, false))

--- a/modules/core/src/test/scala/gem/math/HourAngleSpec.scala
+++ b/modules/core/src/test/scala/gem/math/HourAngleSpec.scala
@@ -3,41 +3,39 @@
 
 package gem.math
 
-import cats.{ Eq, Monoid, Show }
-import cats.implicits._
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class HourAngleSpec extends FlatSpec with Matchers with PropertyChecks {
+final class HourAngleSpec extends CatsSuite {
   import ArbAngle._
 
-  // Compilation test
-  protected val a0 = implicitly[Monoid[HourAngle]]
-  protected val a1 = implicitly[Eq[HourAngle]]
-  protected val a2 = implicitly[Show[HourAngle]]
+  // Laws
+  checkAll("HourAngle", GroupLaws[HourAngle].commutativeGroup)
+  checkAll("HourAngle", OrderLaws[HourAngle].eqv)
 
-  "Equality" must "be natural" in {
+  test("Equality must be natural") {
     forAll { (a: HourAngle, b: HourAngle) =>
       a.equals(b) shouldEqual Eq[HourAngle].eqv(a, b)
     }
   }
 
-  it must "be consistent with .toMicroseconds" in {
+  test("Equality must be consistent with .toMicroseconds") {
     forAll { (a: HourAngle, b: HourAngle) =>
       Eq[Long].eqv(a.toMicroseconds, b.toMicroseconds) shouldEqual
       Eq[HourAngle].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: HourAngle) =>
       a.toString shouldEqual Show[HourAngle].show(a)
     }
   }
 
-  "Conversion to HMS" must "be invertable" in {
+  test("Conversion to HMS must be invertable") {
     forAll { (a: HourAngle) =>
       val hms = a.toHMS
       HourAngle.fromHMS(
@@ -50,55 +48,25 @@ class HourAngleSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  "Widening to Angle" must "be invertable" in {
+  test("Widening to Angle must be invertable") {
     forAll { (a: HourAngle) =>
       a.toAngle.toHourAngle shouldEqual a
     }
   }
 
-  it must "also work for toHourAngleExact" in {
+  test("Widening to Angle must also work for toHourAngleExact") {
     forAll { (a: HourAngle) =>
       a.toAngle.toHourAngleExact shouldEqual Some(a)
     }
   }
 
-  "Flipping" must "be invertable" in {
+  test("Flipping must be invertable") {
     forAll { (a: HourAngle) =>
       a.flip.flip shouldEqual a
     }
   }
 
-  "HourAngle forms an Abelian Group over addition. It" must "be associative" in {
-    forAll { (a: HourAngle, b: HourAngle, c: HourAngle) =>
-      (a + b) + c shouldEqual a + (b + c)
-    }
-  }
-
-  it must "be commutative" in {
-    forAll { (a: HourAngle, b: HourAngle) =>
-      a + b shouldEqual b + a
-    }
-  }
-
-  it must "have a left identity" in {
-    forAll { (a: HourAngle) =>
-      a + HourAngle.HourAngle0 shouldEqual a
-    }
-  }
-
-  it must "have a right identity" in {
-    forAll { (a: HourAngle) =>
-      HourAngle.HourAngle0 + a shouldEqual a
-    }
-  }
-
-  it must "have an inverse" in {
-    forAll { (a: HourAngle) =>
-      a + (-a) shouldEqual HourAngle.HourAngle0
-    }
-  }
-
-  "Construction" must "normalize [non-pathological] angles" in {
+  test("Construction must normalize [non-pathological] angles") {
     forAll { (a: HourAngle, n: Int) =>
       val factor   = n % 10
       val msIn24 = 24L * 60L * 60L * 1000L * 1000L

--- a/modules/core/src/test/scala/gem/math/OffsetPSpec.scala
+++ b/modules/core/src/test/scala/gem/math/OffsetPSpec.scala
@@ -3,71 +3,40 @@
 
 package gem.math
 
-import cats.{ Eq, Show, Monoid }
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class OffsetPSpec extends FlatSpec with Matchers with PropertyChecks {
+final class OffsetPSpec extends CatsSuite {
   import ArbOffset._
 
-  // Compilation test
-  protected val a0 = implicitly[Monoid[Offset.P]]
-  protected val a1 = implicitly[Show[Offset.P]]
-  protected val a2 = implicitly[Eq[Offset.P]]
+  // Laws
+  checkAll("Offset.P", GroupLaws[Offset.P].commutativeGroup)
+  checkAll("Offset.P", OrderLaws[Offset.P].eqv)
 
-  "Equality" must "be natural" in {
+  test("Equality must be natural") {
     forAll { (a: Offset.P, b: Offset.P) =>
       a.equals(b) shouldEqual Eq[Offset.P].eqv(a, b)
     }
   }
 
-  it must "be consistent with .toAngle" in {
+  test("Equality be consistent with .toAngle") {
     forAll { (a: Offset.P, b: Offset.P) =>
       Eq[Angle].eqv(a.toAngle, b.toAngle) shouldEqual Eq[Offset.P].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Offset.P) =>
       a.toString shouldEqual Show[Offset.P].show(a)
     }
   }
 
-  "Conversion to angle" must "be invertable" in {
+  test("Conversion to angle must be invertable") {
     forAll { (p: Offset.P) =>
       Offset.P(p.toAngle) shouldEqual p
-    }
-  }
-
-  "Offset.P forms an Abelian Group over addition. It" must "be associative" in {
-    forAll { (p: Offset.P, b: Offset.P, c: Offset.P) =>
-      (p + b) + c shouldEqual p + (b + c)
-    }
-  }
-
-  it must "be commutative" in {
-    forAll { (p: Offset.P, b: Offset.P) =>
-      p + b shouldEqual b + p
-    }
-  }
-
-  it must "have a left identity" in {
-    forAll { (p: Offset.P) =>
-      p + Offset.P.Zero shouldEqual p
-    }
-  }
-
-  it must "have a right identity" in {
-    forAll { (p: Offset.P) =>
-      Offset.P.Zero + p shouldEqual p
-    }
-  }
-
-  it must "have an inverse" in {
-    forAll { (p: Offset.P) =>
-      p + (-p) shouldEqual Offset.P.Zero
     }
   }
 

--- a/modules/core/src/test/scala/gem/math/OffsetQSpec.scala
+++ b/modules/core/src/test/scala/gem/math/OffsetQSpec.scala
@@ -3,71 +3,40 @@
 
 package gem.math
 
-import cats.{ Eq, Show, Monoid }
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class OffsetQSpec extends FlatSpec with Matchers with PropertyChecks {
+final class OffsetQSpec extends CatsSuite {
   import ArbOffset._
 
-  // Compilation test
-  protected val a0 = implicitly[Monoid[Offset.Q]]
-  protected val a1 = implicitly[Show[Offset.Q]]
-  protected val a2 = implicitly[Eq[Offset.Q]]
+  // Laws
+  checkAll("Offset.Q", GroupLaws[Offset.Q].commutativeGroup)
+  checkAll("Offset.Q", OrderLaws[Offset.Q].eqv)
 
-  "Equality" must "be natural" in {
+  test("Equality must be natural") {
     forAll { (a: Offset.Q, b: Offset.Q) =>
       a.equals(b) shouldEqual Eq[Offset.Q].eqv(a, b)
     }
   }
 
-  it must "be consistent with .toAngle" in {
+  test("Equality be consistent with .toAngle") {
     forAll { (a: Offset.Q, b: Offset.Q) =>
       Eq[Angle].eqv(a.toAngle, b.toAngle) shouldEqual Eq[Offset.Q].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Offset.Q) =>
       a.toString shouldEqual Show[Offset.Q].show(a)
     }
   }
 
-  "Conversion to angle" must "be invertable" in {
-    forAll { (q: Offset.Q) =>
-      Offset.Q(q.toAngle) shouldEqual q
-    }
-  }
-
-  "Offset.Q forms an Abelian Group over addition. It" must "be associative" in {
-    forAll { (q: Offset.Q, b: Offset.Q, c: Offset.Q) =>
-      (q + b) + c shouldEqual q + (b + c)
-    }
-  }
-
-  it must "be commutative" in {
-    forAll { (q: Offset.Q, b: Offset.Q) =>
-      q + b shouldEqual b + q
-    }
-  }
-
-  it must "have a left identity" in {
-    forAll { (q: Offset.Q) =>
-      q + Offset.Q.Zero shouldEqual q
-    }
-  }
-
-  it must "have a right identity" in {
-    forAll { (q: Offset.Q) =>
-      Offset.Q.Zero + q shouldEqual q
-    }
-  }
-
-  it must "have an inverse" in {
-    forAll { (q: Offset.Q) =>
-      q + (-q) shouldEqual Offset.Q.Zero
+  test("Conversion to angle must be invertable") {
+    forAll { (p: Offset.Q) =>
+      Offset.Q(p.toAngle) shouldEqual p
     }
   }
 

--- a/modules/core/src/test/scala/gem/math/OffsetSpec.scala
+++ b/modules/core/src/test/scala/gem/math/OffsetSpec.scala
@@ -3,73 +3,42 @@
 
 package gem.math
 
-import cats.{ Eq, Show, Monoid }
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class OffsetSpec extends FlatSpec with Matchers with PropertyChecks {
+final class OffsetSpec extends CatsSuite {
   import ArbOffset._
 
-  // Compilation test
-  protected val a0 = implicitly[Monoid[Offset]]
-  protected val a1 = implicitly[Show[Offset]]
-  protected val a2 = implicitly[Eq[Offset]]
+  // Laws
+  checkAll("Offset", GroupLaws[Offset].commutativeGroup)
+  checkAll("Offset", OrderLaws[Offset].eqv)
 
-  "Equality" must "be natural" in {
+  test("Equality must be natural") {
     forAll { (a: Offset, b: Offset) =>
       a.equals(b) shouldEqual Eq[Offset].eqv(a, b)
     }
   }
 
-  it must "operate pairwise" in {
+  test("it must operate pairwise") {
     forAll { (a: Offset, b: Offset) =>
       Eq[Offset.P].eqv(a.p, b.p) &&
       Eq[Offset.Q].eqv(a.q, b.q) shouldEqual Eq[Offset].eqv(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Offset) =>
       a.toString shouldEqual Show[Offset].show(a)
     }
   }
 
-  "Conversion to components" must "be invertable" in {
+  test("Conversion to components must be invertable") {
     forAll { (o: Offset) =>
       val (p, q) = (o.p, o.q)
       Offset(p, q) shouldEqual o
-    }
-  }
-
-  "Offset forms an Abelian Group over addition. It" must "be associative" in {
-    forAll { (o: Offset, b: Offset, c: Offset) =>
-      (o + b) + c shouldEqual o + (b + c)
-    }
-  }
-
-  it must "be commutative" in {
-    forAll { (o: Offset, b: Offset) =>
-      o + b shouldEqual b + o
-    }
-  }
-
-  it must "have a left identity" in {
-    forAll { (o: Offset) =>
-      o + Offset.Zero shouldEqual o
-    }
-  }
-
-  it must "have a right identity" in {
-    forAll { (o: Offset) =>
-      Offset.Zero + o shouldEqual o
-    }
-  }
-
-  it must "have an inverse" in {
-    forAll { (o: Offset) =>
-      o + (-o) shouldEqual Offset.Zero
     }
   }
 

--- a/modules/core/src/test/scala/gem/math/RightAscensionSpec.scala
+++ b/modules/core/src/test/scala/gem/math/RightAscensionSpec.scala
@@ -3,36 +3,38 @@
 
 package gem.math
 
-import cats.{ Eq, Order, Show }
-import cats.implicits._
+import cats.tests.CatsSuite
+import cats.{ Eq, Show, Order }
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class RightAscensionSpec extends FlatSpec with Matchers with PropertyChecks {
+final class RightAscensionSpec extends CatsSuite {
   import ArbRightAscension._
 
-  "Equality" must "be natural" in {
+  // Laws
+  checkAll("RightAscension", OrderLaws[RightAscension].order)
+
+  test("Equality must be natural") {
     forAll { (a: RightAscension, b: RightAscension) =>
       a.equals(b) shouldEqual Eq[RightAscension].eqv(a, b)
     }
   }
 
-  "Order" must "be consistent with .toHourAngle.toMicroarcseconds" in {
+  test("Order must be consistent with .toHourAngle.toMicroarcseconds") {
     forAll { (a: RightAscension, b: RightAscension) =>
       Order[Long].comparison(a.toHourAngle.toMicroarcseconds, b.toHourAngle.toMicroarcseconds) shouldEqual
       Order[RightAscension].comparison(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: RightAscension) =>
       a.toString shouldEqual Show[RightAscension].show(a)
     }
   }
 
-  "Conversion to HourAngle" must "be invertable" in {
+  test("Conversion to HourAngle must be invertable") {
     forAll { (a: RightAscension) =>
       RightAscension.fromHourAngle(a.toHourAngle) shouldEqual a
     }

--- a/modules/core/src/test/scala/gem/math/WavelengthSpec.scala
+++ b/modules/core/src/test/scala/gem/math/WavelengthSpec.scala
@@ -3,42 +3,44 @@
 
 package gem.math
 
-import cats.{ Eq, Order, Show }
-import cats.implicits._
+import cats.tests.CatsSuite
+import cats.{ Eq, Show, Order }
+import cats.kernel.laws._
 import gem.arb._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ FlatSpec, Matchers }
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
-class WavelengthSpec extends FlatSpec with Matchers with PropertyChecks {
+final class WavelengthSpec extends CatsSuite {
   import ArbWavelength._
 
-  "Equality" must "be natural" in {
+  // Laws
+  checkAll("Wavelength", OrderLaws[Wavelength].eqv)
+
+  test("Equality must be natural") {
     forAll { (a: Wavelength, b: Wavelength) =>
       a.equals(b) shouldEqual Eq[Wavelength].eqv(a, b)
     }
   }
 
-  "Order" must "be consistent with .toAngstroms" in {
+  test("Order must be consistent with .toAngstroms") {
     forAll { (a: Wavelength, b: Wavelength) =>
       Order[Int].comparison(a.toAngstroms, b.toAngstroms) shouldEqual
       Order[Wavelength].comparison(a, b)
     }
   }
 
-  "Show" must "be natural" in {
+  test("Show must be natural") {
     forAll { (a: Wavelength) =>
       a.toString shouldEqual Show[Wavelength].show(a)
     }
   }
 
-  "Conversion to angstroms" must "be invertable" in {
+  test("Conversion to angstroms must be invertable") {
     forAll { (a: Wavelength) =>
       Wavelength.fromAngstroms(a.toAngstroms) shouldEqual Some(a)
     }
   }
 
-  "Construction from an arbitrary Int" must "not allow negative values" in {
+  test("Construction from an arbitrary Int must not allow negative values") {
     forAll { (n: Int) =>
       Wavelength.fromAngstroms(n).isDefined shouldEqual n >= 0
     }


### PR DESCRIPTION
This changes the `Angle` tests to use [`CatsSuite`](https://github.com/typelevel/cats/blob/6fefa30bfb85e90d193b53300b8313c4dd6c0201/testkit/src/main/scala/cats/tests/CatsSuite.scala), which provides some useful defaults and machinery, specifically for taking advantage of laws defined for cats typeclasses. The five cases in the Abelian group tests are now just

```scala
checkAll("Angle", GroupLaws[Angle].commutativeGroup)
```

This also makes gem consistent with testing in other Typelevel libs like http4s, which means there's one less thing to think about. I don't have strong feelings about it but it seems ok to me.

If this looks ok I will switch all the tests to use `CatsSuite`.
