### PR TITLE
Horizons Designation

### DIFF
--- a/modules/core/shared/src/main/scala/gem/HorizonsDesignation.scala
+++ b/modules/core/shared/src/main/scala/gem/HorizonsDesignation.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package gem.target
+package gem
 
 import gem.enum.HorizonsType
 import gem.parser.HorizonsDesignationParsers

--- a/modules/core/shared/src/main/scala/gem/enum/HorizonsType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/HorizonsType.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.syntax.eq._
+import cats.instances.string._
+
+/**
+ * Enumerated type for horizons non-sidereal target type.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class HorizonsType(
+  val tag: String,
+  val name: String
+)
+
+object HorizonsType {
+
+  /** @group Constructors */ case object Comet extends HorizonsType("Comet", "Comet")
+  /** @group Constructors */ case object AsteroidNew extends HorizonsType("AsteroidNew", "Asteroid New")
+  /** @group Constructors */ case object AsteroidOld extends HorizonsType("AsteroidOld", "Asteroid Old")
+  /** @group Constructors */ case object MajorBody extends HorizonsType("MajorBody", "Major Body")
+
+  /** All members of HorizonsType, in canonical order. */
+  val all: List[HorizonsType] =
+    List(Comet, AsteroidNew, AsteroidOld, MajorBody)
+
+  /** Select the member of HorizonsType with the given tag, if any. */
+  def fromTag(s: String): Option[HorizonsType] =
+    all.find(_.tag === s)
+
+  /** Select the member of HorizonsType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): HorizonsType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val HorizonsTypeEnumerated: Enumerated[HorizonsType] =
+    new Enumerated[HorizonsType] {
+      def all = HorizonsType.all
+      def tag(a: HorizonsType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/HorizonsType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/HorizonsType.scala
@@ -13,15 +13,16 @@ import cats.instances.string._
  */
 sealed abstract class HorizonsType(
   val tag: String,
-  val name: String
+  val shortName: String,
+  val longName: String
 )
 
 object HorizonsType {
 
-  /** @group Constructors */ case object Comet extends HorizonsType("Comet", "Comet")
-  /** @group Constructors */ case object AsteroidNew extends HorizonsType("AsteroidNew", "Asteroid New")
-  /** @group Constructors */ case object AsteroidOld extends HorizonsType("AsteroidOld", "Asteroid Old")
-  /** @group Constructors */ case object MajorBody extends HorizonsType("MajorBody", "Major Body")
+  /** @group Constructors */ case object Comet extends HorizonsType("Comet", "Comet", "Comet")
+  /** @group Constructors */ case object AsteroidNew extends HorizonsType("AsteroidNew", "Asteroid New", "Asteroid (New Format)")
+  /** @group Constructors */ case object AsteroidOld extends HorizonsType("AsteroidOld", "Asteroid Old", "Asteroid (Old Format)")
+  /** @group Constructors */ case object MajorBody extends HorizonsType("MajorBody", "Major Body", "Major Body")
 
   /** All members of HorizonsType, in canonical order. */
   val all: List[HorizonsType] =

--- a/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
@@ -1,10 +1,10 @@
 // Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package gem.parser
+package gem
+package parser
 
-import gem.target.HorizonsDesignation
-import gem.target.HorizonsDesignation._
+import HorizonsDesignation._
 
 import atto._, Atto._
 import cats.implicits._
@@ -30,14 +30,14 @@ trait HorizonsDesignationParsers {
   val asteroidOld: Parser[AsteroidOld] =
     numDes ("AsteroidOld")(AsteroidOld.apply) namedOpaque "asteroidOld"
 
-  val major: Parser[MajorBody] =
+  val majorBody: Parser[MajorBody] =
     numDes ("MajorBody"  )(MajorBody.apply  ) namedOpaque "majorBody"
 
   val horizonsDesignation: Parser[HorizonsDesignation] =
       (comet      .widen[HorizonsDesignation] |
        asteroidNew.widen[HorizonsDesignation] |
        asteroidOld.widen[HorizonsDesignation] |
-       major      .widen[HorizonsDesignation] ) named "horizonsDesignation"
+       majorBody  .widen[HorizonsDesignation] ) named "horizonsDesignation"
 
 }
 

--- a/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.parser
+
+import gem.target.HorizonsDesignation
+import gem.target.HorizonsDesignation._
+
+import atto._, Atto._
+import cats.implicits._
+
+/** Parser for [[gem.target.HorizonsDesignation]]. */
+trait HorizonsDesignationParsers {
+
+  private def des[A,B](s: String, p: Parser[A]): Parser[A] =
+    string(s"${s}_") ~> p
+
+  private def textDes[A](s: String)(f: String => A): Parser[A] =
+    des(s, takeText.map(f))
+
+  private def numDes[A](s: String)(f: Int => A): Parser[A] =
+    des(s, int.map(f))
+
+  val comet: Parser[Comet] =
+    textDes("Comet"      )(Comet.apply      ) namedOpaque "comet"
+
+  val asteroidNew: Parser[AsteroidNew] =
+    textDes("AsteroidNew")(AsteroidNew.apply) namedOpaque "asteroidNew"
+
+  val asteroidOld: Parser[AsteroidOld] =
+    numDes ("AsteroidOld")(AsteroidOld.apply) namedOpaque "asteroidOld"
+
+  val major: Parser[MajorBody] =
+    numDes ("MajorBody"  )(MajorBody.apply  ) namedOpaque "majorBody"
+
+  val horizonsDesignation: Parser[HorizonsDesignation] =
+      (comet      .widen[HorizonsDesignation] |
+       asteroidNew.widen[HorizonsDesignation] |
+       asteroidOld.widen[HorizonsDesignation] |
+       major      .widen[HorizonsDesignation] ) named "horizonsDesignation"
+
+}
+
+object HorizonsDesignationParsers extends HorizonsDesignationParsers

--- a/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
@@ -22,7 +22,7 @@ trait HorizonsDesignationParsers {
     des(s, int.map(f))
 
   val comet: Parser[Comet] =
-    textDes("Comet"      )(Comet.apply      ) namedOpaque "comet"
+    textDes("Comet")(Comet.apply) namedOpaque "comet"
 
   val asteroidNew: Parser[AsteroidNew] =
     textDes("AsteroidNew")(AsteroidNew.apply) namedOpaque "asteroidNew"
@@ -31,7 +31,7 @@ trait HorizonsDesignationParsers {
     numDes ("AsteroidOld")(AsteroidOld.apply) namedOpaque "asteroidOld"
 
   val majorBody: Parser[MajorBody] =
-    numDes ("MajorBody"  )(MajorBody.apply  ) namedOpaque "majorBody"
+    numDes ("MajorBody")(MajorBody.apply) namedOpaque "majorBody"
 
   val horizonsDesignation: Parser[HorizonsDesignation] =
       (comet      .widen[HorizonsDesignation] |

--- a/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/HorizonsDesignation.scala
@@ -12,7 +12,7 @@ import cats.implicits._
 /** Parser for [[gem.target.HorizonsDesignation]]. */
 trait HorizonsDesignationParsers {
 
-  private def des[A,B](s: String, p: Parser[A]): Parser[A] =
+  private def des[A](s: String, p: Parser[A]): Parser[A] =
     string(s"${s}_") ~> p
 
   private def textDes[A](s: String)(f: String => A): Parser[A] =

--- a/modules/core/shared/src/main/scala/gem/target/HorizonsDesignation.scala
+++ b/modules/core/shared/src/main/scala/gem/target/HorizonsDesignation.scala
@@ -1,0 +1,136 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.target
+
+import gem.enum.HorizonsType
+import gem.parser.HorizonsDesignationParsers
+import gem.syntax.parser._
+import gem.util.Lens
+import gem.util.Lens._
+
+import cats.{ Eq, Show }
+
+/**
+ * Unique Horizons designation, which should allow for reproducible ephemeris queries <b>if</b> the
+ * values passed to the constructors are extracted correctly from search results.
+ */
+sealed abstract class HorizonsDesignation(val queryString: String) extends Product with Serializable {
+
+  def des: String // designation, human readable
+
+  import HorizonsDesignation._
+
+  /** Extracts the horizons non-sidereal type from the designation.
+    */
+  def horizonsType: HorizonsType =
+    this match {
+      case Comet(_)       => HorizonsType.Comet
+      case AsteroidNew(_) => HorizonsType.AsteroidNew
+      case AsteroidOld(_) => HorizonsType.AsteroidOld
+      case MajorBody(_)   => HorizonsType.MajorBody
+    }
+
+  /** Exports an HorizonsDesignation to a String in a format that can be read
+    * by the `gem.parsers.HorizonsDesignationParsers` method.
+    */
+  def format: String =
+    s"${horizonsType.tag}_$des"
+}
+
+object HorizonsDesignation {
+
+  /**
+   * Designation for a comet, in the current apparition. Example: `C/1973 E1` for Kohoutek, yielding
+   * the query string `NAME=C/1973 E1;CAP`.
+   */
+  final case class Comet(des: String) extends HorizonsDesignation(s"NAME=$des;CAP")
+
+  object Comet {
+    val des: Comet @> String =
+      Lens((a, b) => a.copy(des = b), _.des)
+  }
+
+  sealed abstract class Asteroid(s: String) extends HorizonsDesignation(s)
+
+  /**
+   * Designation for an asteroid under modern naming conventions. Example: `1971 UC1` for
+   * 1896 Beer, yielding a query string `ASTNAM=1971 UC1`.
+   */
+  final case class AsteroidNew(des: String) extends Asteroid(s"ASTNAM=$des")
+
+  object AsteroidNew {
+    val des: AsteroidNew @> String =
+      Lens((a, b) => a.copy(des = b), _.des)
+  }
+
+  /**
+   * Designation for an asteroid under "old" naming conventions. These are small numbers. Example:
+   * `4` for Vesta, yielding a query string `4;`
+   */
+  final case class AsteroidOld(num: Int) extends Asteroid(s"$num;") {
+    override def des: String =
+      num.toString
+  }
+
+  object AsteroidOld {
+    val num: AsteroidOld @> Int =
+      Lens((a, b) => a.copy(num = b), _.num)
+  }
+
+  /**
+   * Designation for a major body (planet or satellite thereof). These have small numbers. Example:
+   * `606` for Titan, yielding a query string `606`.
+   */
+  final case class MajorBody(num: Int) extends HorizonsDesignation(s"$num") {
+    override def des: String =
+      num.toString
+  }
+
+  object MajorBody {
+    val num: MajorBody @> Int =
+      Lens((a, b) => a.copy(num = b), _.num)
+  }
+
+  /**
+    * Parse an `HorizonsDesignation`.
+    * @group Constructors
+    */
+  def parse(s: String): Option[HorizonsDesignation] =
+    HorizonsDesignationParsers.horizonsDesignation.parseExact(s)
+
+  /**
+    * Parse an `HorizonsDesignation`, raising an exception on failure.
+    * @group Constructors
+    */
+  def unsafeFromString(s: String): HorizonsDesignation =
+    parse(s).getOrElse(sys.error(s"invalid horizons designation: $s"))
+
+  /**
+    * Parse an `HorizonsDesignation` from a type and a human readable
+    * designation.
+    *
+    * @param t horizons type
+    * @param des human readable designation
+    * @group Constructors
+    */
+  def fromTypeAndDes(t: HorizonsType, des: String): Option[HorizonsDesignation] = {
+    import mouse.all._
+
+    t match {
+      case HorizonsType.Comet       => Some(Comet(des))
+      case HorizonsType.AsteroidNew => Some(AsteroidNew(des))
+      case HorizonsType.AsteroidOld => des.parseIntOption.map(AsteroidOld(_))
+      case HorizonsType.MajorBody   => des.parseIntOption.map(MajorBody(_))
+    }
+  }
+
+  def unsafeFromTypeAndDes(t: HorizonsType, des: String): HorizonsDesignation =
+    fromTypeAndDes(t, des).getOrElse(sys.error(s"inavlid horizons designation ${t}_$des"))
+
+  implicit val ShowHorizonsDesignation: Show[HorizonsDesignation] =
+    Show.fromToString
+
+  implicit val EqualHorizonsDesignation: Eq[HorizonsDesignation] =
+    Eq.fromUniversalEquals
+}

--- a/modules/core/shared/src/test/scala/gem/HorizonsDesignationSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/HorizonsDesignationSpec.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.arb.ArbHorizonsDesignation._
+
+import cats.kernel.laws.OrderLaws
+import cats.{Eq, Show}
+import cats.tests.CatsSuite
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class HorizonsDesignationSpec extends CatsSuite {
+
+  // Laws
+  checkAll("HorizonsDesignation", OrderLaws[HorizonsDesignation].eqv)
+
+  test("Equality must be natural") {
+    forAll { (a: HorizonsDesignation, b: HorizonsDesignation) =>
+      a.equals(b) shouldEqual Eq[HorizonsDesignation].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: HorizonsDesignation) =>
+      a.toString shouldEqual Show[HorizonsDesignation].show(a)
+    }
+  }
+
+  test("Round trip from String") {
+    forAll { (a: HorizonsDesignation) =>
+      HorizonsDesignation.unsafeFromString(a.format) shouldEqual a
+    }
+  }
+
+  test("Round trip from type and des") {
+    forAll { (a: HorizonsDesignation) =>
+      HorizonsDesignation.unsafeFromTypeAndDes(a.horizonsType, a.des) shouldEqual a
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/arb/HorizonsDesignation.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/HorizonsDesignation.scala
@@ -4,8 +4,7 @@
 package gem
 package arb
 
-import gem.target.HorizonsDesignation
-import gem.target.HorizonsDesignation._
+import HorizonsDesignation._
 
 import org.scalacheck._
 import org.scalacheck.Arbitrary._

--- a/modules/core/shared/src/test/scala/gem/arb/HorizonsDesignation.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/HorizonsDesignation.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.target.HorizonsDesignation
+import gem.target.HorizonsDesignation._
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbHorizonsDesignation {
+  private def genStringDes[A](f: String => A): Gen[A] =
+    arbitrary[String].map(s => f(s.take(10)))
+
+  private def genIntDes[A](f: Int => A): Gen[A] =
+    arbitrary[Int].map(f)
+
+  implicit val arbHorizonsDesignation: Arbitrary[HorizonsDesignation] =
+    Arbitrary {
+      Gen.oneOf[HorizonsDesignation](
+        genStringDes(Comet.apply      ),
+        genStringDes(AsteroidNew.apply),
+        genIntDes   (AsteroidOld.apply),
+        genIntDes   (MajorBody.apply  )
+      )
+    }
+
+  implicit val CogenHorizonsDesignation: Cogen[HorizonsDesignation] =
+    Cogen[String].contramap(_.format)
+
+}
+
+object ArbHorizonsDesignation extends ArbHorizonsDesignation

--- a/modules/sql/src/main/resources/db/migration/V024__Horizons_Type.sql
+++ b/modules/sql/src/main/resources/db/migration/V024__Horizons_Type.sql
@@ -1,0 +1,20 @@
+
+--
+-- Horizons non-sidereal target types.
+--
+
+CREATE TABLE e_horizons_type (
+    id   identifier            PRIMARY KEY,
+    name character varying(12) NOT NULL
+);
+
+ALTER TABLE e_horizons_type OWNER TO postgres;
+
+
+COPY e_horizons_type (id, name) FROM stdin;
+Comet	Comet
+AsteroidNew	Asteroid New
+AsteroidOld	Asteroid Old
+MajorBody	Major Body
+\.
+

--- a/modules/sql/src/main/resources/db/migration/V024__Horizons_Type.sql
+++ b/modules/sql/src/main/resources/db/migration/V024__Horizons_Type.sql
@@ -4,17 +4,18 @@
 --
 
 CREATE TABLE e_horizons_type (
-    id   identifier            PRIMARY KEY,
-    name character varying(12) NOT NULL
+    id         identifier            PRIMARY KEY,
+    short_name character varying(12) NOT NULL,
+    long_name  character varying(21) NOT NULL
 );
 
 ALTER TABLE e_horizons_type OWNER TO postgres;
 
 
-COPY e_horizons_type (id, name) FROM stdin;
-Comet	Comet
-AsteroidNew	Asteroid New
-AsteroidOld	Asteroid Old
-MajorBody	Major Body
+COPY e_horizons_type (id, short_name, long_name) FROM stdin;
+Comet	Comet	Comet
+AsteroidNew	Asteroid New	Asteroid (New Format)
+AsteroidOld	Asteroid Old	Asteroid (Old Format)
+MajorBody	Major Body	Major Body
 \.
 

--- a/modules/sql/src/main/scala/enum/MiscEnums.scala
+++ b/modules/sql/src/main/scala/enum/MiscEnums.scala
@@ -66,8 +66,8 @@ object MiscEnums {
       },
 
       EnumDef.fromQuery("HorizonsType", "horizons non-sidereal target type") {
-        type R = Record.`'tag -> String, 'name -> String`.T
-        sql"SELECT id, id tag, name FROM e_horizons_type".query[(String, R)]
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"SELECT id, id tag, short_name, long_name FROM e_horizons_type".query[(String, R)]
       }
 
     )

--- a/modules/sql/src/main/scala/enum/MiscEnums.scala
+++ b/modules/sql/src/main/scala/enum/MiscEnums.scala
@@ -63,6 +63,11 @@ object MiscEnums {
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
           WHERE pg_type.typname = 'half'
          """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("HorizonsType", "horizons non-sidereal target type") {
+        type R = Record.`'tag -> String, 'name -> String`.T
+        sql"SELECT id, id tag, name FROM e_horizons_type".query[(String, R)]
       }
 
     )


### PR DESCRIPTION
Brings the `HorizonsDesignation` over from the old `ocs` project so that it is is available to use in the non-sidereal target model.  Horizons designation is a unique horizons id that can be used to construct non-sidereal target queries in JPL horizons.  This is mostly boilerplate but there were some small decisions that may need to be re-evaluated:

1) I placed the `HorizonsDesignation` in a new package called `target` anticipating that the rest of the target model will go there rather than `gem.math`.  Of course `target` is excluded by `.gitignore` by default so that may cause problems?

2) I made an `HorizonsType` enum in the database, anticipating that we'll want to store that, along with the string designation, in the non-sidereal target table.  It isn't really needed yet though.