### PR TITLE
Update atto, doobie, http4s, wartremover

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val gemWarts =
     Wart.Serializable,       // false positives
     Wart.Recursion,          // false positives
     Wart.ImplicitConversion, // we know what we're doing
-    Wart.ImplicitParameter
+    Wart.ImplicitParameter   // false positives
   )
 
 lazy val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 lazy val circeVersion        = "0.9.0-M1"
-lazy val attoVersion         = "0.6.1-M1"
+lazy val attoVersion         = "0.6.1-M5"
 lazy val catsEffectVersion   = "0.4"
 lazy val catsVersion         = "1.0.0-MF"
 lazy val declineVersion      = "0.4.0-M1"
-lazy val doobieVersion       = "0.5.0-M7"
+lazy val doobieVersion       = "0.5.0-M8"
 lazy val flywayVersion       = "4.2.0"
 lazy val fs2Version          = "0.10.0-M6"
-lazy val http4sVersion       = "0.18.0-M1"
+lazy val http4sVersion       = "0.18.0-M2"
 lazy val jwtVersion          = "0.14.0"
 lazy val kpVersion           = "0.9.4"
 lazy val monocleVersion      = "1.5.0-cats-M1"
@@ -74,7 +74,7 @@ lazy val gemWarts =
     Wart.Serializable,       // false positives
     Wart.Recursion,          // false positives
     Wart.ImplicitConversion, // we know what we're doing
-    Wart.ImplicitParameter   // false positives
+    Wart.ImplicitParameter
   )
 
 lazy val commonSettings = Seq(

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -15,7 +15,7 @@ import gem.ocs2.pio.PioError._
 import fs2.Stream
 
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.client.blaze.PooledHttp1Client
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.util.StreamApp

--- a/modules/web/src/main/scala/Application.scala
+++ b/modules/web/src/main/scala/Application.scala
@@ -10,7 +10,7 @@ import gem.json._
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.circe._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 /**
  * The main application web service, which is "authenticated" in the sense that request carries

--- a/modules/web/src/main/scala/package.scala
+++ b/modules/web/src/main/scala/package.scala
@@ -5,7 +5,7 @@ package gem
 
 import cats.implicits._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 package object web {
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("org.scalastyle"   %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"   % "1.1.4")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"               % "0.8.5")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"            % "2.0.0")
-addSbtPlugin("org.wartremover"   % "sbt-wartremover"       % "2.1.1") // 2.2.0 PublicInference fails
+addSbtPlugin("org.wartremover"   % "sbt-wartremover"       % "2.2.1")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"           % "0.6.18")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph"  % "0.8.2")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"           % "0.3.1")


### PR DESCRIPTION
There were some changes to the http4s API that are good simplifications but I had to refactor `Gatekeeper` a little bit. The new version of WartRemover is a lot better. There's still one false positive for `PublicInference` which I suppressed.