### PR TITLE
combinators

### DIFF
--- a/modules/core/shared/src/main/scala/gem/parser/Misc.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Misc.scala
@@ -85,7 +85,7 @@ trait MiscParsers {
         case -1 => err[String]("not satisfied")
         case  n => take(n) <~ advance(1)
       }
-    } named "takeUntilʹ(…)"
+    } named "takeUntilLast(…)"
 
 }
 object MiscParsers extends MiscParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Misc.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Misc.scala
@@ -65,5 +65,27 @@ trait MiscParsers {
 
   } namedOpaque s"frac($n)"
 
+
+  /** Force and return all remaining input without consuming it. */
+  val force: Parser[String] =
+    get.flatMap { s =>
+      opt(ensure(s.length + 1)) flatMap {
+        case Some(_) => force
+        case None    => ok(s)
+      }
+    }
+
+  /**
+   * Force and examine remaining input and yield the longest prefix up to (but not including) a
+   * char satisfying `p`, which is discarded. Fails is no such char is found.
+   */
+  def takeUntilLast(p: Char => Boolean): Parser[String] =
+    force.flatMap { s =>
+      s.lastIndexWhere(p) match {
+        case -1 => err[String]("not satisfied")
+        case  n => take(n) <~ advance(1)
+      }
+    } named "takeUntilʹ(…)"
+
 }
 object MiscParsers extends MiscParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Misc.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Misc.scala
@@ -77,7 +77,7 @@ trait MiscParsers {
 
   /**
    * Force and examine remaining input and yield the longest prefix up to (but not including) a
-   * char satisfying `p`, which is discarded. Fails is no such char is found.
+   * char satisfying `p`, which is discarded. Fails if no such char is found.
    */
   def takeUntilLast(p: Char => Boolean): Parser[String] =
     force.flatMap { s =>


### PR DESCRIPTION
This adds `takeUntilLast` which I think does what @swalker2m was looking for.

```scala
scala> takeUntilLast(_ == 'x').parseOnly("abc")
res0: atto.ParseResult[String] = Fail(abc,List(takeUntilʹ(…)),not satisfied)
 
scala> takeUntilLast(_ == 'x').parseOnly("abcx")
res1: atto.ParseResult[String] = Done(,abc)
 
scala> takeUntilLast(_ == 'x').parseOnly("abcxdef")
res2: atto.ParseResult[String] = Done(def,abc)
 
scala> takeUntilLast(_ == 'x').parseOnly("abcxdefx")
res3: atto.ParseResult[String] = Done(,abcxdef)
 
scala> takeUntilLast(_ == 'x').parseOnly("abcxdefxyz")
res4: atto.ParseResult[String] = Done(yz,abcxdef)
 
scala> takeUntilLast(_ == 'x').parse("ab").feed("cxde").feed("fxyz").done
res5: atto.ParseResult[String] = Done(yz,abcxdef)
```

So you can get the paren bracketing with

```scala
scala> val parens = char('(') ~> takeUntilLast(_ == ')')
parens: atto.Parser[String] = ('(') ~> takeUntilʹ(…)
 
scala> parens.parseOnly("(ab(c)de)fh)hij")
res7: atto.ParseResult[String] = Done(hij,ab(c)de)fh)
```