### PR TITLE
ephemeris_meta for update tracking

### DIFF
--- a/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.util.InstantMicros
+
+import cats.{ Eq, Show }
+
+
+/** Ephemeris meta data related to updates.
+  *
+  * @param lastUpdate time of last update
+  * @param lastUpdateCheck time of last update check
+  * @param solnRef horizons solution reference, if any (applies to comet and
+  *                asteroid ephemeris data fetched from horizons)
+  */
+final case class EphemerisMeta(
+  lastUpdate: InstantMicros,
+  lastUpdateCheck: InstantMicros,
+  solnRef: Option[HorizonsSolutionRef])
+
+
+object EphemerisMeta {
+
+  implicit val eqEphemerisMeta: Eq[EphemerisMeta] =
+    Eq.fromUniversalEquals
+
+  implicit val showEphemerisMeta: Show[EphemerisMeta] =
+    Show.fromToString
+}

--- a/modules/core/shared/src/main/scala/gem/HorizonsSolutionRef.scala
+++ b/modules/core/shared/src/main/scala/gem/HorizonsSolutionRef.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Eq, Show }
+
+
+/** Horizons solution reference.  Comets and asteriods have a unique version
+  * that is updated when the ephemeris calculation changes.  For our purposes
+  * this is opaque data whose only use is to compare to an earlier version in
+  * order to check for changes.
+  */
+final case class HorizonsSolutionRef(stringValue: String)
+
+object HorizonsSolutionRef {
+
+  implicit val ShowHorizonsSolutionRef: Show[HorizonsSolutionRef] =
+    Show.fromToString
+
+  implicit val EqHorizonsSolutionRef: Eq[HorizonsSolutionRef] =
+    Eq.fromUniversalEquals
+}

--- a/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
+++ b/modules/core/shared/src/main/scala/gem/util/InstantMicros.scala
@@ -56,8 +56,9 @@ final class InstantMicros private (val toInstant: Instant) extends AnyVal {
 
 object InstantMicros {
 
-  val Min: InstantMicros = InstantMicros.truncate(Instant.MIN)
-  val Max: InstantMicros = InstantMicros.truncate(Instant.MAX)
+  val Min:   InstantMicros = InstantMicros.truncate(Instant.MIN)
+  val Max:   InstantMicros = InstantMicros.truncate(Instant.MAX)
+  val Epoch: InstantMicros = InstantMicros.truncate(Instant.EPOCH)
 
 
   /** Creates an InstantMicro from the given Instant, assuring that the time

--- a/modules/core/shared/src/test/scala/gem/arb/EphemerisMeta.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/EphemerisMeta.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.util.InstantMicros
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbEphemerisMeta {
+
+  import ArbTime._
+
+  implicit val arbHorizonsSolnRef: Arbitrary[HorizonsSolutionRef] =
+    Arbitrary {
+      Gen.alphaStr.map(HorizonsSolutionRef.apply)
+    }
+
+  implicit val arbEphemerisMeta: Arbitrary[EphemerisMeta] =
+    Arbitrary {
+      for {
+        u <- arbitrary[InstantMicros]
+        c <- arbitrary[InstantMicros]
+        s <- arbitrary[Option[HorizonsSolutionRef]]
+      } yield EphemerisMeta(u, c, s)
+    }
+
+}
+
+object ArbEphemerisMeta extends ArbEphemerisMeta

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -21,8 +21,6 @@ object EphemerisDao {
   import EphemerisKeyComposite._
   import TimeMeta._
 
-//  implicit val han: LogHandler = LogHandler.jdkLogHandler
-
   def insert(k: EphemerisKey, s: Site, e: Ephemeris): ConnectionIO[Int] =
     Statements.insert.updateMany(
       e.toMap.toList.map { case (i, c) => (k, s, i, c, c.ra.format, c.dec.format) }

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -11,7 +11,7 @@ import gem._
 import gem.enum._
 import gem.config._
 import gem.config.DynamicConfig.SmartGcalKey
-import gem.util.Location
+import gem.util.{ InstantMicros, Location }
 import gem.math._
 import java.time.LocalDate
 import org.scalatest._
@@ -63,6 +63,8 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val instrumentConfig = f2Config
     val stepType         = StepType.Science
     val ephemerisKey     = EphemerisKey.Comet("Lanrezac")
+    val horizonsSolnRef  = HorizonsSolutionRef("JPL#K162/5")
+    val ephemerisMeta    = EphemerisMeta(InstantMicros.Min, InstantMicros.Min, Some(horizonsSolnRef))
 
     val gmosCustomRoiEntry =
       gem.config.GmosConfig.GmosCustomRoiEntry.unsafeFromDescription(1, 1, 1, 1)

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -15,4 +15,9 @@ class EphemerisCheck extends Check {
   it should "selectRange" in check(selectRange(Dummy.ephemerisKey, Dummy.site, InstantMicros.Min, InstantMicros.Max))
 
   it should "selectNextUserSuppliedKey" in check(selectNextUserSuppliedKey)
+
+  it should "insertMeta"  in check(insertMeta(Dummy.ephemerisKey, Dummy.site, Dummy.ephemerisMeta))
+  it should "updateMeta"  in check(updateMeta(Dummy.ephemerisKey, Dummy.site, Dummy.ephemerisMeta))
+  it should "deleteMeta"  in check(deleteMeta(Dummy.ephemerisKey, Dummy.site))
+  it should "selectMeta"  in check(selectMeta(Dummy.ephemerisKey, Dummy.site))
 }

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
@@ -18,14 +18,14 @@ import scala.util.matching.Regex
 /** Horizons name-resolution query.
   *
   * {{{
-  * import HorizonsNameQuery.Search.Comet
+  *   import HorizonsNameQuery.Search.Comet
   *
-  * HorizonsNameQuery(Comet("Halley")).lookup.value.unsafeRunSync
+  *   HorizonsNameQuery(Comet("Halley")).lookup.value.unsafeRunSync
   * }}}
   */
 sealed trait HorizonsNameQuery[A] {
 
-  /** URL string corresponding the the horizons request. */
+  /** URL string corresponding to the horizons request. */
   def urlString: String
 
   /** Returns a program that will perform the name lookup when executed,

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsSolutionRefQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsSolutionRefQuery.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import atto.Atto._
+import atto._
+import cats.effect.IO
+import gem.{EphemerisKey, HorizonsSolutionRef}
+
+/** Horizons solution reference query.  Horizons supports a version number, of
+  * sorts, for comet and asteriod ephemeris calculations.  The version is an
+  * opaque `String` that can be used to compare for equality against previous
+  * versions to determine if an update is required.  Unfortunately, major bodies
+  * do not include solution references.
+  *
+  * {{{
+  *   import gem.EphemerisKey
+  *   import gem.horizons.HorizonsSolutionRefQuery
+  *
+  *   HorizonsSolutionRefQuery(EphemerisKey.Comet("81P")).lookup.unsafeRunSync
+  * }}}
+  *
+  */
+sealed trait HorizonsSolutionRefQuery {
+
+  /** URL string corresponding to the horizons request. */
+  def urlString: String
+
+  /** Returns a program that will perform the solution reference lookup when
+    * executed.
+    */
+  def lookup: IO[Option[HorizonsSolutionRef]]
+
+}
+
+object HorizonsSolutionRefQuery {
+
+  private val FixedParams = HorizonsClient.SharedParams ++ Map(
+    "MAKE_EPHEM" -> "NO"  // We don't need actual ephemeris elements
+  )
+
+  private val SolnRefKey = "soln ref.="
+
+  private val solnRefParser: Parser[HorizonsSolutionRef] =
+    (manyUntil(anyChar, string(SolnRefKey)) ~> stringOf1(noneOf(",\n"))).map { s =>
+      HorizonsSolutionRef(s.trim)
+    }
+
+  /** Parses an horizons header string into a solution reference, if found.
+    */
+  def parseSolutionRef(s: String): Option[HorizonsSolutionRef] =
+    (solnRefParser parseOnly s).option
+
+  /** Creates a query instance for the given ephemeris key.
+    */
+  def apply(key: EphemerisKey.Horizons): HorizonsSolutionRefQuery =
+
+    new HorizonsSolutionRefQuery {
+      val reqParams = Map(
+        "COMMAND" -> s"'${key.queryString}'"
+      ) ++ FixedParams
+
+      override val urlString: String =
+        HorizonsClient.urlString(reqParams)
+
+      override val lookup: IO[Option[HorizonsSolutionRef]] =
+        key match {
+
+          // Horizons has no solution references for major bodies so we can skip
+          // doing an actual lookup.
+          case EphemerisKey.MajorBody(_) =>
+            IO.pure(None)
+
+          case _                         =>
+            HorizonsClient.fetch(reqParams).map(parseSolutionRef)
+        }
+    }
+
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
@@ -1,0 +1,128 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.{EphemerisKey, HorizonsSolutionRef}
+import gem.test.Tags.RequiresNetwork
+
+import cats.tests.CatsSuite
+
+final class HorizonsSolutionRefQuerySpec extends CatsSuite {
+
+  import HorizonsSolutionRefQuerySpec._
+
+  test("parse solution ref terminated by comma") {
+    HorizonsSolutionRefQuery.parseSolutionRef(wild2Header) shouldEqual Some(HorizonsSolutionRef("JPL#K162/5"))
+  }
+
+  test("parse solution ref terminated by newline") {
+    HorizonsSolutionRefQuery.parseSolutionRef(beerHeader) shouldEqual Some(HorizonsSolutionRef("JPL#23"))
+  }
+
+  test("parse a major body without solution ref") {
+    HorizonsSolutionRefQuery.parseSolutionRef(titanHeader) shouldEqual None
+  }
+
+  test("runs comet solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(wild2).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+
+  test("runs asteroid solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(beer).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+
+  test("runs major body solution ref query") {
+    HorizonsSolutionRefQuery(titan).lookup.unsafeRunSync shouldEqual None
+  }
+}
+
+object HorizonsSolutionRefQuerySpec {
+
+  val wild2: EphemerisKey.Horizons =
+    EphemerisKey.Comet("81P")
+
+  val wild2Header: String =
+    """
+      |*******************************************************************************
+      |JPL/HORIZONS                     81P/Wild 2                2017-Sep-27 12:26:51
+      |Rec #:900817 (+COV)   Soln.date: 2017-Jul-06_14:39:31   # obs: 4021 (2008-2017)
+      |
+      |IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+      |
+      |  EPOCH=  2455772.5 ! 2011-Jul-30.0000000 (TDB)    RMSW= n.a.
+      |   EC= .5370816286507473   QR= 1.597991694337067   TP= 2455250.0788030997
+      |   OM= 136.0976955732219   W= 41.75965127535293    IN= 3.237207856138221
+      |   A= 3.451994548584135    MA= 80.282282601105     ADIST= 5.305997402831204
+      |   PER= 6.4137697671158    N= .153673474           ANGMOM= .026959831
+      |   DAN= 1.75367            DDN= 4.09807            L= 177.8118934
+      |   B= 2.1553656            MOID= .60296798         TP= 2010-Feb-22.5788030997
+      |
+      |Comet physical (GM= km^3/s^2; RAD= km):
+      |   GM= n.a.                RAD= 2.
+      |   M1=  8.8      M2=  13.1     k1=  14.    k2=  5.      PHCOF=  .030
+      |
+      |Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+      |   AMRAT=  0.                                      DT=  0.
+      |   A1= 1.811725646257E-9   A2= 3.974820487201E-11  A3= 0.
+      | Standard model:
+      |   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+      |
+      |COMET comments
+      |1: soln ref.= JPL#K162/5, data arc: 2008-10-20 to 2017-06-24
+      |2: k1=14., k2=5., phase coef.=0.03;
+      |*******************************************************************************
+    """.stripMargin
+
+  val beer: EphemerisKey.Horizons =
+    EphemerisKey.AsteroidNew("1971 UC1")
+
+  val beerHeader: String =
+    """
+      |*******************************************************************************
+      |JPL/HORIZONS                1896 Beer (1971 UC1)           2017-Sep-27 13:57:35
+      |Rec #:  1896 (+COV)   Soln.date: 2017-May-15_14:17:06   # obs: 1566 (1949-2017)
+      |
+      |IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+      |
+      |  EPOCH=  2455763.5 ! 2011-Jul-21.00 (TDB)         Residual RMS= .33782
+      |   EC= .2217996492354765   QR= 1.842496797109042   TP= 2455815.8047106094
+      |   OM= 182.1795820773458   W=  180.1210417236072   IN= 2.220651628945542
+      |   A= 2.367638096409141    MA= 345.8494963260648   ADIST= 2.892779395709239
+      |   PER= 3.64318            N= .270539749           ANGMOM= .02580981
+      |   DAN= 2.89278            DDN= 1.8425             L= 2.3005429
+      |   B= -.0046903            MOID= .83910203         TP= 2011-Sep-11.3047106094
+      |
+      |Asteroid physical parameters (km, seconds, rotational period in hours):
+      |   GM= n.a.                RAD= 2.6885             ROTPER= 3.3278
+      |   H= 13.8                 G= .150                 B-V= n.a.
+      |                           ALBEDO= .202            STYP= n.a.
+      |
+      |ASTEROID comments:
+      |1: soln ref.= JPL#23
+      |2: source=ORB
+      |*******************************************************************************
+    """.stripMargin
+
+  val titan: EphemerisKey.Horizons =
+    EphemerisKey.MajorBody(606)
+
+  val titanHeader: String =
+    """
+      |*******************************************************************************
+      | Revised: JUn 17, 2016              Titan / (Saturn)                        606
+      |                         http://ssd.jpl.nasa.gov/?sat_phys_par
+      |                           http://ssd.jpl.nasa.gov/?sat_elem
+      |
+      | SATELLITE PHYSICAL PROPERTIES:
+      |  Mean Radius (km)       = 2575.5   +-  2.0  Density (g/cm^3) =  1.880 +- 0.004
+      |  Mass (10^19 kg)        = 13455.3           Geometric Albedo =  0.2
+      |  GM (km^3/s^2)          = 8978.13  +-  0.06  V(1,0)          = -1.2
+      |
+      | SATELLITE ORBITAL DATA:
+      |  Semi-major axis, a (km)= 1221.87 (10^3)  Orbital period     = 15.945421 d
+      |  Eccentricity, e        = 0.0288          Rotational period  =
+      |  Inclination, i  (deg)  = 0.28
+      |*******************************************************************************
+    """.stripMargin
+}

--- a/modules/sql/src/main/resources/db/migration/V029__Ephemeris_Meta.sql
+++ b/modules/sql/src/main/resources/db/migration/V029__Ephemeris_Meta.sql
@@ -1,0 +1,20 @@
+
+--
+-- Ephemeris metadata used to report upon last update times and, for comets
+-- and asteroids, avoid unnecessary updates.
+--
+
+CREATE TABLE ephemeris_meta (
+    key_type          identifier  REFERENCES e_ephemeris_type,
+    key               text        NOT NULL,
+    site              identifier  REFERENCES e_site,
+    last_update       timestamptz NOT NULL,
+    last_update_check timestamptz NOT NULL,
+    horizons_soln_ref text,
+    PRIMARY KEY (key_type, key, site)
+);
+
+ALTER TABLE ephemeris_meta OWNER TO postgres;
+
+COMMENT ON COLUMN ephemeris_meta.horizons_soln_ref IS 'horizons-defined version for comet and asteroid ephemeris calculations';
+


### PR DESCRIPTION
The PR adds a table for tracking information related to ephemeris updates.  In particular it records the last update time, the last update check time, and the horizons solution reference for each ephemeris key.  At the moment, we only have solution reference information for comets and asteroids so this may change if we get more information from horizons about major body versions.  User-supplied ephemeris data also won't have a solution reference of course.