### PR TITLE
update flyway and doobie versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ lazy val attoVersion         = "0.6.1-M1"
 lazy val catsEffectVersion   = "0.4"
 lazy val catsVersion         = "1.0.0-MF"
 lazy val declineVersion      = "0.4.0-M1"
-lazy val doobieVersion       = "0.5.0-M5"
-lazy val flywayVersion       = "4.0.3"
+lazy val doobieVersion       = "0.5.0-M6"
+lazy val flywayVersion       = "4.2.0"
 lazy val fs2Version          = "0.10.0-M6"
 lazy val http4sVersion       = "0.18.0-M1"
 lazy val jwtVersion          = "0.14.0"
@@ -178,7 +178,7 @@ lazy val flywaySettings = Seq(
 lazy val gem = project
   .in(file("."))
   .settings(commonSettings)
-  .aggregate(coreJVM, db, json, ocs2, service, telnetd, ctl, web)
+  .aggregate(coreJVM, db, json, ocs2, service, telnetd, ctl, web, sql)
 
 lazy val core = crossProject
   .crossType(CrossType.Full)
@@ -222,7 +222,7 @@ lazy val db = project
     ),
     initialCommands += """
       |import cats._, cats.data._, cats.implicits._, scalaz.effect.IO
-      |import doobie.imports._
+      |import doobie._, doobie.implicits._
       |import gem._, gem.enum._, gem.dao._
       |val xa = DriverManagerTransactor[IO](
       |  "org.postgresql.Driver",

--- a/modules/db/src/main/scala/gem/Log.scala
+++ b/modules/db/src/main/scala/gem/Log.scala
@@ -4,7 +4,7 @@
 package gem
 
 import cats.implicits._, cats.effect._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.dao.LogDao
 import java.util.concurrent.{ ExecutorService, Executors, TimeUnit }
 import java.util.logging._

--- a/modules/db/src/main/scala/gem/dao/DatasetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/DatasetDao.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.syntax.functor._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.{ Dataset, Observation }
 
 object DatasetDao {

--- a/modules/db/src/main/scala/gem/dao/EventLogDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EventLogDao.scala
@@ -3,7 +3,7 @@
 
 package gem.dao
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.{Event, Observation}
 import gem.Event._
 import gem.enum.EventType

--- a/modules/db/src/main/scala/gem/dao/GcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GcalDao.scala
@@ -6,7 +6,7 @@ package gem.dao
 import cats.implicits._
 import gem.config.GcalConfig
 import gem.config.GcalConfig.GcalLamp
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
 import gem.enum.GcalArc.{ArArc, CuArArc, ThArArc, XeArc}
 import java.time.Duration

--- a/modules/db/src/main/scala/gem/dao/LogDao.scala
+++ b/modules/db/src/main/scala/gem/dao/LogDao.scala
@@ -4,7 +4,7 @@
 package gem
 package dao
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 import java.util.logging.Level
 
 object LogDao {

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -5,7 +5,7 @@ package gem
 package dao
 
 import cats.implicits._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.config.{DynamicConfig, StaticConfig}
 import gem.enum.Instrument
 import gem.util.Location

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -6,7 +6,7 @@ package dao
 
 import gem.config.{DynamicConfig, StaticConfig}
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 
 import cats.implicits._
 

--- a/modules/db/src/main/scala/gem/dao/SemesterDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SemesterDao.scala
@@ -5,7 +5,7 @@ package gem
 package dao
 
 import cats.syntax.functor._
-import doobie.imports._
+import doobie._, doobie.implicits._
 
 object SemesterDao {
 

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.implicits._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem._
 import gem.SmartGcal._
 import gem.config._

--- a/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
@@ -5,7 +5,7 @@ package gem
 package dao
 
 import cats.implicits._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.enum.{ GmosDetector, Instrument, MosPreImaging }
 import gem.config._
 

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -10,7 +10,7 @@ import gem.config._
 import gem.config.GcalConfig.GcalLamp
 import gem.enum._
 import gem.math.{ Offset, Wavelength }
-import doobie.imports._
+import doobie._, doobie.implicits._
 import java.time.Duration
 import scala.collection.immutable.TreeMap
 

--- a/modules/db/src/main/scala/gem/dao/UserDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserDao.scala
@@ -7,7 +7,7 @@ package dao
 import gem.enum.ProgramRole
 import cats.data._, cats.implicits._
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 
 object UserDao {
 

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -4,9 +4,9 @@
 package gem
 
 import cats.data._, cats.implicits._
-import doobie.postgres.imports._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import doobie.enum.jdbctype.{ Distinct => JdbcDistinct, Array => _, _ }
+import doobie.postgres.implicits._
 import gem.math.{ Angle, Offset, Wavelength }
 import gem.util.{ Enumerated, Location }
 import java.sql.Timestamp

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.effect.IO
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.{ Program, Step }
 
 /** Base trait for DAO test cases.

--- a/modules/db/src/test/scala/gem/dao/EventLogDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/EventLogDaoSample.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.effect.IO
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem._
 import java.time.Instant
 

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.implicits._
-import doobie.imports._
+import doobie.implicits._
 import gem.Observation
 import org.scalatest._
 import org.scalatest.prop._

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.implicits._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.arb.ArbEnumerated._
 import gem.config.GcalConfig
 import gem.config.DynamicConfig

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.implicits._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem._
 import gem.SmartGcal._
 import gem.config._

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -3,7 +3,7 @@
 
 package gem.dao
 
-import doobie.imports._
+import doobie._
 import gem.{ Observation, Step }
 import gem.config.DynamicConfig
 import gem.util.Location

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -3,7 +3,7 @@
 
 package gem.dao
 
-import doobie.imports._
+import doobie.implicits._
 import gem._
 import gem.config._
 import gem.config.F2Config.F2FpuChoice.Builtin

--- a/modules/db/src/test/scala/gem/dao/TimedSample.scala
+++ b/modules/db/src/test/scala/gem/dao/TimedSample.scala
@@ -4,7 +4,7 @@
 package gem.dao
 
 import cats.effect.IO
-import doobie.imports._
+import doobie._, doobie.implicits._
 import java.time.{Duration, Instant}
 
 

--- a/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
@@ -4,8 +4,8 @@
 package gem.dao
 
 import cats.implicits._
-import doobie.imports._
-import doobie.postgres.imports._
+import doobie._, doobie.implicits._
+import doobie.postgres.implicits._
 import gem._
 import gem.enum.ProgramRole
 import org.scalatest._

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -5,7 +5,7 @@ package gem.dao
 package check
 
 import cats.effect.IO
-import doobie.imports._
+import doobie._
 import doobie.scalatest.imports._
 import gem._
 import gem.enum._

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -4,9 +4,8 @@
 package gem.ocs2
 
 import cats.effect.IO, cats.implicits._
-import doobie.imports._
-import doobie.util.monaderror._
-import doobie.postgres.imports._
+import doobie._, doobie.implicits._
+import doobie.postgres.implicits._
 import java.util.logging.{ Level, Logger }
 
 /** Shared support for import applications using Doobie. */

--- a/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
@@ -4,7 +4,7 @@
 package gem.ocs2
 
 import cats.effect.IO, cats.implicits._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.{ Dataset, Log, Observation, Program, Step, User }
 import gem.config.{ StaticConfig, DynamicConfig }
 import gem.dao.UserDao

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -5,7 +5,7 @@ package gem.ocs2
 
 import cats.effect.IO
 import cats.implicits._
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.dao._
 import gem.{Dataset, Log, Observation, Program, Step, User}
 import gem.config.{ StaticConfig, DynamicConfig }

--- a/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
@@ -16,7 +16,7 @@ import gem.math.Wavelength
 
 import java.io.File
 import java.time.Duration
-import doobie.imports._
+import doobie._, doobie.implicits._
 
 import scala.reflect.runtime.universe._
 

--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -6,7 +6,7 @@ package gem
 import cats._
 import cats.implicits._
 import cats.effect.Sync
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.dao._
 import gem.enum._
 import gem.util.Lens, Lens._

--- a/modules/sql/src/main/scala/EnumDef.scala
+++ b/modules/sql/src/main/scala/EnumDef.scala
@@ -18,6 +18,7 @@ object EnumDef {
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.ExplicitImplicitTypes"))
   protected[sql] object ToDeclaration extends Poly1 {
+    // scalastyle:off method.type
     implicit def caseString  [S <: Symbol] = at[(S, String)  ] { case (s, _) => "  val " + s.name + ": String" }
     implicit def caseInt     [S <: Symbol] = at[(S, Int)     ] { case (s, _) => "  val " + s.name + ": Int" }
     implicit def caseBoolean [S <: Symbol] = at[(S, Boolean) ] { case (s, _) => "  val " + s.name + ": Boolean" }
@@ -34,6 +35,7 @@ object EnumDef {
 
     implicit def caseOptionWavelengthNm[S <: Symbol] = at[(S, Option[Wavelength.Nm])] { case (s, _) => s"  val ${s.name}: Option[gem.math.Wavelength]" }
     implicit def caseOptionWavelengthUm[S <: Symbol] = at[(S, Option[Wavelength.Um])] { case (s, _) => s"  val ${s.name}: Option[gem.math.Wavelength]" }
+    // scalastyle:on method.type
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.ExplicitImplicitTypes"))
@@ -68,6 +70,7 @@ object EnumDef {
   ): String =
     h.map(ToDeclaration).toList.mkString(s"sealed abstract class $name(\n", ",\n", "\n)")
 
+  // scalastyle:off method.length
   def fromRecords[R <: HList, F <: HList, D <: HList, V <: HList, Lub1, Lub2, L <: HList](name: String, desc: String, records: NonEmptyList[(String, R)])(
     implicit  f: Fields.Aux[R, F],
               d: Mapper.Aux[ToDeclaration.type, F, D],
@@ -117,6 +120,7 @@ object EnumDef {
       |}
       |""".stripMargin.trim
     )
+  // scalastyle:on method.length
 
   def fromQuery[R <: HList, F <: HList, D <: HList, V <: HList, Lub1, Lub2, L <: HList](name: String, desc: String)(records: Query0[(String, R)])(
     implicit  f: Fields.Aux[R, F],

--- a/modules/sql/src/main/scala/EnumDef.scala
+++ b/modules/sql/src/main/scala/EnumDef.scala
@@ -3,7 +3,7 @@
 
 package gem.sql
 
-import doobie.imports._
+import doobie._
 import java.time.{ Duration, ZoneId }
 import cats.data.NonEmptyList, cats.implicits._
 import shapeless._

--- a/modules/sql/src/main/scala/Main.scala
+++ b/modules/sql/src/main/scala/Main.scala
@@ -3,7 +3,7 @@
 
 package gem.sql
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 import gem.sql.enum._
 import java.nio.file._
 import cats.implicits._, cats.effect.IO

--- a/modules/sql/src/main/scala/Main.scala
+++ b/modules/sql/src/main/scala/Main.scala
@@ -30,7 +30,7 @@ object Main {
   def write(dir: Path, d: EnumDef): IO[Unit] = {
     val out = dir.resolve(d.fileName)
     IO(Files.write(out, d.text.getBytes("UTF-8"))) *>
-    IO(Console.println(s"Wrote $out"))
+    IO(Console.println(s"Wrote $out")) // scalastyle:ignore console.io
   }
 
   def writeAll(dir: Path): IO[Unit] =
@@ -43,7 +43,7 @@ object Main {
   def runl(args: List[String]): IO[Unit] =
     args match {
       case List(dirName) => IO(Paths.get(dirName).toAbsolutePath).flatMap(writeAll)
-      case _             => IO(Console.println("usage: <main> path/to/output/dir"))
+      case _             => IO(Console.println("usage: <main> path/to/output/dir")) // scalastyle:ignore console.io
     }
 
   def main(args: Array[String]): Unit =

--- a/modules/sql/src/main/scala/enum/F2Enums.scala
+++ b/modules/sql/src/main/scala/enum/F2Enums.scala
@@ -4,7 +4,7 @@
 package gem.sql
 package enum
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 import java.time.Duration
 import shapeless.record._
 

--- a/modules/sql/src/main/scala/enum/GcalEnums.scala
+++ b/modules/sql/src/main/scala/enum/GcalEnums.scala
@@ -4,7 +4,7 @@
 package gem.sql
 package enum
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 import shapeless.record._
 
 object GcalEnums {

--- a/modules/sql/src/main/scala/enum/GmosEnums.scala
+++ b/modules/sql/src/main/scala/enum/GmosEnums.scala
@@ -4,7 +4,7 @@
 package gem.sql
 package enum
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 import shapeless.record._
 
 object GmosEnums {

--- a/modules/sql/src/main/scala/enum/MiscEnums.scala
+++ b/modules/sql/src/main/scala/enum/MiscEnums.scala
@@ -4,7 +4,7 @@
 package gem.sql
 package enum
 
-import doobie.imports._
+import doobie._, doobie.implicits._
 import java.time.ZoneId
 import shapeless.record._
 

--- a/modules/sql/src/main/scala/package.scala
+++ b/modules/sql/src/main/scala/package.scala
@@ -3,7 +3,7 @@
 
 package gem
 
-import doobie.imports._
+import doobie._
 import java.time.{ Duration, ZoneId }
 
 package object sql {

--- a/modules/telnetd/src/main/scala/main.scala
+++ b/modules/telnetd/src/main/scala/main.scala
@@ -6,7 +6,7 @@ package telnetd
 
 import cats.effect.{ IO, Async }
 import tuco._, Tuco._
-import doobie.imports._
+import doobie._
 import org.flywaydb.core.Flyway
 
 /**

--- a/modules/web/src/main/scala/Environment.scala
+++ b/modules/web/src/main/scala/Environment.scala
@@ -6,7 +6,7 @@ package web
 
 import cats.implicits._
 import cats.effect.IO
-import doobie.imports.Transactor
+import doobie.Transactor
 import gem.{ Service => GemService }
 import io.circe._
 import io.circe.parser.decode

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -44,14 +44,14 @@
  </check> -->
  <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+ <check customId="method.length" level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxLength"><![CDATA[40]]></parameter>
   </parameters>
  </check>
  <!-- <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check> -->
  <!-- <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check> -->
- <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+ <check customId="method.type" level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
   <parameters>
    <parameter name="ignoreOverride">true</parameter>
   </parameters>


### PR DESCRIPTION
This updates flyway to 4.2.0 and doobie to 0.5.0-M6 (which required changing a bunch of imports to avoid deprecation warnings).