### PR TITLE
move Location and Enumerated into gem.util

### DIFF
--- a/modules/core/shared/src/main/scala/gem/SmartGcal.scala
+++ b/modules/core/shared/src/main/scala/gem/SmartGcal.scala
@@ -4,6 +4,7 @@
 package gem
 
 import gem.config.DynamicConfig
+import gem.util.Location
 
 /**
  * Module of types and constuctors related to Smart GCal.

--- a/modules/core/shared/src/main/scala/gem/enum/DailyProgramType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/DailyProgramType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for the subset of [[ProgramType]] allowed for daily science programs.

--- a/modules/core/shared/src/main/scala/gem/enum/EventType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/EventType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for observe [[gem.Event Event]]) types.

--- a/modules/core/shared/src/main/scala/gem/enum/F2Disperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2Disperser.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for Flamingos2 dispersers.

--- a/modules/core/shared/src/main/scala/gem/enum/F2Filter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2Filter.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for Flamingos2 filters.

--- a/modules/core/shared/src/main/scala/gem/enum/F2Fpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2Fpu.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for Flamingos2 focal plane units.

--- a/modules/core/shared/src/main/scala/gem/enum/F2LyotWheel.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2LyotWheel.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for Flamingos2 Lyot wheel.

--- a/modules/core/shared/src/main/scala/gem/enum/F2ReadMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2ReadMode.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for Flamingos2 read modes.

--- a/modules/core/shared/src/main/scala/gem/enum/F2WindowCover.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2WindowCover.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for Flamingos2 window cover state.

--- a/modules/core/shared/src/main/scala/gem/enum/GcalArc.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalArc.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for calibration unit arc lamps.

--- a/modules/core/shared/src/main/scala/gem/enum/GcalBaselineType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalBaselineType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for calibration baseline type.

--- a/modules/core/shared/src/main/scala/gem/enum/GcalContinuum.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalContinuum.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for calibration unit continuum lamps.

--- a/modules/core/shared/src/main/scala/gem/enum/GcalDiffuser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalDiffuser.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for calibration unit diffusers.

--- a/modules/core/shared/src/main/scala/gem/enum/GcalFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalFilter.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for calibration unit filter.

--- a/modules/core/shared/src/main/scala/gem/enum/GcalLampType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalLampType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for calibration lamp type.

--- a/modules/core/shared/src/main/scala/gem/enum/GcalShutter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalShutter.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for calibration unit shutter states.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAdc.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAdc.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS ADC.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAmpCount.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAmpCount.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS amp count.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAmpGain.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAmpGain.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS amp gain.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAmpReadMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAmpReadMode.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS amp read mode.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosCustomSlitWidth.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosCustomSlitWidth.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS custom slit width.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosDetector.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosDetector.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS detector.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosDisperserOrder.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosDisperserOrder.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS disperser order.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosDtax.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosDtax.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS detector translation X offset.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosEOffsetting.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosEOffsetting.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS Electric Offsetting.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthDisperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthDisperser.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS North dispersers.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthFilter.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS North filters.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthFpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthFpu.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS North focal plane units.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthStageMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthStageMode.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS North stage modes.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosRoi.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosRoi.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS ROI (region of interest).

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthDisperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthDisperser.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS South dispersers.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthFilter.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS South filters.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthFpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthFpu.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS South focal plane units.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthStageMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthStageMode.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS South stage mode.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosXBinning.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosXBinning.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS X-binning.

--- a/modules/core/shared/src/main/scala/gem/enum/GmosYBinning.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosYBinning.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for GMOS Y-binning.

--- a/modules/core/shared/src/main/scala/gem/enum/Half.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Half.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for semester half.

--- a/modules/core/shared/src/main/scala/gem/enum/HorizonsType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/HorizonsType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for horizons non-sidereal target type.

--- a/modules/core/shared/src/main/scala/gem/enum/Instrument.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Instrument.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for instruments.

--- a/modules/core/shared/src/main/scala/gem/enum/MosPreImaging.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/MosPreImaging.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for MOS pre-imaging category.

--- a/modules/core/shared/src/main/scala/gem/enum/ProgramRole.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/ProgramRole.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for user roles with respect to a given program.

--- a/modules/core/shared/src/main/scala/gem/enum/ProgramType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/ProgramType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for program types (see [[gem.ProgramId ProgramId]]).

--- a/modules/core/shared/src/main/scala/gem/enum/Site.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Site.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for Gemini observing sites.

--- a/modules/core/shared/src/main/scala/gem/enum/SmartGcalType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/SmartGcalType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for "smart" calibration sequence tpes.

--- a/modules/core/shared/src/main/scala/gem/enum/StepType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/StepType.scala
@@ -6,6 +6,7 @@ package enum
 
 import cats.syntax.eq._
 import cats.instances.string._
+import gem.util.Enumerated
 
 /**
  * Enumerated type for step types.

--- a/modules/core/shared/src/main/scala/gem/parser/Enum.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Enum.scala
@@ -6,6 +6,7 @@ package gem
 import cats.implicits._
 import atto._, Atto._
 import gem.enum._
+import gem.util.Enumerated
 
 /** Parsers for `gem.enum` data types. */
 trait EnumParsers {

--- a/modules/core/shared/src/main/scala/gem/util/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Enumerated.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package gem
+package gem.util
 
 import cats.Order
 import cats.implicits._

--- a/modules/core/shared/src/main/scala/gem/util/Location.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Location.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package gem
+package gem.util
 
 import cats._, cats.data._, cats.implicits._
 import scala.BigDecimal.RoundingMode.FLOOR

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -8,6 +8,7 @@ import gem.arb._
 import gem.config.{DynamicConfig, GcalConfig, StaticConfig, TelescopeConfig}
 import gem.enum.{Instrument, SmartGcalType}
 import gem.math.Offset
+import gem.util.Location
 import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._

--- a/modules/core/shared/src/test/scala/gem/arb/Enumerated.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Enumerated.scala
@@ -4,6 +4,7 @@
 package gem
 package arb
 
+import gem.util.Enumerated
 import org.scalacheck._
 import org.scalacheck.Gen._
 

--- a/modules/core/shared/src/test/scala/gem/util/EnumeratedSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/EnumeratedSpec.scala
@@ -2,6 +2,7 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package gem
+package util
 
 import gem.arb._
 import gem.enum._

--- a/modules/core/shared/src/test/scala/gem/util/LocationSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/LocationSpec.scala
@@ -2,6 +2,7 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package gem
+package util
 
 import cats.{ Eq, Order }
 import cats.kernel.laws._

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import doobie.imports._
 import gem.config.{DynamicConfig, StaticConfig}
 import gem.enum.Instrument
+import gem.util.Location
 
 object ObservationDao {
 

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -11,6 +11,7 @@ import gem.config._
 import gem.config.DynamicConfig.{ SmartGcalKey, SmartGcalSearchKey }
 import gem.enum._
 import gem.math.Wavelength
+import gem.util.Location
 import fs2.Stream
 import scala.collection.immutable.TreeMap
 

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -5,7 +5,7 @@ package gem
 package dao
 
 import cats.implicits._
-import gem.Location
+import gem.util.Location
 import gem.config._
 import gem.config.GcalConfig.GcalLamp
 import gem.enum._

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -8,6 +8,7 @@ import doobie.postgres.imports._
 import doobie.imports._
 import doobie.enum.jdbctype.{ Distinct => JdbcDistinct, Array => _, _ }
 import gem.math.{ Angle, Offset, Wavelength }
+import gem.util.{ Enumerated, Location }
 import java.sql.Timestamp
 import java.time.{Duration, Instant}
 import java.util.logging.Level

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -11,6 +11,7 @@ import gem.config._
 import gem.config.F2Config.F2FpuChoice.Builtin
 import gem.config.GcalConfig.GcalLamp
 import gem.enum._
+import gem.util.Location
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import java.time.Duration
 import scala.collection.immutable.TreeMap

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -4,8 +4,9 @@
 package gem.dao
 
 import doobie.imports._
-import gem.{ Location, Observation, Step }
+import gem.{ Observation, Step }
 import gem.config.DynamicConfig
+import gem.util.Location
 import scala.collection.immutable.TreeMap
 
 object StepDaoSample extends TimedSample {

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -11,6 +11,7 @@ import gem._
 import gem.enum._
 import gem.config._
 import gem.config.DynamicConfig.SmartGcalKey
+import gem.util.Location
 import gem.math.{ Offset, Wavelength }
 import java.time.LocalDate
 import org.scalatest._

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -8,6 +8,7 @@ import gem.enum.GcalArc
 import gem.config.GcalConfig.GcalArcs
 import gem.config.GmosConfig._
 import gem.math.{ Angle, Offset, Wavelength }
+import gem.util.Enumerated
 import io.circe._
 import io.circe.syntax._
 import java.time.Duration

--- a/modules/json/src/test/scala/gem/json/CompilationTest.scala
+++ b/modules/json/src/test/scala/gem/json/CompilationTest.scala
@@ -8,6 +8,7 @@ import io.circe._
 import io.circe.generic.auto._
 import gem.config._
 import gem.enum._
+import gem.util.Enumerated
 
 // N.B. lots of false warnings from codec derivation.
 @SuppressWarnings(Array(

--- a/modules/sql/src/main/scala/EnumDef.scala
+++ b/modules/sql/src/main/scala/EnumDef.scala
@@ -82,6 +82,7 @@ object EnumDef {
       |
       |import cats.syntax.eq._
       |import cats.instances.string._
+      |import gem.util.Enumerated
       |
       |/**
       | * Enumerated type for $desc.


### PR DESCRIPTION
This moves `Location` and `Enumerated` into `gem.util` as proposed in #128. 

(Will need to be rebased after #128 which introduces a new enum.)