### PR TITLE
Ephemeris Table and DAO

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,6 +191,7 @@ lazy val core = crossProject
   .settings(
     libraryDependencies ++= Seq(
       "org.typelevel"              %%% "cats-core"      % catsVersion,
+      "org.typelevel"              %%% "cats-effect"    % catsEffectVersion,
       "org.typelevel"              %%% "cats-testkit"   % catsVersion % "test",
       "com.chuusai"                %%% "shapeless"      % shapelessVersion,
       "org.tpolecat"               %%% "atto-core"      % attoVersion,

--- a/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
@@ -34,7 +34,7 @@ sealed trait EphemerisKey extends Product with Serializable {
     }
 
   /** Exports an ephemeris key to a `String` in a format that can be read by the
-    * `gem.parsers.EphemerisKeyParsers` method.
+    * `parse` method.
     */
   def format: String =
     s"${keyType.tag}_$des"

--- a/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
@@ -86,9 +86,9 @@ object EphemerisKey {
   /** Identifies a user-supplied collection of ephemeris data, where the number
     * comes from a database sequence.
     */
-  @Lenses final case class UserSupplied(num: Int) extends EphemerisKey {
+  @Lenses final case class UserSupplied(id: Int) extends EphemerisKey {
     override def des: String =
-      num.toString
+      id.toString
   }
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object UserSupplied

--- a/modules/core/shared/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Angle.scala
@@ -212,7 +212,7 @@ object Angle {
       milliarcseconds: Int,
       microarcseconds: Int
     ) = Angle.toMicrosexigesimal(toAngle.toMicroarcseconds)
-    def format: String = f"$degrees° $arcminutes%02d′ $arcseconds%02d.$milliarcseconds%03d$microarcseconds%03d″"
+    def format: String = f"$degrees%02d:$arcminutes%02d:$arcseconds%02d.$milliarcseconds%03d$microarcseconds%03d"
     override final def toString = s"DMS($format)"
   }
 
@@ -377,7 +377,7 @@ object HourAngle {
       milliseconds: Int,
       microseconds: Int
     ) = Angle.toMicrosexigesimal(toHourAngle.toMicroseconds)
-    def format: String = f"${hours}h $minutes%02dm $seconds%02d.$milliseconds%03d$microseconds%03ds"
+    def format: String = f"$hours%02d:$minutes%02d:$seconds%02d.$milliseconds%03d$microseconds%03d"
     override final def toString = format
   }
 

--- a/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
+++ b/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
@@ -36,17 +36,17 @@ final class InstantMicros private (val toInstant: Instant) extends AnyVal {
   /** Creates an updated instance of InstantMicros by applying the given
     * function to its wrapped Instant.
     */
-  def updated(f: Instant => Instant): InstantMicros =
+  def mod(f: Instant => Instant): InstantMicros =
     InstantMicros.truncate(f(toInstant))
 
   def plusMillis(millisToAdd: Long): InstantMicros =
-    updated(_.plusMillis(millisToAdd))
+    mod(_.plusMillis(millisToAdd))
 
   def plusMicros(microsToAdd: Long): InstantMicros =
-    updated(_.plusNanos(microsToAdd * 1000))
+    mod(_.plusNanos(microsToAdd * 1000))
 
   def plusSeconds(secondsToAdd: Long): InstantMicros =
-    updated(_.plusSeconds(secondsToAdd))
+    mod(_.plusSeconds(secondsToAdd))
 
   override def toString: String =
     toInstant.toString

--- a/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
+++ b/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
@@ -1,0 +1,93 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.util
+
+import cats._
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit.MICROS
+
+
+/** InstantMicros wraps a `java.util.Instant` that is truncated to microsecond
+  * resolution.  This allows InstantMicros to roundtrip to/from the database
+  * where timestamps support only microsecond resolution.
+  *
+  * @param toInstant
+  */
+final class InstantMicros private (val toInstant: Instant) extends AnyVal {
+
+  /** Gets the number of seconds from the Java epoch of 1970-01-01T00:00:00Z. */
+  def epochSecond: Long =
+    toInstant.getEpochSecond
+
+  /** Gets the number of microseconds after the start of the second returned
+    * by `epochSecond`.
+    */
+  def µs: Long =
+    toInstant.getNano / 1000l
+
+  /** Converts this instant to the number of milliseconds from the epoch of
+    * 1970-01-01T00:00:00Z.
+    */
+  def toEpochMilli: Long =
+    toInstant.toEpochMilli
+
+  /** Creates an updated instance of InstantMicros by applying the given
+    * function to its wrapped Instant.
+    */
+  def updated(f: Instant => Instant): InstantMicros =
+    InstantMicros.truncate(f(toInstant))
+
+  def plusMillis(millisToAdd: Long): InstantMicros =
+    updated(_.plusMillis(millisToAdd))
+
+  def plusMicros(microsToAdd: Long): InstantMicros =
+    updated(_.plusNanos(microsToAdd * 1000))
+
+  def plusSeconds(secondsToAdd: Long): InstantMicros =
+    updated(_.plusSeconds(secondsToAdd))
+
+  override def toString: String =
+    toInstant.toString
+}
+
+object InstantMicros {
+
+  val Min: InstantMicros = InstantMicros.truncate(Instant.MIN)
+  val Max: InstantMicros = InstantMicros.truncate(Instant.MAX)
+
+
+  /** Creates an InstantMicro from the given Instant, assuring that the time
+    * value recorded has a round number of microseconds.
+    *
+    * @group Constructors
+    */
+  def truncate(i: Instant): InstantMicros =
+    new InstantMicros(i.truncatedTo(MICROS))
+
+  /** Creates an InstantMicro representing the current time, truncated to the
+    * last integral number of microseconds.
+    *
+    * @group Constructors
+    */
+  def now(): InstantMicros =
+    truncate(Instant.now())
+
+  /** Creates an InstantMicro representing the current time using milliseconds
+    * from the Java time epoch.
+    *
+    * @group Constructors
+    */
+  def ofEpochMilli(epochMilli: Long): InstantMicros =
+    new InstantMicros(Instant.ofEpochMilli(epochMilli))
+
+  implicit val OrderingInstantMicros: Ordering[InstantMicros] =
+    Ordering.by(_.toInstant)
+
+  implicit val OrderInstantMicros: Order[InstantMicros] =
+    Order.fromOrdering
+
+  implicit val ShowInstantMicros: Show[InstantMicros] =
+    Show.fromToString
+}

--- a/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
+++ b/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
@@ -4,6 +4,7 @@
 package gem.util
 
 import cats._
+import cats.effect.IO
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit.MICROS
@@ -25,7 +26,7 @@ final class InstantMicros private (val toInstant: Instant) extends AnyVal {
     * by `epochSecond`.
     */
   def µs: Long =
-    toInstant.getNano / 1000l
+    toInstant.getNano / 1000L
 
   /** Converts this instant to the number of milliseconds from the epoch of
     * 1970-01-01T00:00:00Z.
@@ -34,9 +35,10 @@ final class InstantMicros private (val toInstant: Instant) extends AnyVal {
     toInstant.toEpochMilli
 
   /** Creates an updated instance of InstantMicros by applying the given
-    * function to its wrapped Instant.
+    * function to its wrapped Instant.  The computed Instant is truncated to
+    * microsecond precision.
     */
-  def mod(f: Instant => Instant): InstantMicros =
+  private def mod(f: Instant => Instant): InstantMicros =
     InstantMicros.truncate(f(toInstant))
 
   def plusMillis(millisToAdd: Long): InstantMicros =
@@ -71,8 +73,10 @@ object InstantMicros {
     *
     * @group Constructors
     */
-  def now(): InstantMicros =
-    truncate(Instant.now())
+  def now: IO[InstantMicros] =
+    IO {
+      truncate(Instant.now())
+    }
 
   /** Creates an InstantMicro representing the current time using milliseconds
     * from the Java time epoch.

--- a/modules/core/shared/src/test/scala/gem/arb/Ephemeris.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Ephemeris.scala
@@ -5,7 +5,8 @@ package gem
 package arb
 
 import gem.math.{ Coordinates, Ephemeris }
-import java.time.Instant
+import gem.util.InstantMicros
+
 import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
@@ -18,7 +19,7 @@ trait ArbEphemeris {
   implicit val arbElement: Arbitrary[Element] =
     Arbitrary {
       for {
-        t  <- arbitrary[Instant]
+        t  <- arbitrary[InstantMicros]
         cs <- arbitrary[Coordinates]
       } yield (t, cs)
     }
@@ -32,7 +33,7 @@ trait ArbEphemeris {
     }
 
   implicit val cogEphemeris: Cogen[Ephemeris] =
-    Cogen[Map[Instant, Coordinates]].contramap(_.toMap)
+    Cogen[Map[InstantMicros, Coordinates]].contramap(_.toMap)
 
 }
 object ArbEphemeris extends ArbEphemeris

--- a/modules/core/shared/src/test/scala/gem/arb/EphemerisKey.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/EphemerisKey.scala
@@ -11,7 +11,7 @@ import org.scalacheck.Arbitrary._
 
 trait ArbEphemerisKey {
   private def genStringDes[A](f: String => A): Gen[A] =
-    arbitrary[String].map(s => f(s.take(10)))
+    Gen.alphaNumStr.map(s => f(s.take(10)))
 
   private def genIntDes[A](f: Int => A): Gen[A] =
     arbitrary[Int].map(f)

--- a/modules/core/shared/src/test/scala/gem/arb/Time.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Time.scala
@@ -4,11 +4,14 @@
 package gem
 package arb
 
-import java.time._
+import gem.util.InstantMicros
+
 import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
+
 import scala.collection.JavaConverters._
+import java.time._
 
 // Arbitrary but resonable dates and times.
 trait ArbTime {
@@ -60,8 +63,14 @@ trait ArbTime {
   implicit val arbInstant: Arbitrary[Instant] =
     Arbitrary(arbitrary[ZonedDateTime].map(_.toInstant))
 
+  implicit val arbInstantMicros: Arbitrary[InstantMicros] =
+    Arbitrary(arbitrary[Instant].map(InstantMicros.truncate))
+
   implicit val cogInstant: Cogen[Instant] =
     Cogen[(Long, Int)].contramap(t => (t.getEpochSecond, t.getNano))
+
+  implicit val cogInstantMicros: Cogen[InstantMicros] =
+    Cogen[Instant].contramap(_.toInstant)
 
   implicit val cogYear: Cogen[Year] =
     Cogen[Int].contramap(_.getValue)

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
@@ -3,11 +3,12 @@
 
 package gem.math
 
-import cats.tests.CatsSuite
+import gem.arb._
+import gem.util.InstantMicros
+
 import cats.Eq
 import cats.kernel.laws._
-import gem.arb._
-import java.time.Instant
+import cats.tests.CatsSuite
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class EphemerisSpec extends CatsSuite {
@@ -33,7 +34,7 @@ final class EphemerisSpec extends CatsSuite {
   }
 
   test("Ephemeris.get.interpolated") {
-    forAll { (t1: Instant, c1: Coordinates, c2: Coordinates, n: Int) =>
+    forAll { (t1: InstantMicros, c1: Coordinates, c2: Coordinates, n: Int) =>
       val offset = (n % 100).abs
       val (t2, t3) = (t1.plusSeconds(offset.toLong), t1.plusSeconds(100))
       val e = Ephemeris(t1 -> c1, t3 -> c2)

--- a/modules/core/shared/src/test/scala/gem/util/InstantMicrosSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/InstantMicrosSpec.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package util
+
+import gem.arb.ArbTime._
+
+import cats.kernel.laws._
+import cats.tests.CatsSuite
+
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
+final class InstantMicrosSpec extends CatsSuite {
+
+  // Laws
+  checkAll("InstantMicro", OrderLaws[InstantMicros].order)
+
+  test("Construction should truncate Instant nanoseconds to microseconds") {
+    forAll { (i: InstantMicros) =>
+      i.toInstant.getNano % 1000l == 0
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/util/InstantMicrosSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/InstantMicrosSpec.scala
@@ -18,7 +18,7 @@ final class InstantMicrosSpec extends CatsSuite {
 
   test("Construction should truncate Instant nanoseconds to microseconds") {
     forAll { (i: InstantMicros) =>
-      i.toInstant.getNano % 1000l == 0
+      i.toInstant.getNano % 1000L == 0
     }
   }
 

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -1,0 +1,99 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.enum.EphemerisKeyType
+import gem.math._
+
+import cats.Monad
+import cats.implicits._
+import doobie._, doobie.implicits._
+import fs2.Stream
+
+import java.time.Instant
+
+object EphemerisDao {
+
+  def insert(k: EphemerisKey, e: Ephemeris): ConnectionIO[Int] =
+    Statements.insert.updateMany(
+      e.toMap.toList.map { case (i, c) => (k, i, c, c.ra.format, c.dec.format) }
+    )
+
+  def streamInsert[M[_]: Monad](k: EphemerisKey, s: Stream[M, Ephemeris.Element], xa: Transactor[M]): Stream[M, Int] =
+    Stream.constant(k)                                                  // Stream[Pure, EphemerisKey]
+      .zip(s)                                                           // Stream[M, (EphemerisKey, Ephemeris.Element)]
+      .map { case (k, (i, c)) => (k, i, c, c.ra.format, c.dec.format) } // Stream[M, EphemerisRow]
+      .segmentN(4096)                                                   // Stream[M, Segment[EphemerisRow, Unit]]
+      .flatMap { rows =>
+        Stream.eval(Statements.insert.updateMany(rows.toVector).transact(xa))
+      }
+
+  def selectAll(k: EphemerisKey): ConnectionIO[Ephemeris] =
+    runSelect(Statements.select(k))
+
+  def selectBetween(k: EphemerisKey, start: Instant, end: Instant): ConnectionIO[Ephemeris] =
+    runSelect(Statements.selectBetween(k, start, end))
+
+  private def runSelect(q: Query0[Ephemeris.Element]): ConnectionIO[Ephemeris] =
+    q.list.map(Ephemeris.fromFoldable[List])
+
+  def streamAll(k: EphemerisKey): Stream[ConnectionIO, Ephemeris.Element] =
+    Statements.select(k).stream
+
+  def streamBetween(k: EphemerisKey, start: Instant, end: Instant): Stream[ConnectionIO, Ephemeris.Element] =
+    Statements.selectBetween(k, start, end).stream
+
+  object Statements {
+
+    // Describe how to turn an EphemerisKey into a (EphemerisKeyType, String)
+    implicit val CompositeEphemerisKey: Composite[EphemerisKey] =
+      Composite[(EphemerisKeyType, String)].imap(
+        (t: (EphemerisKeyType, String)) => EphemerisKey.unsafeFromTypeAndDes(t._1, t._2))(
+        (k: EphemerisKey)               => (k.keyType, k.des)
+      )
+
+    // Describe how to map Coordinates into (Long, Long)
+    implicit val CompositeCoordinates: Composite[Coordinates] =
+      Composite[(Long, Long)].imap(
+        (t: (Long, Long)) =>
+          Coordinates(RightAscension(HourAngle.fromMicroseconds(t._1)),
+                      Declination.unsafeFromAngle(Angle.fromMicroarcseconds(t._2))))(
+        (c: Coordinates)                  =>
+          (c.ra.toHourAngle.toMicroseconds, c.dec.toAngle.toMicroarcseconds)
+      )
+
+    type EphemerisRow = (EphemerisKey, Instant, Coordinates, String, String)
+
+    val insert: Update[EphemerisRow] =
+      Update[EphemerisRow](
+        s"""
+          INSERT INTO ephemeris (key_type,
+                                 key,
+                                 timestamp,
+                                 ra,
+                                 dec,
+                                 ra_str,
+                                 dec_str)
+               VALUES (?, ?, ?, ?, ?, ?, ?)
+        """)
+
+    private def selectFragment(k: EphemerisKey): Fragment =
+      fr"""
+         SELECT timestamp,
+                ra,
+                dec
+           FROM ephemeris
+          WHERE key_type = ${k.keyType} AND key = ${k.des}
+      """
+
+    def select(k: EphemerisKey): Query0[Ephemeris.Element] =
+      selectFragment(k).query[Ephemeris.Element]
+
+    def selectBetween(k: EphemerisKey, s: Instant, e: Instant): Query0[Ephemeris.Element] =
+      (selectFragment(k) ++ fr"""AND timestamp >= $s AND timestamp < $e""")
+        .query[Ephemeris.Element]
+
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -62,6 +62,10 @@ object EphemerisDao {
   def streamRange(k: EphemerisKey, start: InstantMicros, end: InstantMicros): Stream[ConnectionIO, Ephemeris.Element] =
     Statements.selectRange(k, start, end).stream
 
+  /** Create the next UserSupplied ephemeris key value. */
+  val nextUserSuppliedKey: ConnectionIO[EphemerisKey.UserSupplied] =
+    Statements.selectNextUserSuppliedKey.unique
+
   object Statements {
 
     // Describe how to turn an EphemerisKey into a (EphemerisKeyType, String)
@@ -117,6 +121,11 @@ object EphemerisDao {
     def selectRange(k: EphemerisKey, s: InstantMicros, e: InstantMicros): Query0[Ephemeris.Element] =
       (selectFragment(k) ++ fr"""AND timestamp >= $s AND timestamp < $e""")
         .query[Ephemeris.Element]
+
+    val selectNextUserSuppliedKey: Query0[EphemerisKey.UserSupplied] =
+      sql"""
+        SELECT nextval('user_ephemeris_id')
+      """.query[Long].map(id => EphemerisKey.UserSupplied(id.toInt))
 
   }
 }

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -35,9 +35,21 @@ object EphemerisDao {
   def update(k: EphemerisKey, e: Ephemeris): ConnectionIO[Unit] =
     (delete(k) *> insert(k, e)).void
 
+  /** Selects all ephemeris elements associated with the given key into an
+    * Ephemeris object.
+    */
   def selectAll(k: EphemerisKey): ConnectionIO[Ephemeris] =
     runSelect(Statements.select(k))
 
+  /** Selects all ephemeris elements that fall between start (inclusive) and end
+    * (exclusive) into an Ephemeris object.
+    *
+    * @param k     key to match
+    * @param start start time (inclusive)
+    * @param end   end time (exclusive
+    *
+    * @return Ephemeris object with just the matching elements
+    */
   def selectRange(k: EphemerisKey, start: InstantMicros, end: InstantMicros): ConnectionIO[Ephemeris] =
     runSelect(Statements.selectRange(k, start, end))
 

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -8,8 +8,7 @@ import doobie._, doobie.implicits._
 import doobie.enum.jdbctype.{ Distinct => JdbcDistinct, Array => _, _ }
 import doobie.postgres.implicits._
 import gem.math.{ Angle, Offset, Wavelength }
-import gem.util.{ Enumerated, Location }
-import java.sql.Timestamp
+import gem.util.{ Enumerated, InstantMicros, Location }
 import java.time.{Duration, Instant}
 import java.util.logging.Level
 import scala.reflect.runtime.universe.TypeTag
@@ -114,8 +113,8 @@ package object dao {
   implicit def levelMeta: Meta[Level] =
     Meta[String].xmap(Level.parse, _.getName)
 
-  implicit val InstantMeta: Meta[Instant] =
-    Meta[Timestamp].xmap(_.toInstant, Timestamp.from)
+  implicit val InstantMicrosMeta: Meta[InstantMicros] =
+    Meta[Instant].xmap(InstantMicros.truncate, _.toInstant)
 
   implicit val LocationMeta: Meta[Location.Middle] =
     Meta[List[Int]].xmap(Location.unsafeMiddleFromFoldable(_), _.toList)

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -77,4 +77,23 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       e1 shouldEqual execTest(m + (k -> e0), p)
     }
   }
+
+  property("EphemerisDao should generate UserSupplied ephemeris keys") {
+
+    // Select a handful of ids and make sure they are unique.
+    //
+    // NOTE: even though we abort the transaction and rollback, this doesn't
+    // reset the sequence id counter because SEQUENCE is "non-transactional".
+    // A flywayClean followed by flywayMigrate will reset the sequence of
+    // course, or an explicit SELECT setval('user_ephemeris_id', 0, false).
+
+    val ids: List[EphemerisKey.UserSupplied] =
+      (1 to 10)
+        .toList
+        .traverse(_ => EphemerisDao.nextUserSuppliedKey)
+        .transact(xa)
+        .unsafeRunSync
+
+    ids.distinct shouldEqual ids
+  }
 }

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.arb.ArbEphemeris._
+import gem.arb.ArbEphemerisKey._
+import gem.arb.ArbTime._
+import gem.math.Ephemeris
+import gem.util.InstantMicros
+
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.Matchers._
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
+class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
+
+  type EphemerisMap = Map[EphemerisKey, Ephemeris]
+
+  //
+  // Inserts all the ephemeris data and executes the given command.
+  //
+  private def execTest[A](m: EphemerisMap, ca: ConnectionIO[A]): A =
+    (m.toList.traverse((EphemerisDao.insert _).tupled) *> ca)
+      .transact(xa)
+      .unsafeRunSync
+
+  property("EphemerisDao should return empty ephmeris if the key is not found") {
+    forAll { (k: EphemerisKey, m: EphemerisMap) =>
+      val e = execTest(m - k, EphemerisDao.selectAll(k))
+      e shouldEqual Ephemeris.Empty
+    }
+  }
+
+  property("EphemerisDao should selectAll") {
+    forAll { (k: EphemerisKey, e: Ephemeris, m: EphemerisMap) =>
+      val eʹ = execTest(m + (k -> e), EphemerisDao.selectAll(k))
+      e shouldEqual eʹ
+    }
+  }
+
+  property("EphemerisDao should selectRange") {
+    forAll { (k: EphemerisKey, e: Ephemeris, m: EphemerisMap, i0: InstantMicros, i1: InstantMicros) =>
+      val List(start, end) = List(i0, i1).sorted
+      val eʹ = execTest(m + (k -> e), EphemerisDao.selectRange(k, start, end))
+      e.toMap.range(start, end) shouldEqual eʹ.toMap
+    }
+  }
+
+  property("EphemerisDao should delete by key") {
+    forAll { (k: EphemerisKey, e: Ephemeris, m: EphemerisMap) =>
+      val eʹ = execTest(m + (k -> e), EphemerisDao.delete(k) *> EphemerisDao.selectAll(k))
+      eʹ shouldEqual Ephemeris.Empty
+    }
+  }
+
+  property("EphemerisDao should not delete others") {
+    forAll { (k: EphemerisKey, e: Ephemeris, m: EphemerisMap) =>
+      val p  = EphemerisDao.delete(k) *>
+                 (m - k).keys.toList.traverse(kʹ => EphemerisDao.selectAll(kʹ).tupleLeft(kʹ)).map(_.toMap)
+
+      (m - k) shouldEqual execTest(m + (k -> e), p)
+    }
+  }
+
+  property("EphemerisDao update should replace existing") {
+    forAll { (k: EphemerisKey, e0: Ephemeris, e1: Ephemeris, m: EphemerisMap) =>
+      val p = EphemerisDao.update(k, e1) *>
+                EphemerisDao.selectAll(k)
+
+      e1 shouldEqual execTest(m + (k -> e0), p)
+    }
+  }
+}

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -62,6 +62,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val smartGcalType    = SmartGcalType.Arc
     val instrumentConfig = f2Config
     val stepType         = StepType.Science
+    val ephemerisKey     = EphemerisKey.Comet("Lanrezac")
 
     val gmosCustomRoiEntry =
       gem.config.GmosConfig.GmosCustomRoiEntry.unsafeFromDescription(1, 1, 1, 1)

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -12,7 +12,7 @@ class EphemerisCheck extends Check {
             "insert"      in check(insert)
   it should "delete"      in check(delete(Dummy.ephemerisKey))
   it should "select"      in check(select(Dummy.ephemerisKey))
-  it should "selectRange" in check(selectRange(Dummy.ephemerisKey, InstantMicros.now(), InstantMicros.now()))
+  it should "selectRange" in check(selectRange(Dummy.ephemerisKey, InstantMicros.Min, InstantMicros.Max))
 
   it should "selectNextUserSuppliedKey" in check(selectNextUserSuppliedKey)
 }

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -4,12 +4,13 @@
 package gem.dao
 package check
 
-import java.time.Instant
+import gem.util.InstantMicros
 
 class EphemerisCheck extends Check {
   import EphemerisDao.Statements._
   "EphemerisDao.Statements" should
-            "insert"        in check(insert)
-  it should "select"        in check(select(Dummy.ephemerisKey))
-  it should "selectBetween" in check(selectBetween(Dummy.ephemerisKey, Instant.now, Instant.now))
+            "insert"      in check(insert)
+  it should "delete"      in check(delete(Dummy.ephemerisKey))
+  it should "select"      in check(select(Dummy.ephemerisKey))
+  it should "selectRange" in check(selectRange(Dummy.ephemerisKey, InstantMicros.now(), InstantMicros.now()))
 }

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -13,4 +13,6 @@ class EphemerisCheck extends Check {
   it should "delete"      in check(delete(Dummy.ephemerisKey))
   it should "select"      in check(select(Dummy.ephemerisKey))
   it should "selectRange" in check(selectRange(Dummy.ephemerisKey, InstantMicros.now(), InstantMicros.now()))
+
+  it should "selectNextUserSuppliedKey" in check(selectNextUserSuppliedKey)
 }

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import java.time.Instant
+
+class EphemerisCheck extends Check {
+  import EphemerisDao.Statements._
+  "EphemerisDao.Statements" should
+            "insert"        in check(insert)
+  it should "select"        in check(select(Dummy.ephemerisKey))
+  it should "selectBetween" in check(selectBetween(Dummy.ephemerisKey, Instant.now, Instant.now))
+}

--- a/modules/horizons/src/main/scala/gem/horizons/Hello.scala
+++ b/modules/horizons/src/main/scala/gem/horizons/Hello.scala
@@ -1,6 +1,0 @@
-// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
-// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-
-package gem.horizons
-
-trait Hello

--- a/modules/horizons/src/main/scala/gem/horizons/Hello.scala
+++ b/modules/horizons/src/main/scala/gem/horizons/Hello.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+trait Hello

--- a/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
+++ b/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
@@ -2,6 +2,10 @@
 --
 -- Ephemeris
 --
+-- RA and dec are represented in both numeric (µs, µas respectively) and
+-- formatted string representation.  Internally we use the numeric value,
+-- but the string representation is provided as well for human consumption.
+--
 
 CREATE TABLE ephemeris (
     key_type   identifier REFERENCES e_ephemeris_type ON DELETE CASCADE,
@@ -23,6 +27,11 @@ COMMENT ON COLUMN ephemeris.ra_str  IS 'HH:MM:SS.µµµµµµ';
 COMMENT ON COLUMN ephemeris.dec_str IS '[+-]DD:MM:SS.µµµµµµ';
 
 CREATE INDEX ephemeris_index ON ephemeris (key_type, key, timestamp);
+
+--
+-- Sequence for UserSupplied keys.  Here we set the max value to Int.MaxValue
+-- so that we can store the resulting value in an Int.
+--
 
 CREATE SEQUENCE user_ephemeris_id
     MINVALUE 0

--- a/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
+++ b/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
@@ -16,7 +16,8 @@ CREATE TABLE ephemeris (
     ra_str     varchar(15) NOT NULL,
     dec_str    varchar(16) NOT NULL,
     CONSTRAINT ra_str_check  CHECK (ra_str  ~     '^\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'),
-    CONSTRAINT dec_str_check CHECK (dec_str ~ '^[+-]\d\d:\d\d:\d\d\.\d\d\d\d\d\d$')
+    CONSTRAINT dec_str_check CHECK (dec_str ~ '^[+-]\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'),
+    PRIMARY KEY (key_type, key, timestamp)
 );
 
 ALTER TABLE ephemeris OWNER TO postgres;
@@ -26,7 +27,6 @@ COMMENT ON COLUMN ephemeris.dec     IS 'µas';
 COMMENT ON COLUMN ephemeris.ra_str  IS 'HH:MM:SS.µµµµµµ';
 COMMENT ON COLUMN ephemeris.dec_str IS '[+-]DD:MM:SS.µµµµµµ';
 
-CREATE INDEX ephemeris_index ON ephemeris (key_type, key, timestamp);
 
 --
 -- Sequence for UserSupplied keys.  Here we set the max value to Int.MaxValue

--- a/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
+++ b/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
@@ -1,0 +1,33 @@
+
+--
+-- Ephemeris
+--
+
+CREATE TABLE ephemeris (
+    key_type   identifier REFERENCES e_ephemeris_type ON DELETE CASCADE,
+    key        text        NOT NULL,
+    timestamp  timestamptz NOT NULL,
+    ra         bigint      NOT NULL,
+    dec        bigint      NOT NULL,
+    ra_str     varchar(15) NOT NULL,
+    dec_str    varchar(16) NOT NULL,
+    CONSTRAINT ra_str_check  CHECK (ra_str  ~     '^\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'),
+    CONSTRAINT dec_str_check CHECK (dec_str ~ '^[+-]\d\d:\d\d:\d\d\.\d\d\d\d\d\d$')
+);
+
+ALTER TABLE ephemeris OWNER TO postgres;
+
+COMMENT ON COLUMN ephemeris.ra      IS 'µs';
+COMMENT ON COLUMN ephemeris.dec     IS 'µas';
+COMMENT ON COLUMN ephemeris.ra_str  IS 'HH:MM:SS.µµµµµµ';
+COMMENT ON COLUMN ephemeris.dec_str IS '[+-]DD:MM:SS.µµµµµµ';
+
+CREATE INDEX ephemeris_index ON ephemeris (key_type, key, timestamp);
+
+CREATE SEQUENCE user_ephemeris_id
+    MINVALUE 0
+    MAXVALUE 2147483647
+    START WITH 0
+    NO CYCLE;
+
+ALTER SEQUENCE user_ephemeris_id OWNER TO postgres;


### PR DESCRIPTION
This is the next installment in porting ephemeris support from the old OCS.  Here we introduce an `ephemeris` table and a DAO for getting data into and out of it.

This PR also changes the format of RA and Dec to `HH:MM:SS.µµµµµµ` and `[-+]DD:MM:SS.µµµµµµ` respectively to support sorting by RA and Dec.