### PR TITLE
Potential fix for issue #115

### DIFF
--- a/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
@@ -129,15 +129,21 @@ final class CoordinatesSpec extends CatsSuite {
     }
   }
 
-  test("interpolate should be consistent with fractional angular separation, to within 1µsec (15 µas)") {
+  test("interpolate should be consistent with fractional angular separation, to within 20 µas") {
+    val µas180 = Angle.Angle180.toMicroarcseconds
+    val µas360 = µas180 * 2L
+
     forAll { (c1: Coordinates, c2: Coordinates) =>
       val sep = c1.angularDistance(c2)
       val Δs  = (-1.0 to 2.0 by 0.1).map { f =>
-        val stepSep = c1.interpolate(c2, f).angularDistance(c1)
-        (stepSep.toMicroarcseconds - (sep.toSignedMicroarcseconds * f.abs).toLong)
+        val stepSep  = c1.interpolate(c2, f).angularDistance(c1).toMicroarcseconds
+        val fracSep  = (sep.toMicroarcseconds * f.abs).toLong
+        val fracSepʹ = if (fracSep <= µas180) fracSep else µas360 - fracSep
+        (stepSep - fracSepʹ).abs
       }
-      Δs.filter(_ > 15L) shouldBe empty
+      Δs.filter(_ > 20L) shouldBe empty
     }
+
   }
 
   test("format and parse must round-trip") {


### PR DESCRIPTION
This PR addresses a sporadic test case failure detailed in issue #115.  It

* increases the tolerance for error a bit

* accounts for coordinates nearly 12 hours apart where interpolation to fractional values greater than 1.0 can actually decrease the angular separation