### PR TITLE
Parses revision date as solution ref for major bodies

### DIFF
--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
@@ -3,25 +3,27 @@
 
 package gem.horizons
 
-import gem.{EphemerisKey, HorizonsSolutionRef}
+import gem.{ EphemerisKey, HorizonsSolutionRef }
+
+import gem.test.RespectIncludeTags
 import gem.test.Tags.RequiresNetwork
 
 import cats.tests.CatsSuite
 
-final class HorizonsSolutionRefQuerySpec extends CatsSuite {
+final class HorizonsSolutionRefQuerySpec extends CatsSuite with RespectIncludeTags {
 
   import HorizonsSolutionRefQuerySpec._
 
   test("parse solution ref terminated by comma") {
-    HorizonsSolutionRefQuery.parseSolutionRef(wild2Header) shouldEqual Some(HorizonsSolutionRef("JPL#K162/5"))
+    HorizonsSolutionRefQuery.parseSolutionRef(wild2, wild2Header) shouldEqual Some(HorizonsSolutionRef("JPL#K162/5"))
   }
 
   test("parse solution ref terminated by newline") {
-    HorizonsSolutionRefQuery.parseSolutionRef(beerHeader) shouldEqual Some(HorizonsSolutionRef("JPL#23"))
+    HorizonsSolutionRefQuery.parseSolutionRef(beer, beerHeader) shouldEqual Some(HorizonsSolutionRef("JPL#23"))
   }
 
   test("parse a major body without solution ref") {
-    HorizonsSolutionRefQuery.parseSolutionRef(titanHeader) shouldEqual None
+    HorizonsSolutionRefQuery.parseSolutionRef(titan, titanHeader) shouldEqual Some(HorizonsSolutionRef("JUn 17, 2016"))
   }
 
   test("runs comet solution ref query", RequiresNetwork) {
@@ -32,8 +34,8 @@ final class HorizonsSolutionRefQuerySpec extends CatsSuite {
     HorizonsSolutionRefQuery(beer).lookup.unsafeRunSync.isDefined shouldBe true
   }
 
-  test("runs major body solution ref query") {
-    HorizonsSolutionRefQuery(titan).lookup.unsafeRunSync shouldEqual None
+  test("runs major body solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(titan).lookup.unsafeRunSync.isDefined shouldBe true
   }
 }
 


### PR DESCRIPTION
Per review meeting discussion and subsequent followup with JPL, this PR uses the "Revision" date in Major Body object headers as if it were the solution reference.  The actual value of a solution reference or revision date is irrelevant and opaque to us except for difference comparisons. 

I decided not to hash the revision date or the solution reference proper so that we can easily check values in the database against horizons query results. 