### PR TITLE
Respect ScalaTest Include Flags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -164,6 +164,8 @@ lazy val commonSettings = Seq(
     "-doc-version", version.value
   ),
 
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork"), // by default, ignore network tests
+
   // We need kind-projector generally, and paradise for
   addCompilerPlugin("org.spire-math"  %% "kind-projector" % kpVersion),
   addCompilerPlugin("org.scalamacros" %% "paradise"       % paradiseVersion cross CrossVersion.patch),
@@ -297,8 +299,7 @@ lazy val ephemeris = project
       "co.fs2"        %% "fs2-io"              % fs2Version     % "test",
       "org.http4s"    %% "http4s-blaze-client" % http4sVersion,
       "org.typelevel" %% "cats-testkit"        % catsVersion    % "test"
-    ),
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork") // by default, ignore network tests
+    )
   )
 
 lazy val service = project

--- a/modules/core/shared/src/test/scala/gem/test/RespectIncludeTags.scala
+++ b/modules/core/shared/src/test/scala/gem/test/RespectIncludeTags.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.test
+
+import org.scalatest._
+
+
+/** Reverses the meaning of Scala Test test filters.  The TLDR version of what
+  * this does is:
+  *
+  * - Allows explicit include filters to override exclude filters
+  * - Explicit include filters don't exclude anything
+  *
+  * This makes it possible to specify Tags and apply them to test cases that
+  * usually should not be run but that can be run when desired.
+  *
+  *
+  * Setting up Tests Excluded by Default
+  *
+  * 1. First chose or create a new Tag (see `gem.test.Tags`).  For example,
+  *    `gem.test.Tags.RequiresNetwork` for tests that require an external
+  *    resource.
+  *
+  * 2. Make sure the build contains a setting to exclude the tag.  For example
+  *
+  *        testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork") // by default, ignore network tests
+  *
+  * 3. Now, to turn on tests that are normally excluded use
+  *
+  *        `testOnly testName -- -n gem.test.Tags.RequiresNetwork`
+  *
+  *    Unfortunately this doesn't work with the `test` command itself.  For that
+  *    you must update the setting which can be done on the SBT command line with:
+  *
+  *        set testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-n", "gem.test.Tags.RequiresNetwork")
+  *
+  *
+  * Background
+  *
+  * ScalaTest provides the concept of test tags that can be used to control
+  * which tests are executed at runtime.  In particular, two filters are
+  * available, an "include" filter and an "exclude" filter.  The include filter
+  * excludes everything except tests tagged with the given tags, provided they
+  * are not also mentioned in the exclude filter.  The exclude filter just lists
+  * tags whose associated tests should not be executed.  Using the SB `testOnly`
+  * command, include tags can be specified with `-n` and exclude tags with `-l`
+  * (that's lowercase L).  See
+  *
+  * http://www.scalatest.org/user_guide/using_scalatest_with_sbt
+  *
+  * for more information.
+  *
+  */
+trait RespectIncludeTags extends Suite {
+
+  override protected def runTests(testName: Option[String], args: Args): Status = {
+
+    val filter     = args.filter
+    val isExcluded = filter.tagsToExclude
+    val isIncluded = filter.tagsToInclude.getOrElse(Set.empty)
+    val exclude    = isIncluded.foldLeft(isExcluded)(_ - _)
+    val newFilter  = Filter(None, exclude, filter.excludeNestedSuites, filter.dynaTags)
+
+    super.runTests(testName, args.copy(filter = newFilter))
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/test/RespectIncludeTags.scala
+++ b/modules/core/shared/src/test/scala/gem/test/RespectIncludeTags.scala
@@ -33,7 +33,7 @@ import org.scalatest._
   *    Unfortunately this doesn't work with the `test` command itself.  For that
   *    you must update the setting which can be done on the SBT command line with:
   *
-  *        set testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-n", "gem.test.Tags.RequiresNetwork")
+  *        set testOptions in ThisBuild += Tests.Argument(TestFrameworks.ScalaTest, "-n", "gem.test.Tags.RequiresNetwork")
   *
   *
   * Background

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisQuerySpec.scala
@@ -6,6 +6,7 @@ package gem.horizons
 import gem.EphemerisKey
 import gem.enum.Site.GS
 import gem.math.Ephemeris
+import gem.test.RespectIncludeTags
 import gem.test.Tags._
 import gem.util.InstantMicros
 
@@ -24,7 +25,7 @@ import java.time.temporal.ChronoUnit.DAYS
   *
   */
 @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-final class EphemerisQuerySpec extends CatsSuite with EphemerisTestSupport {
+final class EphemerisQuerySpec extends CatsSuite with EphemerisTestSupport with RespectIncludeTags {
 
   import EphemerisQuerySpec._
 


### PR DESCRIPTION
This PR provides a means to exclude tagged tests by default and yet still execute them on demand from the command line.  Unfortunately the logic used by ScalaTest for including and excluding tests is exactly the opposite of what I wanted so this had to be hacked in using a new trait.   It is documented in detail in the code so I won't describe it again here.