### PR TITLE
EphemerisUpdater

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ git.uncommittedSignifier in ThisBuild := Some("UNCOMMITTED")
 // check for library updates whenever the project is [re]load
 onLoad in Global := { s => "dependencyUpdates" :: s }
 
+cancelable in Global := true
+
 // some extra commands for us
 addCommandAlias("genEnums", "; sql/runMain gem.sql.Main modules/core/shared/src/main/scala/gem/enum; headerCreate")
 addCommandAlias("schemaSpy", "sql/runMain org.schemaspy.Main -t pgsql -port 5432 -db gem -o modules/sql/target/schemaspy -u postgres -host localhost -s public")

--- a/modules/db/src/main/scala/gem/Log.scala
+++ b/modules/db/src/main/scala/gem/Log.scala
@@ -56,6 +56,14 @@ abstract class Log[M[_]] private (name: String, xa: Transactor[IO]) {
       a       <- disj.fold(t => fail(user, msg, elapsed, t), a => success(user, msg, elapsed, a))
     } yield a
 
+  /**
+   * Constructs a new program in `M` that simply writes a message without an
+   * associated timed action.  Roughly equivalent to `log(user, msg)(().pure[M])`
+   * but guaranteed to record 0 elapsed time.
+   */
+  def logMessage(user: User[_], msg: => String): M[Unit] =
+    success(user, msg, 0, ())
+
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def shutdown(ms: Long): M[Unit] =
     M.delay {

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -73,6 +73,12 @@ object EphemerisDao {
   def streamRange(k: EphemerisKey, s: Site, start: InstantMicros, end: InstantMicros): Stream[ConnectionIO, Ephemeris.Element] =
     Statements.selectRange(k, s, start, end).stream
 
+  /** Selects the min and max times for which ephemeris data is available, if
+    * any.
+    */
+  def selectTimes(k: EphemerisKey, s: Site): ConnectionIO[Option[(InstantMicros, InstantMicros)]] =
+    Statements.selectTimes(k, s).unique
+
   /** Create the next UserSupplied ephemeris key value. */
   val nextUserSuppliedKey: ConnectionIO[EphemerisKey.UserSupplied] =
     Statements.selectNextUserSuppliedKey.unique
@@ -132,6 +138,14 @@ object EphemerisDao {
     def selectRange(k: EphemerisKey, s: Site, start: InstantMicros, end: InstantMicros): Query0[Ephemeris.Element] =
       (selectFragment(k, s) ++ fr"""AND timestamp >= $start AND timestamp < $end""")
         .query[Ephemeris.Element]
+
+    def selectTimes(k: EphemerisKey, s: Site): Query0[Option[(InstantMicros, InstantMicros)]] =
+      sql"""
+          SELECT min(timestamp),
+                 max(timestamp)
+            FROM ephemeris
+           WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s
+      """.query[(Option[InstantMicros], Option[InstantMicros])].map(_.tupled)
 
     val selectNextUserSuppliedKey: Query0[EphemerisKey.UserSupplied] =
       sql"""

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -73,8 +73,7 @@ object EphemerisDao {
   def streamRange(k: EphemerisKey, s: Site, start: InstantMicros, end: InstantMicros): Stream[ConnectionIO, Ephemeris.Element] =
     Statements.selectRange(k, s, start, end).stream
 
-  /** Selects the min and max times for which ephemeris data is available, if
-    * any.
+  /** Selects the min and max times for which an ephemeris is available, if any.
     */
   def selectTimes(k: EphemerisKey, s: Site): ConnectionIO[Option[(InstantMicros, InstantMicros)]] =
     Statements.selectTimes(k, s).unique

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -144,7 +144,7 @@ object EphemerisDao {
                  max(timestamp)
             FROM ephemeris
            WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s
-      """.query[(Option[InstantMicros], Option[InstantMicros])].map(_.tupled)
+      """.query[Option[(InstantMicros, InstantMicros)]]
 
     val selectNextUserSuppliedKey: Query0[EphemerisKey.UserSupplied] =
       sql"""

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -215,6 +215,19 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     }
   }
 
+  property("EphemerisDao should select times") {
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+
+      val p  = EphemerisDao.selectTimes(ks.key, ks.site)
+      val em = e.toMap
+
+      val expected =
+        if (em.isEmpty) Option.empty[(InstantMicros, InstantMicros)]
+        else Some((em.firstKey, em.lastKey))
+
+      expected shouldEqual execTest(m + (ks -> e), p)
+    }
+  }
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.Equals"))

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -228,6 +228,16 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       expected shouldEqual execTest(m + (ks -> e), p)
     }
   }
+
+  property("EphemerisDao should select None times if no matching ephemeris") {
+    forAll { (ks: KS, m: EphemerisMap) =>
+
+      val p  = EphemerisDao.selectTimes(ks.key, ks.site)
+
+      None shouldEqual execTest(m - ks, p)
+    }
+
+  }
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.Equals"))

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -20,4 +20,6 @@ class EphemerisCheck extends Check {
   it should "updateMeta"  in check(updateMeta(Dummy.ephemerisKey, Dummy.site, Dummy.ephemerisMeta))
   it should "deleteMeta"  in check(deleteMeta(Dummy.ephemerisKey, Dummy.site))
   it should "selectMeta"  in check(selectMeta(Dummy.ephemerisKey, Dummy.site))
+
+  it should "selectTimes" in check(selectTimes(Dummy.ephemerisKey, Dummy.site))
 }

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -1,0 +1,186 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+package horizons
+
+import gem.dao.EphemerisDao
+import gem.enum.Site
+import gem.math.Ephemeris
+import gem.util.InstantMicros
+import gem.horizons.VelocityCompression._
+
+import cats._
+import cats.effect._
+import cats.effect.implicits._
+import cats.implicits._
+
+import doobie._, doobie.implicits._
+
+import java.time.{ Duration, Period }
+
+import fs2.Stream
+
+import scala.math.Ordering.Implicits._
+
+/** Utility for inserting / updating en ephemeris. */
+final case class HorizonsEphemerisUpdater(
+                   user: User[_],
+                   log:  Log[ConnectionIO],
+                   xa:   Transactor.Aux[IO, Unit]) {
+
+  import HorizonsEphemerisUpdater._
+
+  /** Constructs an action that when run will provide the current context
+    * information for an ephemeris.  This information can be used to determine
+    * whether an update is needed, to see when the last update was performed,
+    * and when the last update check happened.
+    */
+  def report(key:  EphemerisKey.Horizons, site: Site): IO[Context] =
+
+    for {
+
+      meta <- log.log(user, s"EphemerisDao.selectMeta($key, $site)") {
+                EphemerisDao.selectMeta(key, site)
+              }.transact(xa)
+
+      rnge <- log.log(user, s"EphemerisDao.selectTimes($key, $site)") {
+                EphemerisDao.selectTimes(key, site)
+              }.transact(xa)
+
+      soln <- log.log(user, s"HorizonsSolutionRefQuery($key).lookup") {
+                HorizonsSolutionRefQuery(key).lookup.liftIO[ConnectionIO]
+              }.transact(xa)
+
+    } yield Context(key, site, meta, rnge, soln)
+
+
+  /** Constructs an action that when run will insert a new ephemeris or update
+    * an existing one if necessary.
+    */
+  def update(key: EphemerisKey.Horizons, site: Site): IO[Unit] =
+
+    for {
+
+      time <- InstantMicros.now
+      sem  <- Semester.current(site)
+      ctx  <- report(key, site)
+      _    <- calcUpdate(ctx, time, sem).transact(xa)
+
+    } yield ()
+
+
+  private def logMessage(msg: String): ConnectionIO[Unit] =
+    log.log(user, msg)(().pure[ConnectionIO])
+
+  private def insertMeta(key: EphemerisKey.Horizons, site: Site, m: EphemerisMeta): ConnectionIO[Unit] =
+    log.log(user, s"insertMeta($key, $site, $m)") {
+      EphemerisDao.insertMeta(key, site, m).void
+    }
+
+  private def updateMeta(key: EphemerisKey.Horizons, site: Site, m: EphemerisMeta): ConnectionIO[Unit] =
+    log.log(user, s"updateMeta($key, $site, $m)") {
+      EphemerisDao.updateMeta(key, site, m).void
+    }
+
+  private def streamEphemeris(
+                key:      EphemerisKey.Horizons,
+                site:     Site,
+                semester: Semester): Stream[ConnectionIO, Ephemeris.Element] = {
+
+    val qs = HorizonsEphemerisQuery.pagingSemester(key, site, semester, StepSize, Padding)
+
+    qs.foldMap(_.streamEphemeris)
+      .through(standardVelocityCompression)
+      .translateSync(λ[IO ~> ConnectionIO](_.liftIO[ConnectionIO]))
+  }
+
+  private def calcUpdate(ctx:  Context,
+                         time: InstantMicros,
+                         sem:  Semester): ConnectionIO[Unit] =
+
+    if (ctx.isUpToDateFor(sem)) {
+
+      // Just need to update the last update check time
+      ctx.meta.fold(().pure[ConnectionIO]) { m =>
+        updateMeta(ctx.key, ctx.site, EphemerisMeta.lastUpdateCheck.set(time)(m))
+      }
+
+    } else {
+
+      // Need to update both meta and ephemeris.  First the new
+      // meta data.
+      val mʹ   = EphemerisMeta(time, time, ctx.soln)
+
+      // The sink for writing the ephemeris data to the database.  Have to pick
+      // either insert or update depending upon whether there is an existing
+      // ephemeris.
+      val sink = ctx.rnge.fold(EphemerisDao.streamInsert(ctx.key, ctx.site)) { _ =>
+        EphemerisDao.streamUpdate(ctx.key, ctx.site)
+      }
+
+      // Update the metadata and stream the ephemeris into the database.
+      for {
+        _ <- logMessage(s"Update ${ctx.key}@${ctx.site}")
+        _ <- ctx.meta.fold(insertMeta(ctx.key, ctx.site, mʹ)) { _ =>
+               updateMeta(ctx.key, ctx.site, mʹ)
+             }
+        _ <- log.log(user, s"streamEphemeris(${ctx.key}, ${ctx.site}, $sem)") {
+               streamEphemeris(ctx.key, ctx.site, sem).to(sink).run
+             }
+      } yield ()
+    }
+
+}
+
+object HorizonsEphemerisUpdater {
+
+  /** Padding on either side of the semester to include in an ephemeris. */
+  val Padding: Period =
+    Period.ofMonths(1)
+
+  /** Maximum time between ephemeris elements, before removing points that
+    * should be interpolated.
+    */
+  val StepSize: Duration =
+    Duration.ofMinutes(1L)
+
+  /** Collection of information related to an ephemeris.  Used to determine
+    * whether an update is needed.
+    *
+    * @param key  unique horizons id of the object
+    * @param site information valid for the given site
+    * @param meta associated ephemeris metadata, if any
+    * @param rnge earliest and latest ephemeris element times, if any
+    * @param soln current horizons solution reference from JPL, if any
+    */
+  final case class Context(key:  EphemerisKey.Horizons,
+                           site: Site,
+                           meta: Option[EphemerisMeta],
+                           rnge: Option[(InstantMicros, InstantMicros)],
+                           soln: Option[HorizonsSolutionRef]) {
+
+    /** Determines whether the existing ephemeris, if any, covers the given
+      * semester.
+      */
+    def coversSemester(sem: Semester): Boolean =
+      rnge.exists { case (start, end) =>
+        (start.toInstant <= sem.start.atSite(site).toInstant) &&
+          (sem.end.atSite(site).toInstant <= end.toInstant)
+      }
+
+    /** Whether the database and latest horizons version data matches. */
+    val sameSolution: Boolean =
+      (meta.flatMap(_.solnRef), soln).tupled.exists { case (s0, s1) =>
+        s0 === s1
+      }
+
+    /** Determines whether updates are needed to obtain the latest ephemeris for
+      * the given semester.
+      */
+    def isUpToDateFor(sem: Semester): Boolean =
+      coversSemester(sem) && sameSolution
+  }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -71,9 +71,6 @@ final case class HorizonsEphemerisUpdater(
     } yield ()
 
 
-  private def logMessage(msg: String): ConnectionIO[Unit] =
-    log.log(user, msg)(().pure[ConnectionIO])
-
   private def insertMeta(key: EphemerisKey.Horizons, site: Site, m: EphemerisMeta): ConnectionIO[Unit] =
     log.log(user, s"insertMeta($key, $site, $m)") {
       EphemerisDao.insertMeta(key, site, m).void
@@ -114,7 +111,7 @@ final case class HorizonsEphemerisUpdater(
   ): ConnectionIO[Unit] =
 
     for {
-      _ <- logMessage(s"${ctx.key}@${ctx.site} already up-to-date. Record update check.")
+      _ <- log.logMessage(user, s"${ctx.key}@${ctx.site} already up-to-date. Record update check.")
       _ <- ctx.meta.fold(().pure[ConnectionIO]) { m =>
             updateMeta(ctx.key, ctx.site, EphemerisMeta.lastUpdateCheck.set(time)(m))
           }
@@ -139,7 +136,7 @@ final case class HorizonsEphemerisUpdater(
 
     // Update the metadata and stream the ephemeris into the database.
     for {
-      _ <- logMessage(s"Update ${ctx.key}@${ctx.site}")
+      _ <- log.logMessage(user, s"Update ${ctx.key}@${ctx.site}")
       _ <- ctx.meta.fold(insertMeta(ctx.key, ctx.site, mʹ)) { _ =>
              updateMeta(ctx.key, ctx.site, mʹ)
            }

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsUpdaterApp.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsUpdaterApp.scala
@@ -1,0 +1,97 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.{ EphemerisKey, Log }
+import gem.dao.UserDao
+import gem.enum.Site
+
+import cats.effect.IO
+import cats.implicits._
+
+import doobie._, doobie.implicits._
+
+
+/** A simple test application that drives ephemeris updates.
+  *
+  * {{{
+  *   > ephemeris/test:run gem.horizons.HorizonsUpdater site key ...
+  * }}}
+  *
+  * e.g.,
+  *
+  * {{{
+  *   ephemeris/test:run gem.horizons.HorizonsUpdater GS MajorBody_605 MajorBody_606
+  * }}}
+  */
+object HorizonsUpdaterApp {
+
+  private val Url  = "jdbc:postgresql:gem"
+  private val User = "postgres"
+  private val Pass = ""
+
+  private val xa = Transactor.fromDriverManager[IO](
+    "org.postgresql.Driver", Url, User, Pass
+  )
+
+  private def putStrLn(msg: String): IO[Unit] =
+    IO(println(msg))
+
+  type Parsed[A] = Either[String, A]
+
+  final case class Args(site: Site, keys: List[EphemerisKey.Horizons])
+
+  object Args {
+
+    def parse(args: List[String]): Parsed[Args] = {
+
+      def parseSite(siteStr: String): Parsed[Site] =
+        Site.fromTag(siteStr) match {
+          case Some(site) => Either.right(site)
+          case None       => Either.left(s"Expecting GN or GS, not '$siteStr'")
+        }
+
+      def parseKeys(keys: List[String]): Parsed[List[EphemerisKey.Horizons]] =
+        keys.traverse { keyStr =>
+          EphemerisKey.parse(keyStr) match {
+            case Some(key: EphemerisKey.Horizons) => Either.right(key)
+            case Some(key)                        => Either.left(s"'$keyStr' is not an horizons key")
+            case None                             => Either.left(s"Could not parse '$keyStr' as an horizons key")
+          }
+        }
+
+      args.drop(1).toList match {
+
+        case siteStr :: keys =>
+          for {
+            s  <- parseSite(siteStr)
+            ks <- parseKeys(keys)
+          } yield Args(s, ks)
+
+        case _ =>
+          Either.left("usage: HorizonsUpdaterApp [GN|GS] ephemeris_key...")
+      }
+    }
+  }
+
+  def main(args: Array[String]): Unit =
+
+    (Args.parse(args.toList) match {
+
+      case Left(msg)  =>
+        putStrLn(msg)
+
+      case Right(cmd) =>
+        for {
+          user <- UserDao.selectRootUser.transact(xa)
+          log  <- Log.newLogIn[ConnectionIO, IO]("HorizonsEphemerisUpdater", xa)
+          up    = HorizonsEphemerisUpdater(user, log, xa)
+          _    <- cmd.keys.traverse(up.update(_, cmd.site))
+          _    <- log.shutdown(5 * 1000).transact(xa)
+        } yield ()
+      }
+
+    ).unsafeRunSync
+
+}


### PR DESCRIPTION
This PR offers the culmination of the previous `ephemeris?` PRs in that it provides a utility for creating/updating an ephemeris as necessary.  The `HorizonsEphemerisUpdater` is the main objective, but in order to exercise it I included a test application in `src/test/scala` that can be launched from SBT.  I don't think the test app will survive and ultimately we'll want to do periodic updates from, say, a cron job.  Perhaps we should rework it into a telnetd command.

The logging and configuration is a bit awkward so I'd especially welcome any feedback about that.