### PR TITLE
Ephemeris Parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val flywaySettings = Seq(
 lazy val gem = project
   .in(file("."))
   .settings(commonSettings)
-  .aggregate(coreJVM, db, json, ocs2, service, telnetd, ctl, web, sql)
+  .aggregate(coreJVM, db, json, ocs2, ephemeris, service, telnetd, ctl, web, sql)
 
 lazy val core = crossProject
   .crossType(CrossType.Full)
@@ -281,6 +281,17 @@ lazy val ocs2 = project
       "org.http4s"             %% "http4s-scala-xml"         % http4sVersion,
       "org.http4s"             %% "http4s-blaze-client"      % http4sVersion,
       "org.http4s"             %% "http4s-blaze-server"      % http4sVersion
+    )
+  )
+
+lazy val ephemeris = project
+  .in(file("modules/ephemeris"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(coreJVM, db, sql)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-testkit" % catsVersion % "test"
     )
   )
 

--- a/modules/core/shared/src/main/scala/gem/parser/Misc.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Misc.scala
@@ -13,17 +13,37 @@ trait MiscParsers {
   val void: Parser[Unit] =
     ok(()) namedOpaque "void"
 
+  /** Creates a Parser that consumes the given character. */
+  private def matchChar(c: Char, n: String): Parser[Unit] =
+    char(c).void namedOpaque n
+
+  /** Parser for a colon. */
+  val colon: Parser[Unit] =
+    matchChar(':', "colon")
+
+  /** Parser for a dot/period/decimal point. */
+  val dot: Parser[Unit] =
+    matchChar('.', "dot")
+
   /** Parser for a hyphen. */
   val hyphen: Parser[Unit] =
-    char('-').void namedOpaque "hyphen"
+    matchChar('-', "hyphen")
+
+  /** Parser for a single space. */
+  val space: Parser[Unit] =
+    matchChar(' ', "space")
 
   /** Parser for one or more spaces. */
   val spaces1: Parser[Unit] =
-    skipMany1(char(' ')) namedOpaque "spaces1"
+    skipMany1(space) namedOpaque "spaces1"
 
   /** Parser for a non-whitespace string. */
   val nonWhitespace: Parser[String] =
     takeWhile(c => !c.isWhitespace) namedOpaque "nonWhitespace"
+
+  /** Parser for a vertical whitespace String. */
+  val verticalWhitespace: Parser[Unit] =
+    skipMany1(char('\n') | char('\r'))
 
   /** Catch a `NumberFormatException`, useful for flatMap. */
   def catchNFE[A, B](f: A => B): A => Parser[B] = a =>

--- a/modules/core/shared/src/main/scala/gem/parser/Time.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Time.scala
@@ -3,12 +3,15 @@
 
 package gem.parser
 
+import cats.implicits._
+
 import atto._, Atto._
-import java.time.{ DateTimeException, Year, Month, LocalDate }
+import java.time.{ DateTimeException, Instant, LocalDate, LocalDateTime, LocalTime, Month, Year, ZoneOffset }
 
 /** Parsers for `java.time` data types. */
 trait TimeParsers {
-  import MiscParsers.intN
+
+  import MiscParsers.{ dot, frac, intN, spaces1, void }
 
   /** Catch a `DateTimeException`, useful for flatMap. */
   def catchDTE[A, B](f: A => B): A => Parser[B] = a =>
@@ -22,14 +25,61 @@ trait TimeParsers {
   val month2: Parser[Month] =
     intN(2).flatMap(catchDTE(Month.of)) namedOpaque "month2"
 
+  /** Parser for 3 letter month strings like "Jan", parsed as a `Month`. */
+  val monthMMM: Parser[Month] = {
+    import Month._
+
+    val months = List(
+      "Jan" -> JANUARY, "Feb" -> FEBRUARY, "Mar" -> MARCH,
+      "Apr" -> APRIL,   "May" -> MAY,      "Jun" -> JUNE,
+      "Jul" -> JULY,    "Aug" -> AUGUST,   "Sep" -> SEPTEMBER,
+      "Oct" -> OCTOBER, "Nov" -> NOVEMBER, "Dec" -> DECEMBER
+    )
+
+    choice(months.map { case (s, m) => string(s).as(m) }) namedOpaque "monthMMM"
+  }
+
+  /** Generic parser for a local date string in the order year, month, day.
+    *
+    * @param month parser for the month component
+    * @param sep   parser for any separator between components
+    */
+  def genYMD(month: Parser[Month], sep: Parser[_]): Parser[LocalDate] =
+    (for {
+      y <- year4 <~ sep
+      m <- month <~ sep
+      d <- intN(2) namedOpaque "2-digit day of month"
+      l <- catchDTE((d: Int) => LocalDate.of(y.getValue, m, d))(d)
+    } yield l) named s"genYMD($month, $sep)"
+
   /** Parser for a `LocalDate` in the form `20151107`. */
   def yyyymmdd: Parser[LocalDate] =
-    (for {
-      y <- year4
-      m <- month2
-      d <- intN(2) namedOpaque "2-digit day of month"
-      a <- catchDTE((d: Int) => LocalDate.of(y.getValue, m, d))(d)
-    } yield a) named "yyyymmdd"
+    genYMD(month2, void) named "yyyymmdd"
 
+  /** Generic parser for a `LocalTime` with fractional seconds to nanosecond
+    * precision.
+    *
+    * @param sep parser for any separator between hours, minutes, and seconds
+    */
+  def genLocalTime(sep: Parser[_]): Parser[LocalTime] = {
+    val nano: Parser[Int] =
+      opt(dot ~> frac(9)).flatMap(o => ok(o.getOrElse(0))) namedOpaque "up to 9 digits nanoseconds"
+
+    (for {
+      h  <- (intN(2) namedOpaque "2-digit hour of day")     <~ sep
+      m  <- (intN(2) namedOpaque "2-digit minute of hour")  <~ sep
+      s  <- (intN(2) namedOpaque "2-digit second of minute")
+      ns <- nano
+      t  <- catchDTE((ms: Int) => LocalTime.of(h, m, s, ns))(ns)
+    } yield t) named "00:00:00.000000000"
+  }
+
+  /** Parser for instants in UTC, where the date is followed by the time and
+    * separated by spaces.
+    */
+  def instantUTC(date: Parser[LocalDate], time: Parser[LocalTime]): Parser[Instant] =
+    (date <~ spaces1, time).mapN { case (d, t) =>
+      LocalDateTime.of(d, t).toInstant(ZoneOffset.UTC)
+    }
 }
 object TimeParsers extends TimeParsers

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package horizons
+
+import gem.math.Ephemeris
+import gem.util.InstantMicros
+
+import atto.ParseResult
+import atto.syntax.parser._
+
+
+/** Horizons ephemeris parser.  Parses horizons output generated with the flags
+  *
+  * 	QUANTITIES=1; time digits=FRACSEC; extra precision=YES
+  *
+  * into an `Ephemeris` object.
+  */
+object EphemerisParser {
+
+  private object impl {
+
+    import atto._
+    import Atto._
+    import cats.implicits._
+    import gem.parser.CoordinateParsers._
+    import gem.parser.MiscParsers._
+    import gem.parser.TimeParsers._
+
+    val soe           = string("$$SOE")
+    val eoe           = string("$$EOE")
+    val skipPrefix    = manyUntil(anyChar, soe)  ~> verticalWhitespace
+    val skipEol       = skipMany(noneOf("\n\r")) ~> verticalWhitespace
+    val solarPresence = oneOf("*CNA ").void namedOpaque "solarPresence"
+    val lunarPresence = oneOf("mrts ").void namedOpaque "lunarPresence"
+
+    val utc: Parser[InstantMicros] =
+      instantUTC(
+        genYMD(monthMMM, hyphen) named "yyyy-MMM-dd",
+        genLocalTime(colon)
+      ).map(InstantMicros.truncate)
+
+    val element: Parser[Ephemeris.Element] =
+      for {
+        _ <- space
+        i <- utc           <~ space
+        _ <- solarPresence
+        _ <- lunarPresence <~ spaces1
+        c <- coordinates   <~ skipEol
+      } yield (i, c)
+
+    val ephemeris: Parser[Ephemeris] =
+      skipPrefix ~> (
+        many(element).map(Ephemeris.fromFoldable[List]) <~ eoe
+      )
+  }
+
+  def parse(s: String): ParseResult[Ephemeris] =
+    impl.ephemeris.parseOnly(s)
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
@@ -13,7 +13,7 @@ import atto.syntax.parser._
 
 /** Horizons ephemeris parser.  Parses horizons output generated with the flags
   *
-  * 	QUANTITIES=1; time digits=FRACSEC; extra precision=YES
+  *   `QUANTITIES=1; time digits=FRACSEC; extra precision=YES`
   *
   * into an `Ephemeris` object.
   */

--- a/modules/ephemeris/src/test/resources/gem/horizons/borrelly.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/borrelly.eph
@@ -1,0 +1,238 @@
+*******************************************************************************
+JPL/HORIZONS                    19P/Borrelly               2017-Sep-08 05:33:32
+Rec #:900302          Soln.date: 2017-May-07_17:25:46   # obs: 2845 (1973-2017)
+ 
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs): 
+ 
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.                  
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061      
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391       
+   A= 3.609665546424225    MA= 137.93043492053     ADIST= 5.859531354066144    
+   PER= 6.8581765453391    N= .143715502           ANGMOM= .025557412          
+   DAN= 1.36332            DDN= 5.79504            L= 69.6892033               
+   B= -3.3504474           MOID= .377543           TP= 2001-Sep-14.2536303061  
+ 
+Comet physical (GM= km^3/s^2; RAD= km):                                        
+   GM= n.a.                RAD= 2.4                                            
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030           
+ 
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au): 
+   AMRAT=  0.                                      DT=  -47.24577              
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10       
+ Standard model:                                                               
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808    
+ 
+COMET comments 
+1: soln ref.= JPL#K157/5, data arc: 1973-08-23 to 2017-03-30
+2: k1=17., k2=5., phase coef.=0.03;
+*******************************************************************************
+ 
+ 
+*******************************************************************************
+Ephemeris / WWW_USER Fri Sep  8 05:33:32 2017 Pasadena, USA      / Horizons    
+*******************************************************************************
+Target body name: 19P/Borrelly                    {source: JPL#K157/5}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-01 00:00:00.0000 UT      
+Stop  time      : A.D. 2018-Feb-01 00:00:00.0000 UT      
+Step-size       : 100 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 4.2 x 4.2 x 4.2 km              {Equator, meridian, pole}    
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}    
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2                              
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL 
+EOP file        : eop.170907.p171129                                           
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-SEP-07. PREDICTS-> 2017-NOV-28
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s 
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )                           
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.                  
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061      
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391       
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-2.901624145572271E+00  Y=-4.714098832558961E+00  Z=-1.011739942319315E+00
+  VX= 2.370889154078356E-03 VY=-2.679782026686279E-03 VZ=-3.223564467123717E-03
+Comet physical (GM= km^3/s^2; RAD= km):                                        
+   GM= n.a.                RAD= 2.4                                            
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030           
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au): 
+   AMRAT=  0.                                      DT=  -47.24577              
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10       
+ Standard model:                                                               
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808    
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC
+*********************************************************
+$$SOE
+ 2017-Aug-01 00:00:00.000  m  14 47 38.2973 -01 50 22.540
+ 2017-Aug-02 20:09:36.000 *m  14 47 51.5561 -01 59 08.132
+ 2017-Aug-04 16:19:12.000 *   14 48 07.0089 -02 07 58.456
+ 2017-Aug-06 12:28:48.000 *   14 48 24.5857 -02 16 53.192
+ 2017-Aug-08 08:38:24.000  m  14 48 44.2911 -02 25 52.044
+ 2017-Aug-10 04:48:00.000  m  14 49 06.1660 -02 34 54.695
+ 2017-Aug-12 00:57:36.000     14 49 30.2181 -02 44 00.800
+ 2017-Aug-13 21:07:12.000 *   14 49 56.3840 -02 53 10.007
+ 2017-Aug-15 17:16:48.000 *   14 50 24.5539 -03 02 22.007
+ 2017-Aug-17 13:26:24.000 *m  14 50 54.6378 -03 11 36.553
+ 2017-Aug-19 09:36:00.000  m  14 51 26.6133 -03 20 53.425
+ 2017-Aug-21 05:45:36.000     14 52 00.5127 -03 30 12.369
+ 2017-Aug-23 01:55:12.000     14 52 36.3611 -03 39 33.061
+ 2017-Aug-24 22:04:48.000 *m  14 53 14.1199 -03 48 55.128
+ 2017-Aug-26 18:14:24.000 *m  14 53 53.6845 -03 58 18.219
+ 2017-Aug-28 14:24:00.000 *   14 54 34.9390 -04 07 42.062
+ 2017-Aug-30 10:33:36.000 N   14 55 17.8185 -04 17 06.454
+ 2017-Sep-01 06:43:12.000  m  14 56 02.3274 -04 26 31.200
+ 2017-Sep-03 02:52:48.000  m  14 56 48.4959 -04 35 56.046
+ 2017-Sep-04 23:02:24.000 Nm  14 57 36.3165 -04 45 20.676
+ 2017-Sep-06 19:12:00.000 *   14 58 25.7147 -04 54 44.779
+ 2017-Sep-08 15:21:36.000 *   14 59 16.5807 -05 04 08.119
+ 2017-Sep-10 11:31:12.000 *m  15 00 08.8327 -05 13 30.560
+ 2017-Sep-12 07:40:48.000  m  15 01 02.4574 -05 22 52.002
+ 2017-Sep-14 03:50:24.000     15 01 57.4900 -05 32 12.289
+ 2017-Sep-16 00:00:00.000     15 02 53.9529 -05 41 31.166
+ 2017-Sep-17 20:09:36.000 *m  15 03 51.8053 -05 50 48.322
+ 2017-Sep-19 16:19:12.000 *m  15 04 50.9476 -06 00 03.484
+ 2017-Sep-21 12:28:48.000 *m  15 05 51.2765 -06 09 16.474
+ 2017-Sep-23 08:38:24.000     15 06 52.7410 -06 18 27.188
+ 2017-Sep-25 04:48:00.000     15 07 55.3515 -06 27 35.499
+ 2017-Sep-27 00:57:36.000  m  15 08 59.1342 -06 36 41.184
+ 2017-Sep-28 21:07:12.000 *m  15 10 04.0721 -06 45 43.939
+ 2017-Sep-30 17:16:48.000 *   15 11 10.0843 -06 54 43.478
+ 2017-Oct-02 13:26:24.000 *   15 12 17.0636 -07 03 39.620
+ 2017-Oct-04 09:36:00.000 Nm  15 13 24.9370 -07 12 32.302
+ 2017-Oct-06 05:45:36.000  m  15 14 33.6984 -07 21 21.489
+ 2017-Oct-08 01:55:12.000  m  15 15 43.3828 -07 30 07.066
+ 2017-Oct-09 22:04:48.000 *   15 16 54.0065 -07 38 48.806
+ 2017-Oct-11 18:14:24.000 *   15 18 05.5242 -07 47 26.438
+ 2017-Oct-13 14:24:00.000 *m  15 19 17.8414 -07 55 59.762
+ 2017-Oct-15 10:33:36.000 *m  15 20 30.8692 -08 04 28.702
+ 2017-Oct-17 06:43:12.000     15 21 44.5730 -08 12 53.243
+ 2017-Oct-19 02:52:48.000     15 22 58.9716 -08 21 13.311
+ 2017-Oct-20 23:02:24.000 Cm  15 24 14.0880 -08 29 28.698
+ 2017-Oct-22 19:12:00.000 *m  15 25 29.8952 -08 37 39.105
+ 2017-Oct-24 15:21:36.000 *m  15 26 46.3061 -08 45 44.273
+ 2017-Oct-26 11:31:12.000 *   15 28 03.2161 -08 53 44.081
+ 2017-Oct-28 07:40:48.000     15 29 20.5612 -09 01 38.532
+ 2017-Oct-30 03:50:24.000  m  15 30 38.3407 -09 09 27.633
+ 2017-Nov-01 00:00:00.000 Nm  15 31 56.5849 -09 17 11.273
+ 2017-Nov-02 20:09:36.000 *   15 33 15.2968 -09 24 49.218
+ 2017-Nov-04 16:19:12.000 *   15 34 34.4193 -09 32 21.217
+ 2017-Nov-06 12:28:48.000 *   15 35 53.8567 -09 39 47.140
+ 2017-Nov-08 08:38:24.000 Am  15 37 13.5312 -09 47 07.005
+ 2017-Nov-10 04:48:00.000     15 38 33.4227 -09 54 20.886
+ 2017-Nov-12 00:57:36.000     15 39 53.5577 -10 01 28.756
+ 2017-Nov-13 21:07:12.000 *   15 41 13.9554 -10 08 30.424
+ 2017-Nov-15 17:16:48.000 *m  15 42 34.5792 -10 15 25.612
+ 2017-Nov-17 13:26:24.000 *m  15 43 55.3350 -10 22 14.105
+ 2017-Nov-19 09:36:00.000 C   15 45 16.1201 -10 28 55.856
+ 2017-Nov-21 05:45:36.000     15 46 36.8779 -10 35 30.937
+ 2017-Nov-23 01:55:12.000  m  15 47 57.6121 -10 41 59.392
+ 2017-Nov-24 22:04:48.000 *m  15 49 18.3473 -10 48 21.115
+ 2017-Nov-26 18:14:24.000 *m  15 50 39.0713 -10 54 35.867
+ 2017-Nov-28 14:24:00.000 *   15 51 59.7111 -11 00 43.420
+ 2017-Nov-30 10:33:36.000 *   15 53 20.1629 -11 06 43.700
+ 2017-Dec-02 06:43:12.000  m  15 54 40.3510 -11 12 36.806
+ 2017-Dec-04 02:52:48.000  m  15 56 00.2632 -11 18 22.881
+ 2017-Dec-05 23:02:24.000 *   15 57 19.9301 -11 24 01.943
+ 2017-Dec-07 19:12:00.000 *   15 58 39.3665 -11 29 33.831
+ 2017-Dec-09 15:21:36.000 *m  15 59 58.5261 -11 34 58.308
+ 2017-Dec-11 11:31:12.000 *m  16 01 17.3088 -11 40 15.233
+ 2017-Dec-13 07:40:48.000  m  16 02 35.6141 -11 45 24.649
+ 2017-Dec-15 03:50:24.000     16 03 53.3929 -11 50 26.707
+ 2017-Dec-17 00:00:00.000 C   16 05 10.6523 -11 55 21.489
+ 2017-Dec-18 20:09:36.000 *m  16 06 27.4100 -12 00 08.899
+ 2017-Dec-20 16:19:12.000 *m  16 07 43.6383 -12 04 48.710
+ 2017-Dec-22 12:28:48.000 *   16 08 59.2485 -12 09 20.738
+ 2017-Dec-24 08:38:24.000 A   16 10 14.1289 -12 13 44.984
+ 2017-Dec-26 04:48:00.000     16 11 28.2045 -12 18 01.626
+ 2017-Dec-28 00:57:36.000 Am  16 12 41.4645 -12 22 10.853
+ 2017-Dec-29 21:07:12.000 *m  16 13 53.9350 -12 26 12.702
+ 2017-Dec-31 17:16:48.000 *   16 15 05.6191 -12 30 07.033
+ 2018-Jan-02 13:26:24.000 *   16 16 16.4590 -12 33 53.666
+ 2018-Jan-04 09:36:00.000 Cm  16 17 26.3505 -12 37 32.562
+ 2018-Jan-06 05:45:36.000  m  16 18 35.1987 -12 41 03.874
+ 2018-Jan-08 01:55:12.000     16 19 42.9642 -12 44 27.839
+ 2018-Jan-09 22:04:48.000 *   16 20 49.6588 -12 47 44.581
+ 2018-Jan-11 18:14:24.000 *m  16 21 55.2943 -12 50 54.019
+ 2018-Jan-13 14:24:00.000 *m  16 22 59.8284 -12 53 55.955
+ 2018-Jan-15 10:33:36.000 *m  16 24 03.1584 -12 56 50.264
+ 2018-Jan-17 06:43:12.000     16 25 05.1669 -12 59 37.037
+ 2018-Jan-19 02:52:48.000     16 26 05.7813 -13 02 16.531
+ 2018-Jan-20 23:02:24.000 *m  16 27 04.9945 -13 04 48.982
+ 2018-Jan-22 19:12:00.000 *m  16 28 02.8282 -13 07 14.440
+ 2018-Jan-24 15:21:36.000 *   16 28 59.2716 -13 09 32.775
+ 2018-Jan-26 11:31:12.000 *   16 29 54.2499 -13 11 43.852
+ 2018-Jan-28 07:40:48.000     16 30 47.6507 -13 13 47.719
+ 2018-Jan-30 03:50:24.000  m  16 31 39.3844 -13 15 44.639
+ 2018-Feb-01 00:00:00.000 Cm  16 32 29.4260 -13 17 34.938
+$$EOE
+*******************************************************************************
+Column meaning:
+ 
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+ 
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by a lunar-presence symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+             ephemeris
+ 
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/resources/gem/horizons/ceres.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/ceres.eph
@@ -1,0 +1,229 @@
+*******************************************************************************
+JPL/HORIZONS                       1 Ceres                 2017-Sep-08 05:44:34
+Rec #:     1 (+COV)   Soln.date: 2017-Apr-04_16:23:28   # obs: 5993 (1950-2017)
+ 
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs): 
+ 
+  EPOCH=  2449731.5 ! 1995-Jan-14.00 (TDB)         Residual RMS= .3289         
+   EC= .07610292126891821  QR= 2.556624726195814   TP= 2449823.0922807939      
+   OM= 80.65851514365535   W=  71.44921526124109   IN= 10.60069567603618       
+   A= 2.767218108003098    MA= 340.389084821267    ADIST= 2.977811489810382    
+   PER= 4.60334            N= .214110998           ANGMOM= .028532632          
+   DAN= 2.68615            DDN= 2.81946            L= 151.8082012              
+   B= 10.0440306           MOID= 1.59241998        TP= 1995-Apr-15.5922807939  
+ 
+Asteroid physical parameters (km, seconds, rotational period in hours):        
+   GM= 62.6284             RAD= 469.7              ROTPER= 9.07417             
+   H= 3.34                 G= .120                 B-V= .713                   
+                           ALBEDO= .090            STYP= C                     
+ 
+ASTEROID comments: 
+1: soln ref.= JPL#34, OCC=0           radar(405 delay, 0 Dop.
+2: source=ORB
+*******************************************************************************
+ 
+ 
+*******************************************************************************
+Ephemeris / WWW_USER Fri Sep  8 05:44:34 2017 Pasadena, USA      / Horizons    
+*******************************************************************************
+Target body name: 1 Ceres                         {source: JPL#34}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-01 00:00:00.0000 UT      
+Stop  time      : A.D. 2018-Feb-01 00:00:00.0000 UT      
+Step-size       : 100 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 487.3 x 487.3 x 454.7 km        {Equator, meridian, pole}    
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}    
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2                              
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL 
+EOP file        : eop.170907.p171129                                           
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-SEP-07. PREDICTS-> 2017-NOV-28
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s 
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )                           
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2449731.5 ! 1995-Jan-14.00 (TDB)         Residual RMS= .3289         
+   EC= .07610292126891821  QR= 2.556624726195814   TP= 2449823.0922807939      
+   OM= 80.65851514365535   W=  71.44921526124109   IN= 10.60069567603618       
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-1.595314070299652E+00  Y= 1.679592434318194E+00  Z= 1.115015709161572E+00
+  VX=-8.276811304306792E-03 VY=-7.202858709771250E-03 VZ=-1.698003095770422E-03
+Asteroid physical parameters (km, seconds, rotational period in hours):        
+   GM= 62.6284             RAD= 469.7              ROTPER= 9.07417             
+   H= 3.34                 G= .120                 B-V= .713                   
+                           ALBEDO= .090            STYP= C                     
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC
+*********************************************************
+$$SOE
+ 2017-Aug-01 00:00:00.000  m  06 38 09.5151 +24 12 20.292
+ 2017-Aug-02 20:09:36.000 *m  06 41 28.7671 +24 12 58.899
+ 2017-Aug-04 16:19:12.000 *   06 44 47.7154 +24 13 24.383
+ 2017-Aug-06 12:28:48.000 *   06 48 06.2543 +24 13 36.360
+ 2017-Aug-08 08:38:24.000  m  06 51 24.2199 +24 13 35.111
+ 2017-Aug-10 04:48:00.000  m  06 54 41.5122 +24 13 21.564
+ 2017-Aug-12 00:57:36.000     06 57 58.1600 +24 12 56.714
+ 2017-Aug-13 21:07:12.000 *   07 01 14.2682 +24 12 20.987
+ 2017-Aug-15 17:16:48.000 *   07 04 29.8934 +24 11 34.126
+ 2017-Aug-17 13:26:24.000 *m  07 07 44.9591 +24 10 35.710
+ 2017-Aug-19 09:36:00.000  m  07 10 59.2865 +24 09 25.837
+ 2017-Aug-21 05:45:36.000     07 14 12.7156 +24 08 05.354
+ 2017-Aug-23 01:55:12.000     07 17 25.2090 +24 06 35.425
+ 2017-Aug-24 22:04:48.000 *m  07 20 36.8467 +24 04 56.825
+ 2017-Aug-26 18:14:24.000 *m  07 23 47.7148 +24 03 09.577
+ 2017-Aug-28 14:24:00.000 *   07 26 57.7909 +24 01 13.290
+ 2017-Aug-30 10:33:36.000 N   07 30 06.9281 +23 59 07.870
+ 2017-Sep-01 06:43:12.000  m  07 33 14.9532 +23 56 53.986
+ 2017-Sep-03 02:52:48.000  m  07 36 21.7923 +23 54 32.867
+ 2017-Sep-04 23:02:24.000 Nm  07 39 27.5080 +23 52 05.596
+ 2017-Sep-06 19:12:00.000 *   07 42 32.2147 +23 49 32.555
+ 2017-Sep-08 15:21:36.000 *   07 45 35.9451 +23 46 53.503
+ 2017-Sep-10 11:31:12.000 *m  07 48 38.5872 +23 44 08.243
+ 2017-Sep-12 07:40:48.000  m  07 51 39.9478 +23 41 17.263
+ 2017-Sep-14 03:50:24.000     07 54 39.8868 +23 38 21.796
+ 2017-Sep-16 00:00:00.000     07 57 38.4006 +23 35 23.217
+ 2017-Sep-17 20:09:36.000 *m  08 00 35.5806 +23 32 22.330
+ 2017-Sep-19 16:19:12.000 *m  08 03 31.4822 +23 29 19.177
+ 2017-Sep-21 12:28:48.000 *m  08 06 26.0248 +23 26 13.540
+ 2017-Sep-23 08:38:24.000     08 09 19.0131 +23 23 05.693
+ 2017-Sep-25 04:48:00.000     08 12 10.2629 +23 19 56.730
+ 2017-Sep-27 00:57:36.000  m  08 14 59.7218 +23 16 48.164
+ 2017-Sep-28 21:07:12.000 *m  08 17 47.4729 +23 13 41.153
+ 2017-Sep-30 17:16:48.000 *   08 20 33.6193 +23 10 36.055
+ 2017-Oct-02 13:26:24.000 *   08 23 18.1487 +23 07 32.705
+ 2017-Oct-04 09:36:00.000 Nm  08 26 00.9007 +23 04 31.181
+ 2017-Oct-06 05:45:36.000  m  08 28 41.6658 +23 01 32.378
+ 2017-Oct-08 01:55:12.000  m  08 31 20.3273 +22 58 37.874
+ 2017-Oct-09 22:04:48.000 *   08 33 56.9178 +22 55 49.203
+ 2017-Oct-11 18:14:24.000 *   08 36 31.5375 +22 53 07.183
+ 2017-Oct-13 14:24:00.000 *m  08 39 04.2049 +22 50 31.903
+ 2017-Oct-15 10:33:36.000 *m  08 41 34.7739 +22 48 03.382
+ 2017-Oct-17 06:43:12.000     08 44 02.9939 +22 45 42.321
+ 2017-Oct-19 02:52:48.000     08 46 28.6619 +22 43 30.260
+ 2017-Oct-20 23:02:24.000 Cm  08 48 51.7345 +22 41 28.991
+ 2017-Oct-22 19:12:00.000 *m  08 51 12.2980 +22 39 39.740
+ 2017-Oct-24 15:21:36.000 *m  08 53 30.4223 +22 38 02.852
+ 2017-Oct-26 11:31:12.000 *   08 55 46.0284 +22 36 38.261
+ 2017-Oct-28 07:40:48.000     08 57 58.8880 +22 35 26.345
+ 2017-Oct-30 03:50:24.000  m  09 00 08.7573 +22 34 28.396
+ 2017-Nov-01 00:00:00.000 Nm  09 02 15.5274 +22 33 46.285
+ 2017-Nov-02 20:09:36.000 *   09 04 19.2538 +22 33 21.617
+ 2017-Nov-04 16:19:12.000 *   09 06 20.0365 +22 33 15.118
+ 2017-Nov-06 12:28:48.000 *   09 08 17.8519 +22 33 26.817
+ 2017-Nov-08 08:38:24.000 Am  09 10 12.4864 +22 33 56.878
+ 2017-Nov-10 04:48:00.000     09 12 03.6328 +22 34 46.334
+ 2017-Nov-12 00:57:36.000     09 13 51.0667 +22 35 57.069
+ 2017-Nov-13 21:07:12.000 *   09 15 34.7458 +22 37 31.032
+ 2017-Nov-15 17:16:48.000 *m  09 17 14.7447 +22 39 29.377
+ 2017-Nov-17 13:26:24.000 *m  09 18 51.0825 +22 41 52.264
+ 2017-Nov-19 09:36:00.000 C   09 20 23.5970 +22 44 39.525
+ 2017-Nov-21 05:45:36.000     09 21 51.9804 +22 47 51.604
+ 2017-Nov-23 01:55:12.000  m  09 23 15.9476 +22 51 29.937
+ 2017-Nov-24 22:04:48.000 *m  09 24 35.3890 +22 55 36.411
+ 2017-Nov-26 18:14:24.000 *m  09 25 50.3715 +23 00 12.373
+ 2017-Nov-28 14:24:00.000 *   09 27 00.9826 +23 05 18.047
+ 2017-Nov-30 10:33:36.000 *   09 28 07.1533 +23 10 52.897
+ 2017-Dec-02 06:43:12.000  m  09 29 08.6163 +23 16 56.644
+ 2017-Dec-04 02:52:48.000  m  09 30 05.0371 +23 23 30.031
+ 2017-Dec-05 23:02:24.000 *   09 30 56.2029 +23 30 34.657
+ 2017-Dec-07 19:12:00.000 *   09 31 42.1037 +23 38 11.980
+ 2017-Dec-09 15:21:36.000 *m  09 32 22.8312 +23 46 22.343
+ 2017-Dec-11 11:31:12.000 *m  09 32 58.3842 +23 55 04.881
+ 2017-Dec-13 07:40:48.000  m  09 33 28.5527 +24 04 18.394
+ 2017-Dec-15 03:50:24.000     09 33 52.9916 +24 14 02.418
+ 2017-Dec-17 00:00:00.000 C   09 34 11.4239 +24 24 17.526
+ 2017-Dec-18 20:09:36.000 *m  09 34 23.7990 +24 35 04.560
+ 2017-Dec-20 16:19:12.000 *m  09 34 30.2653 +24 46 23.440
+ 2017-Dec-22 12:28:48.000 *   09 34 30.9782 +24 58 12.589
+ 2017-Dec-24 08:38:24.000 A   09 34 25.9121 +25 10 29.506
+ 2017-Dec-26 04:48:00.000     09 34 14.8425 +25 23 12.007
+ 2017-Dec-28 00:57:36.000 Am  09 33 57.5192 +25 36 19.058
+ 2017-Dec-29 21:07:12.000 *m  09 33 33.8789 +25 49 50.443
+ 2017-Dec-31 17:16:48.000 *   09 33 04.1098 +26 03 45.545
+ 2018-Jan-02 13:26:24.000 *   09 32 28.5065 +26 18 02.274
+ 2018-Jan-04 09:36:00.000 Cm  09 31 47.2415 +26 32 37.117
+ 2018-Jan-06 05:45:36.000  m  09 31 00.2554 +26 47 26.255
+ 2018-Jan-08 01:55:12.000     09 30 07.3688 +27 02 26.826
+ 2018-Jan-09 22:04:48.000 *   09 29 08.5228 +27 17 37.182
+ 2018-Jan-11 18:14:24.000 *m  09 28 03.9437 +27 32 55.895
+ 2018-Jan-13 14:24:00.000 *m  09 26 54.0912 +27 48 20.364
+ 2018-Jan-15 10:33:36.000 *m  09 25 39.4346 +28 03 46.250
+ 2018-Jan-17 06:43:12.000     09 24 20.2505 +28 19 08.303
+ 2018-Jan-19 02:52:48.000     09 22 56.6192 +28 34 21.924
+ 2018-Jan-20 23:02:24.000 *m  09 21 28.6246 +28 49 24.118
+ 2018-Jan-22 19:12:00.000 *m  09 19 56.5828 +29 04 13.041
+ 2018-Jan-24 15:21:36.000 *   09 18 21.0971 +29 18 46.533
+ 2018-Jan-26 11:31:12.000 *   09 16 42.8866 +29 33 00.952
+ 2018-Jan-28 07:40:48.000     09 15 02.5300 +29 46 51.372
+ 2018-Jan-30 03:50:24.000  m  09 13 20.3432 +30 00 13.038
+ 2018-Feb-01 00:00:00.000 Cm  09 11 36.4958 +30 13 02.822
+$$EOE
+*******************************************************************************
+Column meaning:
+ 
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+ 
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by a lunar-presence symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+             ephemeris
+ 
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/resources/gem/horizons/enceladus.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/enceladus.eph
@@ -1,0 +1,208 @@
+*******************************************************************************
+ Revised: Jun 17, 2016            Enceladus / (Saturn)                      602
+                           http://ssd.jpl.nasa.gov/?sat_phys_par
+                             http://ssd.jpl.nasa.gov/?sat_elem
+
+ SATELLITE PHYSICAL PROPERTIES:
+  Mean Radius (km)        = 252.3   +- 0.6   Density (g/cm^3) =  1.606 +- 0.012
+  Mass (10^19 kg)         =  10.805          Geometric Albedo =  1.04
+  GM (km^3/s^2)           =   7.206 +- 0.011 V(1,0)           =  +2.2
+
+ SATELLITE ORBITAL DATA (mean elements referred to local Laplace plane):
+  Semi-major axis, a (km) = 238.04(10^3)    Orbital period    = 1.370218 d
+  Eccentricity, e         = 0.0047          Rotational period = Synchronous
+  Inclination, i  (deg)   = 0.009
+*******************************************************************************
+ 
+ 
+*******************************************************************************
+Ephemeris / WWW_USER Fri Sep  8 05:45:31 2017 Pasadena, USA      / Horizons    
+*******************************************************************************
+Target body name: Enceladus (602)                 {source: sat389}
+Center body name: Earth (399)                     {source: sat389}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-01 00:00:00.0000 UT      
+Stop  time      : A.D. 2018-Feb-01 00:00:00.0000 UT      
+Step-size       : 100 steps
+*******************************************************************************
+Target pole/equ : IAU_ENCELADUS                   {East-longitude -}
+Target radii    : 256.6 x 251.4 x 248.3 km        {Equator, meridian, pole}    
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}    
+Target primary  : Saturn
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: sat389}
+Rel. light bend : Sun, EARTH                      {source: sat389}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2                              
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL 
+EOP file        : eop.170907.p171129                                           
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-SEP-07. PREDICTS-> 2017-NOV-28
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s 
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )                           
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC
+*********************************************************
+$$SOE
+ 2017-Aug-01 00:00:00.000  m  17 22 55.2824 -21 54 44.331
+ 2017-Aug-02 20:09:36.000 *m  17 22 38.2185 -21 54 20.115
+ 2017-Aug-04 16:19:12.000 *   17 22 25.7048 -21 54 44.439
+ 2017-Aug-06 12:28:48.000 *   17 22 06.7120 -21 54 56.333
+ 2017-Aug-08 08:38:24.000  m  17 21 54.1381 -21 54 37.854
+ 2017-Aug-10 04:48:00.000  m  17 21 44.9343 -21 55 09.682
+ 2017-Aug-12 00:57:36.000     17 21 29.7717 -21 55 20.676
+ 2017-Aug-13 21:07:12.000 *   17 21 21.9818 -21 55 08.203
+ 2017-Aug-15 17:16:48.000 *   17 21 16.1578 -21 55 45.744
+ 2017-Aug-17 13:26:24.000 *m  17 21 04.9505 -21 55 55.464
+ 2017-Aug-19 09:36:00.000  m  17 21 01.8385 -21 55 50.310
+ 2017-Aug-21 05:45:36.000     17 20 59.4427 -21 56 33.944
+ 2017-Aug-23 01:55:12.000     17 20 52.6127 -21 56 43.519
+ 2017-Aug-24 22:04:48.000 *m  17 20 54.4065 -21 56 46.135
+ 2017-Aug-26 18:14:24.000 *m  17 20 55.5716 -21 57 33.991
+ 2017-Aug-28 14:24:00.000 *   17 20 53.1983 -21 57 42.841
+ 2017-Aug-30 10:33:36.000 N   17 20 59.6244 -21 57 53.559
+ 2017-Sep-01 06:43:12.000  m  17 21 04.2378 -21 58 45.530
+ 2017-Sep-03 02:52:48.000  m  17 21 06.5118 -21 58 55.024
+ 2017-Sep-04 23:02:24.000 Nm  17 21 17.6366 -21 59 14.249
+ 2017-Sep-06 19:12:00.000 *   17 21 25.8269 -22 00 08.587
+ 2017-Sep-08 15:21:36.000 *   17 21 32.7714 -22 00 18.009
+ 2017-Sep-10 11:31:12.000 *m  17 21 48.2294 -22 00 45.113
+ 2017-Sep-12 07:40:48.000  m  17 21 59.7951 -22 01 41.225
+ 2017-Sep-14 03:50:24.000     17 22 11.4237 -22 01 51.946
+ 2017-Sep-16 00:00:00.000     17 22 31.1991 -22 02 27.252
+ 2017-Sep-17 20:09:36.000 *m  17 22 46.3406 -22 03 23.806
+ 2017-Sep-19 16:19:12.000 *m  17 23 02.7217 -22 03 35.226
+ 2017-Sep-21 12:28:48.000 *m  17 23 26.4904 -22 04 17.463
+ 2017-Sep-23 08:38:24.000     17 23 44.9828 -22 05 13.597
+ 2017-Sep-25 04:48:00.000     17 24 05.9423 -22 05 26.972
+ 2017-Sep-27 00:57:36.000  m  17 24 33.5335 -22 06 16.350
+ 2017-Sep-28 21:07:12.000 *m  17 24 55.5060 -22 07 11.197
+ 2017-Sep-30 17:16:48.000 *   17 25 21.0374 -22 07 25.954
+ 2017-Oct-02 13:26:24.000 *   17 25 52.1209 -22 08 20.511
+ 2017-Oct-04 09:36:00.000 Nm  17 26 17.3094 -22 09 12.786
+ 2017-Oct-06 05:45:36.000  m  17 26 47.0755 -22 09 29.717
+ 2017-Oct-08 01:55:12.000  m  17 27 21.3695 -22 10 29.456
+ 2017-Oct-09 22:04:48.000 *   17 27 49.8569 -22 11 18.907
+ 2017-Oct-11 18:14:24.000 *   17 28 23.8398 -22 11 37.732
+ 2017-Oct-13 14:24:00.000 *m  17 29 01.1145 -22 12 40.485
+ 2017-Oct-15 10:33:36.000 *m  17 29 32.7005 -22 13 25.677
+ 2017-Oct-17 06:43:12.000     17 30 10.5064 -22 13 46.660
+ 2017-Oct-19 02:52:48.000     17 30 50.4358 -22 14 52.169
+ 2017-Oct-20 23:02:24.000 Cm  17 31 25.1470 -22 15 33.423
+ 2017-Oct-22 19:12:00.000 *m  17 32 06.7125 -22 15 56.640
+ 2017-Oct-24 15:21:36.000 *m  17 32 49.1222 -22 17 02.850
+ 2017-Oct-26 11:31:12.000 *   17 33 26.7572 -22 17 38.756
+ 2017-Oct-28 07:40:48.000     17 34 11.5800 -22 18 03.863
+ 2017-Oct-30 03:50:24.000  m  17 34 56.0310 -22 19 10.103
+ 2017-Nov-01 00:00:00.000 Nm  17 35 36.4674 -22 19 41.238
+ 2017-Nov-02 20:09:36.000 *   17 36 24.3912 -22 20 08.454
+ 2017-Nov-04 16:19:12.000 *   17 37 10.7752 -22 21 12.897
+ 2017-Nov-06 12:28:48.000 *   17 37 53.8804 -22 21 38.042
+ 2017-Nov-08 08:38:24.000 Am  17 38 44.4314 -22 22 06.553
+ 2017-Nov-10 04:48:00.000     17 39 32.3287 -22 23 08.307
+ 2017-Nov-12 00:57:36.000     17 40 17.9124 -22 23 28.352
+ 2017-Nov-13 21:07:12.000 *   17 41 10.8881 -22 23 58.646
+ 2017-Nov-15 17:16:48.000 *m  17 42 00.2588 -22 24 56.433
+ 2017-Nov-17 13:26:24.000 *m  17 42 48.2438 -22 25 10.513
+ 2017-Nov-19 09:36:00.000 C   17 43 43.2014 -22 25 41.356
+ 2017-Nov-21 05:45:36.000     17 44 33.6214 -22 26 33.998
+ 2017-Nov-23 01:55:12.000  m  17 45 23.6822 -22 26 43.026
+ 2017-Nov-24 22:04:48.000 *m  17 46 20.2874 -22 27 14.973
+ 2017-Nov-26 18:14:24.000 *m  17 47 11.6839 -22 28 01.802
+ 2017-Nov-28 14:24:00.000 *   17 48 03.7260 -22 28 05.377
+ 2017-Nov-30 10:33:36.000 *   17 49 01.5667 -22 28 36.937
+ 2017-Dec-02 06:43:12.000  m  17 49 53.5458 -22 29 16.561
+ 2017-Dec-04 02:52:48.000  m  17 50 47.1666 -22 29 15.397
+ 2017-Dec-05 23:02:24.000 *   17 51 45.8521 -22 29 47.023
+ 2017-Dec-07 19:12:00.000 *   17 52 38.3674 -22 30 19.424
+ 2017-Dec-09 15:21:36.000 *m  17 53 33.5249 -22 30 13.747
+ 2017-Dec-11 11:31:12.000 *m  17 54 32.7691 -22 30 44.051
+ 2017-Dec-13 07:40:48.000  m  17 55 25.5298 -22 31 07.965
+ 2017-Dec-15 03:50:24.000     17 56 21.7775 -22 30 58.325
+ 2017-Dec-17 00:00:00.000 C   17 57 21.1079 -22 31 27.587
+ 2017-Dec-18 20:09:36.000 *m  17 58 13.9880 -22 31 43.527
+ 2017-Dec-20 16:19:12.000 *m  17 59 11.2097 -22 31 30.609
+ 2017-Dec-22 12:28:48.000 *   18 00 10.3728 -22 31 57.556
+ 2017-Dec-24 08:38:24.000 A   18 01 03.1287 -22 32 04.395
+ 2017-Dec-26 04:48:00.000     18 02 00.8306 -22 31 48.443
+ 2017-Dec-28 00:57:36.000 Am  18 02 59.2971 -22 32 13.098
+ 2017-Dec-29 21:07:12.000 *m  18 03 51.7285 -22 32 11.830
+ 2017-Dec-31 17:16:48.000 *   18 04 49.7342 -22 31 53.989
+ 2018-Jan-02 13:26:24.000 *   18 05 47.3293 -22 32 15.426
+ 2018-Jan-04 09:36:00.000 Cm  18 06 39.3066 -22 32 05.257
+ 2018-Jan-06 05:45:36.000  m  18 07 37.1813 -22 31 45.469
+ 2018-Jan-08 01:55:12.000     18 08 33.4244 -22 32 03.407
+ 2018-Jan-09 22:04:48.000 *   18 09 24.7212 -22 31 45.676
+ 2018-Jan-11 18:14:24.000 *m  18 10 22.2333 -22 31 25.482
+ 2018-Jan-13 14:24:00.000 *m  18 11 16.9922 -22 31 39.565
+ 2018-Jan-15 10:33:36.000 *m  18 12 07.5195 -22 31 14.051
+ 2018-Jan-17 06:43:12.000     18 13 04.2249 -22 30 53.152
+ 2018-Jan-19 02:52:48.000     18 13 56.9973 -22 31 02.739
+ 2018-Jan-20 23:02:24.000 *m  18 14 46.4131 -22 30 30.792
+ 2018-Jan-22 19:12:00.000 *m  18 15 41.9573 -22 30 10.751
+ 2018-Jan-24 15:21:36.000 *   18 16 32.6189 -22 30 15.969
+ 2018-Jan-26 11:31:12.000 *   18 17 20.8857 -22 29 37.982
+ 2018-Jan-28 07:40:48.000     18 18 14.9019 -22 29 18.412
+ 2018-Jan-30 03:50:24.000  m  18 19 03.0465 -22 29 18.472
+ 2018-Feb-01 00:00:00.000 Cm  18 19 49.8023 -22 28 35.777
+$$EOE
+*******************************************************************************
+Column meaning:
+ 
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+ 
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by a lunar-presence symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+             ephemeris
+ 
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/resources/gem/horizons/mars.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/mars.eph
@@ -1,0 +1,217 @@
+*******************************************************************************
+ Revised: Sep 28, 2012                 Mars                             499 / 4
+ 
+ GEOPHYSICAL DATA (updated 2009-May-26):
+  Mean radius (km)      = 3389.9(2+-4)    Density (g cm^-3)     =  3.933(5+-4)
+  Mass (10^23 kg )      =    6.4185       Flattening, f         =  1/154.409
+  Volume (x10^10 km^3)  =   16.318        Semi-major axis       =  3397+-4
+  Sidereal rot. period  =   24.622962 hr  Rot. Rate (x10^5 s)   =  7.088218
+  Mean solar day        =    1.0274907 d  Polar gravity ms^-2   =  3.758
+  Mom. of Inertia       =    0.366        Equ. gravity  ms^-2   =  3.71
+  Core radius (km)      =  ~1700          Potential Love # k2   =  0.153 +-.017
+ 
+  Grav spectral fact u  =   14 (x10^5)    Topo. spectral fact t = 96 (x10^5)
+  Fig. offset (Rcf-Rcm) = 2.50+-0.07 km   Offset (lat./long.)   = 62d / 88d
+  GM (km^3 s^-2)        = 42828.3         Equatorial Radius, Re = 3394.0 km 
+  GM 1-sigma (km^3 s^-2)= +- 0.1          Mass ratio (Sun/Mars) = 3098708+-9
+  
+  Atmos. pressure (bar) =    0.0056       Max. angular diam.    =  17.9"
+  Mean Temperature (K)  =  210            Visual mag. V(1,0)    =  -1.52
+  Geometric albedo      =    0.150        Obliquity to orbit    =  25.19 deg
+  Mean sidereal orb per =    1.88081578 y Orbit vel.  km/s      =  24.1309
+  Mean sidereal orb per =  686.98 d       Escape vel. km/s      =   5.027
+  Hill's sphere rad. Rp =  319.8          Mag. mom (gauss Rp^3) = < 1x10^-4 
+*******************************************************************************
+ 
+ 
+*******************************************************************************
+Ephemeris / WWW_USER Fri Sep  8 05:46:33 2017 Pasadena, USA      / Horizons    
+*******************************************************************************
+Target body name: Mars (499)                      {source: mar097}
+Center body name: Earth (399)                     {source: mar097}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-01 00:00:00.0000 UT      
+Stop  time      : A.D. 2018-Feb-01 00:00:00.0000 UT      
+Step-size       : 100 steps
+*******************************************************************************
+Target pole/equ : IAU_MARS                        {East-longitude -}
+Target radii    : 3396.2 x 3396.2 x 3376.2 km     {Equator, meridian, pole}    
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}    
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: mar097}
+Rel. light bend : Sun, EARTH                      {source: mar097}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2                              
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL 
+EOP file        : eop.170907.p171129                                           
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-SEP-07. PREDICTS-> 2017-NOV-28
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s 
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )                           
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC
+*********************************************************
+$$SOE
+ 2017-Aug-01 00:00:00.000  m  08 39 26.1113 +19 33 27.498
+ 2017-Aug-02 20:09:36.000 *m  08 44 16.7664 +19 15 25.619
+ 2017-Aug-04 16:19:12.000 *   08 49 06.2770 +18 56 56.576
+ 2017-Aug-06 12:28:48.000 *   08 53 54.4942 +18 38 00.694
+ 2017-Aug-08 08:38:24.000  m  08 58 41.2883 +18 18 39.054
+ 2017-Aug-10 04:48:00.000  m  09 03 26.6807 +17 58 53.052
+ 2017-Aug-12 00:57:36.000     09 08 10.8393 +17 38 43.682
+ 2017-Aug-13 21:07:12.000 *   09 12 53.9428 +17 18 11.210
+ 2017-Aug-15 17:16:48.000 *   09 17 36.0354 +16 57 15.516
+ 2017-Aug-17 13:26:24.000 *m  09 22 17.0024 +16 35 56.776
+ 2017-Aug-19 09:36:00.000  m  09 26 56.6885 +16 14 15.864
+ 2017-Aug-21 05:45:36.000     09 31 35.0496 +15 52 14.124
+ 2017-Aug-23 01:55:12.000     09 36 12.2022 +15 29 52.732
+ 2017-Aug-24 22:04:48.000 *m  09 40 48.3270 +15 07 12.242
+ 2017-Aug-26 18:14:24.000 *m  09 45 23.5152 +14 44 12.708
+ 2017-Aug-28 14:24:00.000 *   09 49 57.6995 +14 20 54.238
+ 2017-Aug-30 10:33:36.000 N   09 54 30.7317 +13 57 17.467
+ 2017-Sep-01 06:43:12.000  m  09 59 02.5383 +13 33 23.529
+ 2017-Sep-03 02:52:48.000  m  10 03 33.2109 +13 09 13.564
+ 2017-Sep-04 23:02:24.000 Nm  10 08 02.9505 +12 44 48.244
+ 2017-Sep-06 19:12:00.000 *   10 12 31.9152 +12 20 07.725
+ 2017-Sep-08 15:21:36.000 *   10 17 00.1093 +11 55 12.056
+ 2017-Sep-10 11:31:12.000 *m  10 21 27.4124 +11 30 01.654
+ 2017-Sep-12 07:40:48.000  m  10 25 53.7217 +11 04 37.424
+ 2017-Sep-14 03:50:24.000     10 30 19.0765 +10 39 00.440
+ 2017-Sep-16 00:00:00.000     10 34 43.6514 +10 13 11.511
+ 2017-Sep-17 20:09:36.000 *m  10 39 07.6235 +09 47 11.023
+ 2017-Sep-19 16:19:12.000 *m  10 43 31.0352 +09 20 59.174
+ 2017-Sep-21 12:28:48.000 *m  10 47 53.7769 +08 54 36.375
+ 2017-Sep-23 08:38:24.000     10 52 15.7076 +08 28 03.418
+ 2017-Sep-25 04:48:00.000     10 56 36.8052 +08 01 21.303
+ 2017-Sep-27 00:57:36.000  m  11 00 57.2113 +07 34 30.875
+ 2017-Sep-28 21:07:12.000 *m  11 05 17.1298 +07 07 32.626
+ 2017-Sep-30 17:16:48.000 *   11 09 36.6726 +06 40 26.817
+ 2017-Oct-02 13:26:24.000 *   11 13 55.7902 +06 13 13.775
+ 2017-Oct-04 09:36:00.000 Nm  11 18 14.3520 +05 45 54.086
+ 2017-Oct-06 05:45:36.000  m  11 22 32.3020 +05 18 28.528
+ 2017-Oct-08 01:55:12.000  m  11 26 49.7489 +04 50 57.827
+ 2017-Oct-09 22:04:48.000 *   11 31 06.9067 +04 23 22.496
+ 2017-Oct-11 18:14:24.000 *   11 35 23.9380 +03 55 42.890
+ 2017-Oct-13 14:24:00.000 *m  11 39 40.8402 +03 27 59.407
+ 2017-Oct-15 10:33:36.000 *m  11 43 57.4788 +03 00 12.634
+ 2017-Oct-17 06:43:12.000     11 48 13.7357 +02 32 23.314
+ 2017-Oct-19 02:52:48.000     11 52 29.6416 +02 04 32.190
+ 2017-Oct-20 23:02:24.000 Cm  11 56 45.3723 +01 36 39.881
+ 2017-Oct-22 19:12:00.000 *m  12 01 01.1129 +01 08 46.912
+ 2017-Oct-24 15:21:36.000 *m  12 05 16.9144 +00 40 53.815
+ 2017-Oct-26 11:31:12.000 *   12 09 32.6720 +00 13 01.197
+ 2017-Oct-28 07:40:48.000     12 13 48.2472 -00 14 50.307
+ 2017-Oct-30 03:50:24.000  m  12 18 03.6244 -00 42 40.126
+ 2017-Nov-01 00:00:00.000 Nm  12 22 18.9587 -01 10 27.779
+ 2017-Nov-02 20:09:36.000 *   12 26 34.4718 -01 38 12.799
+ 2017-Nov-04 16:19:12.000 *   12 30 50.2885 -02 05 54.643
+ 2017-Nov-06 12:28:48.000 *   12 35 06.3594 -02 33 32.701
+ 2017-Nov-08 08:38:24.000 Am  12 39 22.5404 -03 01 06.391
+ 2017-Nov-10 04:48:00.000     12 43 38.7563 -03 28 35.243
+ 2017-Nov-12 00:57:36.000     12 47 55.0997 -03 55 58.851
+ 2017-Nov-13 21:07:12.000 *   12 52 11.7746 -04 23 16.708
+ 2017-Nov-15 17:16:48.000 *m  12 56 28.9334 -04 50 28.088
+ 2017-Nov-17 13:26:24.000 *m  13 00 46.5562 -05 17 32.127
+ 2017-Nov-19 09:36:00.000 C   13 05 04.4846 -05 44 28.048
+ 2017-Nov-21 05:45:36.000     13 09 22.5820 -06 11 15.347
+ 2017-Nov-23 01:55:12.000  m  13 13 40.8771 -06 37 53.727
+ 2017-Nov-24 22:04:48.000 *m  13 17 59.5595 -07 04 22.822
+ 2017-Nov-26 18:14:24.000 *m  13 22 18.8307 -07 30 41.959
+ 2017-Nov-28 14:24:00.000 *   13 26 38.7443 -07 56 50.215
+ 2017-Nov-30 10:33:36.000 *   13 30 59.1811 -08 22 46.745
+ 2017-Dec-02 06:43:12.000  m  13 35 19.9840 -08 48 31.094
+ 2017-Dec-04 02:52:48.000  m  13 39 41.1304 -09 14 03.183
+ 2017-Dec-05 23:02:24.000 *   13 44 02.7835 -09 39 22.921
+ 2017-Dec-07 19:12:00.000 *   13 48 25.1718 -10 04 29.788
+ 2017-Dec-09 15:21:36.000 *m  13 52 48.4036 -10 29 22.781
+ 2017-Dec-11 11:31:12.000 *m  13 57 12.3833 -10 54 00.799
+ 2017-Dec-13 07:40:48.000  m  14 01 36.9076 -11 18 23.146
+ 2017-Dec-15 03:50:24.000     14 06 01.8568 -11 42 29.661
+ 2017-Dec-17 00:00:00.000 C   14 10 27.3098 -12 06 20.337
+ 2017-Dec-18 20:09:36.000 *m  14 14 53.4788 -12 29 54.765
+ 2017-Dec-20 16:19:12.000 *m  14 19 20.5203 -12 53 11.911
+ 2017-Dec-22 12:28:48.000 *   14 23 48.3945 -13 16 10.492
+ 2017-Dec-24 08:38:24.000 A   14 28 16.9024 -13 38 49.626
+ 2017-Dec-26 04:48:00.000     14 32 45.8711 -14 01 09.168
+ 2017-Dec-28 00:57:36.000 Am  14 37 15.3204 -14 23 09.394
+ 2017-Dec-29 21:07:12.000 *m  14 41 45.4591 -14 44 50.282
+ 2017-Dec-31 17:16:48.000 *   14 46 16.5096 -15 06 11.060
+ 2018-Jan-02 13:26:24.000 *   14 50 48.5166 -15 27 10.437
+ 2018-Jan-04 09:36:00.000 Cm  14 55 21.3125 -15 47 47.356
+ 2018-Jan-06 05:45:36.000  m  14 59 54.6715 -16 08 01.563
+ 2018-Jan-08 01:55:12.000     15 04 28.5161 -16 27 53.457
+ 2018-Jan-09 22:04:48.000 *   15 09 02.9849 -16 47 23.298
+ 2018-Jan-11 18:14:24.000 *m  15 13 38.2970 -17 06 30.486
+ 2018-Jan-13 14:24:00.000 *m  15 18 14.5345 -17 25 13.600
+ 2018-Jan-15 10:33:36.000 *m  15 22 51.5427 -17 43 31.209
+ 2018-Jan-17 06:43:12.000     15 27 29.0441 -18 01 22.750
+ 2018-Jan-19 02:52:48.000     15 32 06.8677 -18 18 48.654
+ 2018-Jan-20 23:02:24.000 *m  15 36 45.0855 -18 35 49.568
+ 2018-Jan-22 19:12:00.000 *m  15 41 23.9297 -18 52 25.360
+ 2018-Jan-24 15:21:36.000 *   15 46 03.5634 -19 08 34.827
+ 2018-Jan-26 11:31:12.000 *   15 50 43.9116 -19 24 16.426
+ 2018-Jan-28 07:40:48.000     15 55 24.7095 -19 39 29.390
+ 2018-Jan-30 03:50:24.000  m  16 00 05.7288 -19 54 14.198
+ 2018-Feb-01 00:00:00.000 Cm  16 04 46.9735 -20 08 31.938
+$$EOE
+*******************************************************************************
+Column meaning:
+ 
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+ 
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by a lunar-presence symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+             ephemeris
+ 
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -1,0 +1,124 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.math.{ Coordinates, Ephemeris }
+import gem.util.InstantMicros
+
+import cats.tests.CatsSuite
+
+import java.time.{ LocalDateTime, ZoneOffset }
+import java.time.format.DateTimeFormatter
+
+import scala.collection.immutable.TreeMap
+import scala.io.Source
+
+
+/** Not really a spec per se, but rather a way to exercise the ephemeris parser
+  * with a few fixed examples and get a sense of whether it works.
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+final class EphemerisParserSpec extends CatsSuite {
+
+  import EphemerisParserSpec._
+
+  test("Must parse borrelly") {
+
+    val head = eph(
+      "2017-Aug-01 00:00:00.000" -> "14 47 38.2973 -01 50 22.540",
+      "2017-Aug-02 20:09:36.000" -> "14 47 51.5561 -01 59 08.132",
+      "2017-Aug-04 16:19:12.000" -> "14 48 07.0089 -02 07 58.456"
+    )
+
+    val tail = eph(
+      "2018-Jan-28 07:40:48.000" -> "16 30 47.6507 -13 13 47.719",
+      "2018-Jan-30 03:50:24.000" -> "16 31 39.3844 -13 15 44.639",
+      "2018-Feb-01 00:00:00.000" -> "16 32 29.4260 -13 17 34.938"
+    )
+
+    checkEph("borrelly", head, tail)
+  }
+
+  test("Must parse ceres") {
+
+    val head = eph(
+      "2017-Aug-01 00:00:00.000" -> "06 38 09.5151 +24 12 20.292",
+      "2017-Aug-02 20:09:36.000" -> "06 41 28.7671 +24 12 58.899",
+      "2017-Aug-04 16:19:12.000" -> "06 44 47.7154 +24 13 24.383"
+    )
+
+    val tail = eph(
+      "2018-Jan-28 07:40:48.000" -> "09 15 02.5300 +29 46 51.372",
+      "2018-Jan-30 03:50:24.000" -> "09 13 20.3432 +30 00 13.038",
+      "2018-Feb-01 00:00:00.000" -> "09 11 36.4958 +30 13 02.822"
+    )
+
+    checkEph("ceres", head, tail)
+  }
+
+  test("Must parse enceladus") {
+
+    val head = eph(
+      "2017-Aug-01 00:00:00.000" -> "17 22 55.2824 -21 54 44.331",
+      "2017-Aug-02 20:09:36.000" -> "17 22 38.2185 -21 54 20.115",
+      "2017-Aug-04 16:19:12.000" -> "17 22 25.7048 -21 54 44.439"
+    )
+
+    val tail = eph(
+      "2018-Jan-28 07:40:48.000" -> "18 18 14.9019 -22 29 18.412",
+      "2018-Jan-30 03:50:24.000" -> "18 19 03.0465 -22 29 18.472",
+      "2018-Feb-01 00:00:00.000" -> "18 19 49.8023 -22 28 35.777"
+    )
+
+    checkEph("enceladus", head, tail)
+  }
+
+  test("Must parse mars") {
+
+    val head = eph(
+      "2017-Aug-01 00:00:00.000" -> "08 39 26.1113 +19 33 27.498",
+      "2017-Aug-02 20:09:36.000" -> "08 44 16.7664 +19 15 25.619",
+      "2017-Aug-04 16:19:12.000" -> "08 49 06.2770 +18 56 56.576"
+    )
+
+    val tail = eph(
+      "2018-Jan-28 07:40:48.000" -> "15 55 24.7095 -19 39 29.390",
+      "2018-Jan-30 03:50:24.000" -> "16 00 05.7288 -19 54 14.198",
+      "2018-Feb-01 00:00:00.000" -> "16 04 46.9735 -20 08 31.938"
+    )
+
+    checkEph("mars", head, tail)
+  }
+
+  private def checkEph(name: String,
+               head: TreeMap[InstantMicros, Coordinates],
+               tail: TreeMap[InstantMicros, Coordinates]): org.scalatest.Assertion = {
+
+    val e = EphemerisParser.parse(load(name)).option.getOrElse(Ephemeris.Empty)
+
+    // This works but the error message isn't helpful when it fails.  There
+    // should be a way to combine shouldEqual assertions ...
+    assert(
+      (e.toMap.size                == 101 ) &&
+      (e.toMap.to(head.lastKey)    == head) &&
+      (e.toMap.from(tail.firstKey) == tail)
+    )
+  }
+}
+
+object EphemerisParserSpec {
+  private val TimeFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss.SSS")
+
+  private def load(n: String): String =
+    Source.fromInputStream(getClass.getResourceAsStream(s"$n.eph")).mkString
+
+  private def time(s: String): InstantMicros =
+    InstantMicros.truncate(LocalDateTime.parse(s, TimeFormat).toInstant(ZoneOffset.UTC))
+
+  private def coords(s: String): Coordinates =
+    Coordinates.parse(s).getOrElse(Coordinates.Zero)
+
+  private def eph(elems: (String, String)*): TreeMap[InstantMicros, Coordinates] =
+    TreeMap(elems.map { case (i, c) => time(i) -> coords(c) }: _*)
+}


### PR DESCRIPTION
This is part of the series of PRs that will pull horizons processing over from the `ocs` project.  This installment adds an `ephemeris` module with a simple ephemeris data parser that replaces similar functionality in the old `ocs` project `CgiReplyBuilder.java` with `atto`-based parsing.  The idea is to remove any dependence on `CgiReplyBuilder` and other parts of the Java-based Horizons API.  I chose the name `ephemeris` for the module instead of `horizons` because I think that any user-supplied ephemeris support probably belongs here as well.

There isn't much code here.  Most of the update consists of a few ephemeris file samples.
