### PR TITLE
schemaspy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ code in the `sql` project. In any case, you can [re]-generate the enumerated typ
 sbt genEnums
 ```
 
+### Generating Schema Documentation
+
+You can do `sbt schemaSpy` to generate a little website about the database. It will appear in `modules/sql/target/schemaspy`.
+
 
 ### Importing
 
@@ -142,12 +146,6 @@ Multiple main classes detected, select one to run:
 
 If you pick the program importer, it will import everything which is the same as explicitly passing in `Int.MaxValue`.
 
-
-### Enumerated Types
-
-Enumerated types are represented by tables named `e_whatever` which are the source for generated code on the Scala side. After compiling if you look in `modules/core/target/scala-2.11/src_managed/gem` you will see the source. The rationale for this is that the database becomes the source of truth, which makes things like filter wavelengths, etc., available for querying and reporting.
-
-It's not yet clear which bits could be data-driven and which need to exist in Scala code. We do need to write code against specific filters and so on but we could still read these from the database on the fly. TBD.
 
 ### Schema Updates
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sbt genEnums
 
 ### Generating Schema Documentation
 
-You can do `sbt schemaSpy` to generate a little website about the database. It will appear in `modules/sql/target/schemaspy`.
+You can do `sbt schemaSpy` to generate a little website about the database using [SchemaSpy](http://schemaspy.org/). It will appear in `modules/sql/target/schemaspy`.
 
 
 ### Importing

--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ to poke around with the database on the commandline. For real work I recommend a
 
 ### Generating Enumerated Types
 
-There are many enumerated types in the database. The Scala equivalents are generated *on demand* by queries, then checked into source control like normal source files. This is only needed if you update the contents of an enum in the schema, or add/modify a the generation
+There are many enumerated types in the database, represented by tables named `e_whatever`. The Scala equivalents are generated *on demand* by queries, then checked into source control like normal source files. This is only needed if you update the contents of an enum in the schema, or add/modify a the generation
 code in the `sql` project. In any case, you can [re]-generate the enumerated types thus:
 
 ```
 sbt genEnums
 ```
+
+The source files appear in `modules/core/shared/src/main/scala/gem/enum`.
 
 ### Generating Schema Documentation
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,10 @@ git.uncommittedSignifier in ThisBuild := Some("UNCOMMITTED")
 // check for library updates whenever the project is [re]load
 onLoad in Global := { s => "dependencyUpdates" :: s }
 
+// some extra commands for us
+addCommandAlias("genEnums", "; sql/runMain gem.sql.Main modules/core/shared/src/main/scala/gem/enum; headerCreate")
+addCommandAlias("schemaSpy", "sql/runMain org.schemaspy.Main -t pgsql -port 5432 -db gem -o modules/sql/target/schemaspy -u postgres -host localhost -s public")
+
 // Before printing the prompt check git to make sure all is well.
 shellPrompt in ThisBuild := { state =>
   import scala.sys.process._
@@ -263,8 +267,7 @@ lazy val sql = project
       "org.flywaydb" %  "flyway-core"      % flywayVersion,
       "org.tpolecat" %% "doobie-core"      % doobieVersion,
       "org.tpolecat" %% "doobie-postgres"  % doobieVersion
-    ),
-    addCommandAlias("genEnums", "; sql/runMain gem.sql.Main modules/core/src/main/scala/gem/enum; headerCreate")
+    )
   )
 
 lazy val ocs2 = project


### PR DESCRIPTION
This adds Schema Spy to the build so you can generate a data dictionary locally. Eventually this will be produced and published as part of the automated build.