### PR TITLE
organize reusable meta/composite instances

### DIFF
--- a/modules/db/src/main/scala/gem/dao/DatasetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/DatasetDao.scala
@@ -6,8 +6,11 @@ package gem.dao
 import cats.syntax.functor._
 import doobie._, doobie.implicits._
 import gem.{ Dataset, Observation }
+import gem.dao.meta._
 
 object DatasetDao {
+  import DatasetLabelMeta._
+  import ObservationIdMeta._
 
   /**
    * Construct a program to insert the given a `Dataset`, associating it with the given step

--- a/modules/db/src/main/scala/gem/dao/EventLogDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EventLogDao.scala
@@ -5,6 +5,7 @@ package gem.dao
 
 import doobie._, doobie.implicits._
 import gem.{Event, Observation}
+import gem.dao.meta._
 import gem.Event._
 import gem.enum.EventType
 import gem.enum.EventType.{Abort, Continue, EndIntegration, EndSequence, EndSlew, EndVisit, Pause, StartIntegration, StartSequence, StartSlew, StartVisit, Stop}
@@ -12,6 +13,8 @@ import java.time.Instant
 
 
 object EventLogDao {
+  import EnumeratedMeta._
+  import ObservationIdMeta._
 
   def insertAbortObserve(oid: Observation.Id): ConnectionIO[Int] =
     Statements.insertEvent(Abort, oid, None).run

--- a/modules/db/src/main/scala/gem/dao/GcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GcalDao.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import gem.config.GcalConfig
 import gem.config.GcalConfig.GcalLamp
 import doobie._, doobie.implicits._
+import gem.dao.meta._
 import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
 import gem.enum.GcalArc.{ArArc, CuArArc, ThArArc, XeArc}
 import java.time.Duration
@@ -15,6 +16,9 @@ import java.time.Duration
   * gcal (for smart gcal lookup).
   */
 object GcalDao {
+  import EnumeratedMeta._
+  import TimeMeta._
+
   def insertStepGcal(stepId: Int, gcal: GcalConfig): ConnectionIO[Int] =
     Statements.insertStepGcal(stepId, gcal).run
 

--- a/modules/db/src/main/scala/gem/dao/LogDao.scala
+++ b/modules/db/src/main/scala/gem/dao/LogDao.scala
@@ -6,8 +6,11 @@ package dao
 
 import doobie._, doobie.implicits._
 import java.util.logging.Level
+import gem.dao.meta._
 
 object LogDao {
+  import LevelMeta._
+  import ProgramIdMeta._
 
   def insert(user: User[_], level: Level, pid: Option[Program.Id], msg: String, t: Option[Throwable], elapsed: Option[Long]): ConnectionIO[Int] =
     Statements.insert(user, level, pid, msg, t, elapsed).run

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -7,10 +7,14 @@ package dao
 import cats.implicits._
 import doobie._, doobie.implicits._
 import gem.config.{DynamicConfig, StaticConfig}
+import gem.dao.meta._
 import gem.enum.Instrument
 import gem.util.Location
 
 object ObservationDao {
+  import EnumeratedMeta._
+  import ObservationIdMeta._
+  import ProgramIdMeta._
 
   /**
    * Construct a program to insert a fully-populated Observation. This program will raise a

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -4,13 +4,14 @@
 package gem
 package dao
 
-import gem.config.{DynamicConfig, StaticConfig}
-
-import doobie._, doobie.implicits._
-
 import cats.implicits._
+import doobie._, doobie.implicits._
+import gem.config.{DynamicConfig, StaticConfig}
+import gem.dao.meta._
 
 object ProgramDao {
+  import EnumeratedMeta._
+  import ProgramIdMeta._
 
   /** Insert a program, disregarding its observations, if any. */
   def insertFlat(p: Program[_]): ConnectionIO[Program.Id] =

--- a/modules/db/src/main/scala/gem/dao/SemesterDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SemesterDao.scala
@@ -6,8 +6,10 @@ package dao
 
 import cats.syntax.functor._
 import doobie._, doobie.implicits._
+import gem.dao.meta._
 
 object SemesterDao {
+  import EnumeratedMeta._
 
   def canonicalize(s: Semester): ConnectionIO[Semester] =
     Statements.canonicalize(s).run.as(s)

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -9,6 +9,7 @@ import gem._
 import gem.SmartGcal._
 import gem.config._
 import gem.config.DynamicConfig.{ SmartGcalKey, SmartGcalSearchKey }
+import gem.dao.meta._
 import gem.enum._
 import gem.math.Wavelength
 import gem.util.Location
@@ -16,6 +17,8 @@ import fs2.Stream
 import scala.collection.immutable.TreeMap
 
 object SmartGcalDao {
+  import EnumeratedMeta._
+  import WavelengthMeta._
 
   def select(k: SmartGcalSearchKey, t: SmartGcalType): ConnectionIO[List[GcalConfig]] =
     for {

--- a/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
@@ -7,9 +7,12 @@ package dao
 import cats.implicits._
 import doobie._, doobie.implicits._
 import gem.enum.{ GmosDetector, Instrument, MosPreImaging }
+import gem.dao.meta._
 import gem.config._
 
 object StaticConfigDao {
+  import EnumeratedMeta._
+  import OffsetMeta._
 
   def insert(s: StaticConfig): ConnectionIO[Int] =
     for {

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -5,16 +5,22 @@ package gem
 package dao
 
 import cats.implicits._
+import doobie._, doobie.implicits._
 import gem.util.Location
 import gem.config._
 import gem.config.GcalConfig.GcalLamp
+import gem.dao.meta._
 import gem.enum._
 import gem.math.{ Offset, Wavelength }
-import doobie._, doobie.implicits._
 import java.time.Duration
 import scala.collection.immutable.TreeMap
 
 object StepDao {
+  import EnumeratedMeta._
+  import LocationMeta._
+  import ObservationIdMeta._
+  import OffsetMeta._
+  import TimeMeta._
 
   type Loc = Location.Middle
 

--- a/modules/db/src/main/scala/gem/dao/UserDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserDao.scala
@@ -4,12 +4,15 @@
 package gem
 package dao
 
+import gem.dao.meta._
 import gem.enum.ProgramRole
 import cats.data._, cats.implicits._
 
 import doobie._, doobie.implicits._
 
 object UserDao {
+  import EnumeratedMeta._
+  import ProgramIdMeta._
 
   /**
    * Select the root user, for system processes. Always succceds if the system is consistent;

--- a/modules/db/src/main/scala/gem/dao/composite/Coordinates.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/Coordinates.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import doobie._
+import gem.math.{ Angle, HourAngle, Coordinates, Declination, RightAscension }
+
+trait CoordinatesComposite {
+
+  /** Map Coordinates as a (µsec, µasec) pair. */
+  implicit val CompositeCoordinates: Composite[Coordinates] =
+    Composite[(Long, Long)].imap {
+      case (ra, dec) =>
+        Coordinates(
+          RightAscension(HourAngle.fromMicroseconds(ra)),
+          Declination.unsafeFromAngle(Angle.fromMicroarcseconds(dec))
+        )
+      }(c => (c.ra.toHourAngle.toMicroseconds, c.dec.toAngle.toMicroarcseconds))
+
+}
+object CoordinatesComposite extends CoordinatesComposite

--- a/modules/db/src/main/scala/gem/dao/composite/EphemerisKey.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/EphemerisKey.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import doobie._
+import gem.EphemerisKey
+import gem.enum.EphemerisKeyType
+import gem.dao.meta._
+
+trait EphemerisKeyComposite {
+  import EnumeratedMeta._
+
+  /** Map an EphemerisKey as an (EphemerisKeyType, String) pair. */
+  implicit val CompositeEphemerisKey: Composite[EphemerisKey] =
+    Composite[(EphemerisKeyType, String)].imap(
+      (t: (EphemerisKeyType, String)) => EphemerisKey.unsafeFromTypeAndDes(t._1, t._2))(
+      (k: EphemerisKey)               => (k.keyType, k.des)
+    )
+
+}
+object EphemerisKeyComposite extends EphemerisKeyComposite

--- a/modules/db/src/main/scala/gem/dao/meta/Angle.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Angle.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math.Angle
+
+trait AngleMeta {
+
+  // Angle mapping to signed arcseconds via NUMERIC. NOT implicit. We're mapping a type that
+  // is six orders of magnitude more precise than the database column, so we will shift
+  // the decimal pure back and forth.
+  val AngleMetaAsSignedArcseconds: Meta[Angle] =
+    Meta[java.math.BigDecimal]
+      .xmap[Angle](
+        b => Angle.fromMicroarcseconds(b.movePointRight(6).longValue),
+        a => new java.math.BigDecimal(a.toSignedMicroarcseconds).movePointLeft(6)
+      )
+
+}
+object AngleMeta extends AngleMeta

--- a/modules/db/src/main/scala/gem/dao/meta/DatasetLabel.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/DatasetLabel.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.Dataset
+
+trait DatasetLabelMeta {
+
+  // Dataset.Label as string
+  implicit val DatasetLabelMeta: Meta[Dataset.Label] =
+    Meta[String].xmap(Dataset.Label.unsafeFromString, _.format)
+
+}
+object DatasetLabelMeta extends DatasetLabelMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Distinct.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Distinct.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import cats.data.NonEmptyList
+import doobie._
+import doobie.enum.jdbctype.{ Distinct => JdbcDistinct, _ }
+
+/**
+ * Constructor for a Meta instances with an underlying types that are reported by JDBC as
+ * type Distinct, as happens when a column has a check constraint. By using a data type with
+ * a Distinct Meta instance we can satisfy the query checker.
+ */
+object Distinct {
+
+  def integer(name: String): Meta[Int] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, Integer),
+      NonEmptyList.of(name),
+      _ getInt _,
+      _.setInt(_, _),
+      _.updateInt(_, _)
+    )
+
+  def long(name: String): Meta[Long] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, BigInt),
+      NonEmptyList.of(name),
+      _ getLong _,
+      _.setLong(_, _),
+      _.updateLong(_, _)
+    )
+
+  def short(name: String): Meta[Short] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, SmallInt),
+      NonEmptyList.of(name),
+      _ getShort _,
+      _.setShort(_, _),
+      _.updateShort(_, _)
+    )
+
+  def string(name: String): Meta[String] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, VarChar),
+      NonEmptyList.of(name),
+      _ getString _,
+      _.setString(_, _),
+      _.updateString(_, _)
+    )
+
+}

--- a/modules/db/src/main/scala/gem/dao/meta/Enumerated.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Enumerated.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.util.Enumerated
+import scala.reflect.runtime.universe.TypeTag
+
+trait EnumeratedMeta {
+
+  // Enumerated by tag as DISTINCT (identifier)
+  implicit def enumeratedMeta[A >: Null : TypeTag](implicit ev: Enumerated[A]): Meta[A] =
+    Distinct.string("identifier").xmap[A](ev.unsafeFromTag(_), ev.tag(_))
+
+}
+object EnumeratedMeta extends EnumeratedMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Level.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Level.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import java.util.logging.Level
+
+trait LevelMeta {
+
+  // Java Log Levels (not nullable)
+  implicit val levelMeta: Meta[Level] =
+    Meta[String].xmap(Level.parse, _.getName)
+
+}
+object LevelMeta extends LevelMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Location.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Location.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import cats.implicits._
+import doobie._
+import doobie.postgres.implicits._
+import gem.util.Location
+
+trait LocationMeta {
+
+  implicit val LocationMeta: Meta[Location.Middle] =
+    Meta[List[Int]].xmap(Location.unsafeMiddleFromFoldable(_), _.toList)
+
+}
+object LocationMeta extends LocationMeta

--- a/modules/db/src/main/scala/gem/dao/meta/ObservationId.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ObservationId.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.Observation
+
+trait ObservationIdMeta {
+
+  // Observation.Id as string
+  implicit val ObservationIdMeta: Meta[Observation.Id] =
+    Meta[String].xmap(Observation.Id.unsafeFromString, _.format)
+
+}
+object ObservationIdMeta extends ObservationIdMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Offset.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Offset.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math.Offset
+
+trait OffsetMeta {
+  import AngleMeta._
+
+  // OffsetP maps to a signed angle in arcseconds
+  implicit val OffsetPMeta: Meta[Offset.P] =
+    AngleMetaAsSignedArcseconds.xmap(Offset.P(_), _.toAngle)
+
+  // OffsetQ maps to a signed angle in arcseconds
+  implicit val OffsetQMeta: Meta[Offset.Q] =
+    AngleMetaAsSignedArcseconds.xmap(Offset.Q(_), _.toAngle)
+
+}
+object OffsetMeta extends OffsetMeta

--- a/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.Program
+
+trait ProgramIdMeta {
+
+  // Program.Id as string
+  implicit val ProgramIdMeta: Meta[Program.Id] =
+    Meta[String].xmap(Program.Id.unsafeFromString, _.format)
+
+}
+object ProgramIdMeta extends ProgramIdMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Time.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Time.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.util.InstantMicros
+import java.time.{ Instant, Duration }
+
+trait TimeMeta {
+
+  implicit val InstantMicrosMeta: Meta[InstantMicros] =
+    Meta[Instant].xmap(InstantMicros.truncate, _.toInstant)
+
+  implicit val DurationMeta: Meta[Duration] =
+    Distinct.long("milliseconds").xmap(Duration.ofMillis, _.toMillis)
+
+}
+object TimeMeta extends TimeMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Wavelength.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Wavelength.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math.Wavelength
+
+trait WavelengthMeta {
+
+  // Wavelength maps to an integer in angstroms
+  implicit val WavelengthMeta: Meta[Wavelength] =
+    Meta[Int].xmap(Wavelength.unsafeFromAngstroms, _.toAngstroms)
+
+}
+object WavelengthMeta extends WavelengthMeta

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -5,11 +5,12 @@ package gem.ocs2
 
 import cats.effect.IO, cats.implicits._
 import doobie._, doobie.implicits._
+import gem.dao.meta._
 import doobie.postgres.implicits._
 import java.util.logging.{ Level, Logger }
 
 /** Shared support for import applications using Doobie. */
-trait DoobieClient {
+trait DoobieClient extends ProgramIdMeta with ObservationIdMeta {
 
   val Url  = "jdbc:postgresql:gem"
   val User = "postgres"


### PR DESCRIPTION
This is the first of a few database layer cleanups. This moves the reusable meta instances out of the package object and imports them explicitly where needed. This seems cleaner to me and it simplifies the dependency graph which might help compilation times a bit.