### PR TITLE
cats 1.0.0-RC1, remove mouse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,15 @@
-lazy val circeVersion        = "0.9.0-M1"
-lazy val attoVersion         = "0.6.1-M5"
-lazy val catsEffectVersion   = "0.4"
-lazy val catsVersion         = "1.0.0-MF"
-lazy val declineVersion      = "0.4.0-M1"
-lazy val doobieVersion       = "0.5.0-M8"
+lazy val circeVersion        = "0.9.0-M2"
+lazy val attoVersion         = "0.6.1-M7"
+lazy val catsEffectVersion   = "0.5"
+lazy val catsVersion         = "1.0.0-RC1"
+lazy val declineVersion      = "0.4.0-RC1"
+lazy val doobieVersion       = "0.5.0-M9"
 lazy val flywayVersion       = "4.2.0"
-lazy val fs2Version          = "0.10.0-M6"
-lazy val http4sVersion       = "0.18.0-M2"
-lazy val jwtVersion          = "0.14.0"
+lazy val fs2Version          = "0.10.0-M8"
+lazy val http4sVersion       = "0.18.0-M5"
+lazy val jwtVersion          = "0.14.1"
 lazy val kpVersion           = "0.9.4"
-lazy val monocleVersion      = "1.5.0-cats-M1"
-lazy val mouseVersion        = "0.10-MF"
+lazy val monocleVersion      = "1.5.0-cats-M2"
 lazy val paradiseVersion     = "2.1.1"
 lazy val scalaCheckVersion   = "1.13.5"
 lazy val scalaParsersVersion = "1.0.6"
@@ -18,7 +17,7 @@ lazy val scalaTestVersion    = "3.0.4"
 lazy val scalaXmlVerson      = "1.0.6"
 lazy val shapelessVersion    = "2.3.2"
 lazy val slf4jVersion        = "1.7.25"
-lazy val tucoVersion         = "0.3.0-M3"
+lazy val tucoVersion         = "0.3.0-M5"
 
 enablePlugins(GitVersioning)
 
@@ -203,7 +202,6 @@ lazy val core = crossProject
       "org.typelevel"              %%% "cats-testkit"   % catsVersion % "test",
       "com.chuusai"                %%% "shapeless"      % shapelessVersion,
       "org.tpolecat"               %%% "atto-core"      % attoVersion,
-      "com.github.benhutchison"    %%% "mouse"          % mouseVersion,
       "com.github.julien-truffaut" %%% "monocle-core"   % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-macro"  % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-law"    % monocleVersion % "test"
@@ -356,11 +354,10 @@ lazy val ctl = project
   .settings (
     resolvers += Resolver.bintrayRepo("bkirwi", "maven"),
     libraryDependencies ++= Seq(
-      "org.typelevel"           %% "cats-core"   % catsVersion,
-      "org.typelevel"           %% "cats-free"   % catsVersion,
-      "org.typelevel"           %% "cats-effect" % catsEffectVersion,
-      "com.monovore"            %% "decline"     % declineVersion,
-      "com.github.benhutchison" %% "mouse"       % mouseVersion
+      "org.typelevel" %% "cats-core"   % catsVersion,
+      "org.typelevel" %% "cats-free"   % catsVersion,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion,
+      "com.monovore"  %% "decline"     % declineVersion,
     ),
     addCommandAlias("gemctl", "ctl/runMain gem.ctl.main")
   )

--- a/modules/core/jvm/src/main/scala/gem/syntax/Stream.scala
+++ b/modules/core/jvm/src/main/scala/gem/syntax/Stream.scala
@@ -49,7 +49,7 @@ final class StreamOps[F[_], O](val self: Stream[F, O]) {
             val aʹ = f(a, o)
             if (p(aʹ)) (matching :+ o, z) else (matching, aʹ)
           }).flatMap { case (matching, aʹ) =>
-            Pull.output(Chunk.vector(matching)) >> go(aʹ, tl)
+            Pull.output(Chunk.vector(matching)) *> go(aʹ, tl)
           }
       }
 

--- a/modules/core/shared/src/main/scala/gem/Dataset.scala
+++ b/modules/core/shared/src/main/scala/gem/Dataset.scala
@@ -6,8 +6,8 @@ package gem
 import cats.{ Order, Show }
 import cats.implicits._
 import gem.imp.TimeInstances._
+import gem.syntax.string._
 import java.time.Instant
-import mouse.all._
 
 /**
  * A labeled, timestamped data file.
@@ -37,7 +37,7 @@ object Dataset {
         case -1 => None
         case  n =>
           val (a, b) = s.splitAt(n)
-          b.drop(1).parseInt.toOption.flatMap { n =>
+          b.drop(1).parseIntOption.flatMap { n =>
             Observation.Id.fromString(a).map(oid => Dataset.Label(oid, n))
           }
       }
@@ -51,8 +51,7 @@ object Dataset {
      * @group Typeclass Instances
      */
     implicit val LabelOrder: Order[Label] =
-      Order[Observation.Id].contramap[Label](_.observationId) whenEqual
-      Order[Int]           .contramap[Label](_.index)
+      Order.by(a => (a.observationId, a.index))
 
     /** @group Typeclass Instances */
     implicit val LabelShow: Show[Label] =
@@ -66,9 +65,7 @@ object Dataset {
    * @group Typeclass Instances
    */
   implicit val DatasetOrder: Order[Dataset] =
-    Order[Label]  .contramap[Dataset](_.label)     whenEqual
-    Order[Instant].contramap[Dataset](_.timestamp) whenEqual
-    Order[String] .contramap[Dataset](_.filename)
+    Order.by(a => (a.label, a.timestamp, a.filename))
 
   /** @group Typeclass Instances */
   implicit val DatasetShow: Show[Dataset] =

--- a/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
@@ -6,6 +6,7 @@ package gem
 import gem.enum.EphemerisKeyType
 import gem.parser.EphemerisKeyParsers
 import gem.syntax.parser._
+import gem.syntax.string._
 
 import cats.{ Eq, Show }
 import monocle.macros.Lenses
@@ -116,9 +117,7 @@ object EphemerisKey {
     * @param des human readable designation
     * @group Constructors
     */
-  def fromTypeAndDes(t: EphemerisKeyType, des: String): Option[EphemerisKey] = {
-    import mouse.all._
-
+  def fromTypeAndDes(t: EphemerisKeyType, des: String): Option[EphemerisKey] =
     t match {
       case EphemerisKeyType.Comet        => Some(Comet(des))
       case EphemerisKeyType.AsteroidNew  => Some(AsteroidNew(des))
@@ -126,7 +125,6 @@ object EphemerisKey {
       case EphemerisKeyType.MajorBody    => des.parseIntOption.map(MajorBody(_))
       case EphemerisKeyType.UserSupplied => des.parseIntOption.map(UserSupplied(_))
     }
-  }
 
   def unsafeFromTypeAndDes(t: EphemerisKeyType, des: String): EphemerisKey =
     fromTypeAndDes(t, des).getOrElse(sys.error(s"inavlid ephemeris key ${t}_$des"))

--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -43,8 +43,7 @@ object Observation {
 
     /** Observations are ordered by program id and index. */
     implicit val OrderId: Order[Id] =
-      Order[Program.Id].contramap[Id](_.pid)   whenEqual
-      Order[Int]       .contramap[Id](_.index)
+      Order.by(a => (a.pid, a.index))
 
     implicit val OrderingId: scala.math.Ordering[Id] =
       OrderId.toOrdering

--- a/modules/core/shared/src/main/scala/gem/ProgramId.scala
+++ b/modules/core/shared/src/main/scala/gem/ProgramId.scala
@@ -88,10 +88,7 @@ object ProgramId {
 
     /** `Science` program ids are ordered pairwise by their data members. */
     implicit val ScienceOrder: Order[Science] =
-      Order[Site]       .contramap[Science](_.site)        whenEqual
-      Order[Semester]   .contramap[Science](_.semester)    whenEqual
-      Order[ProgramType].contramap[Science](_.programType) whenEqual
-      Order[Int]        .contramap[Science](_.index)
+      Order.by(a => (a.site, a.semester, a.programType, a.index))
 
   }
 
@@ -153,9 +150,7 @@ object ProgramId {
 
     /** `Daily` program ids are ordered pairwise by their data members. */
     implicit val DailyOrder: Order[Daily] =
-      Order[Site]            .contramap[Daily](_.site)             whenEqual
-      Order[DailyProgramType].contramap[Daily](_.dailyProgramType) whenEqual
-      Order[LocalDate]       .contramap[Daily](_.localDate)
+      Order.by(a => (a.site, a.dailyProgramType, a.localDate))
 
   }
 
@@ -204,10 +199,7 @@ object ProgramId {
 
     /** `Nonstandard` program ids are ordered pairwise by their data members. */
     implicit val NonStandardOrder: Order[Nonstandard] =
-      Order[Option[Site]]       .contramap[Nonstandard](_.siteOption)        whenEqual
-      Order[Option[Semester]]   .contramap[Nonstandard](_.semesterOption)    whenEqual
-      Order[Option[ProgramType]].contramap[Nonstandard](_.programTypeOption) whenEqual
-      Order[String]             .contramap[Nonstandard](_.tail)
+      Order.by(a => (a.siteOption, a.semesterOption, a.programTypeOption, a.tail))
 
   }
 

--- a/modules/core/shared/src/main/scala/gem/Semester.scala
+++ b/modules/core/shared/src/main/scala/gem/Semester.scala
@@ -132,8 +132,7 @@ object Semester {
 
   /** `Semester` is ordered pairwise by its data members. */
   implicit val SemesterOrder: Order[Semester] =
-    Order[Year].contramap[Semester](_.year) whenEqual
-    Order[Half].contramap[Semester](_.half)
+    Order.by(a => (a.year, a.half))
 
   /**
    * `Ordering` instance for Scala standard library.

--- a/modules/core/shared/src/main/scala/gem/syntax/String.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/String.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+final class StringOps(val self: String) extends AnyVal {
+
+  private def parse[A](f: String => A): Option[A] =
+    try Some(f(self)) catch { case _: IllegalArgumentException => None }
+
+  def parseShortOption:   Option[Short]   = parse(_.toShort)
+  def parseIntOption:     Option[Int]     = parse(_.toInt)
+  def parseLongOption:    Option[Long]    = parse(_.toLong)
+  def parseDoubleOption:  Option[Double]  = parse(_.toDouble)
+  def parseBooleanOption: Option[Boolean] = parse(_.toBoolean)
+  def parseBigDecimalOption: Option[BigDecimal] = parse(BigDecimal(_)) 
+
+}
+
+trait ToStringOps {
+  implicit def ToStringOps[A](p: String): StringOps = new StringOps(p)
+}
+
+object string extends ToStringOps

--- a/modules/core/shared/src/main/scala/gem/syntax/String.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/String.scala
@@ -13,7 +13,7 @@ final class StringOps(val self: String) extends AnyVal {
   def parseLongOption:    Option[Long]    = parse(_.toLong)
   def parseDoubleOption:  Option[Double]  = parse(_.toDouble)
   def parseBooleanOption: Option[Boolean] = parse(_.toBoolean)
-  def parseBigDecimalOption: Option[BigDecimal] = parse(BigDecimal(_)) 
+  def parseBigDecimalOption: Option[BigDecimal] = parse(BigDecimal(_))
 
 }
 

--- a/modules/core/shared/src/test/scala/gem/DatasetLabelSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/DatasetLabelSpec.scala
@@ -5,7 +5,7 @@ package gem
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString"))
@@ -13,7 +13,7 @@ final class DatasetLabelSpec extends CatsSuite {
   import ArbDataset._
 
   // Laws
-  checkAll("DatasetLabel", OrderLaws[Dataset.Label].order)
+  checkAll("DatasetLabel", OrderTests[Dataset.Label].order)
 
   test("Equality must be natural") {
     forAll { (a: Dataset.Label, b: Dataset.Label) =>

--- a/modules/core/shared/src/test/scala/gem/DatasetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/DatasetSpec.scala
@@ -5,7 +5,7 @@ package gem
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 import gem.imp.TimeInstances._
 import java.time.Instant
@@ -15,7 +15,7 @@ final class DatasetSpec extends CatsSuite {
   import ArbDataset._
 
   // Laws
-  checkAll("DatasetLabel", OrderLaws[Dataset].order)
+  checkAll("DatasetLabel", OrderTests[Dataset].order)
 
   test("Equality must be natural") {
     forAll { (a: Dataset, b: Dataset) =>

--- a/modules/core/shared/src/test/scala/gem/EphemerisKeySpec.scala
+++ b/modules/core/shared/src/test/scala/gem/EphemerisKeySpec.scala
@@ -6,14 +6,14 @@ package gem
 import gem.arb.ArbEphemerisKey._
 
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class EphemerisKeySpec extends CatsSuite {
 
   // Laws
-  checkAll("EphemerisKey", OrderLaws[EphemerisKey].eqv)
+  checkAll("EphemerisKey", EqTests[EphemerisKey].eqv)
 
   test("Equality must be natural") {
     forAll { (a: EphemerisKey, b: EphemerisKey) =>

--- a/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
@@ -4,7 +4,7 @@
 package gem
 
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.arb._
 
@@ -13,7 +13,7 @@ final class ObservationIdSpec extends CatsSuite {
   import ArbObservation._
 
   // Laws
-  checkAll("Observation.Id", OrderLaws[Observation.Id].order)
+  checkAll("Observation.Id", OrderTests[Observation.Id].order)
 
   test("Equality must be natural") {
     forAll { (a: Observation.Id, b: Observation.Id) =>

--- a/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
@@ -4,7 +4,7 @@
 package gem
 
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.arb._
 import gem.enum.{ Site, DailyProgramType }
@@ -18,7 +18,7 @@ final class ProgramIdSpec extends CatsSuite {
   import ArbTime._
 
   // Laws
-  checkAll("Program.Id", OrderLaws[Program.Id].order)
+  checkAll("Program.Id", OrderTests[Program.Id].order)
 
   test("Equality must be natural") {
     forAll { (a: ProgramId, b: ProgramId) =>

--- a/modules/core/shared/src/test/scala/gem/SemesterSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/SemesterSpec.scala
@@ -4,7 +4,7 @@
 package gem
 
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.arb._
 import gem.enum.{ Half, Site }
@@ -19,7 +19,7 @@ final class SemesterSpec extends CatsSuite {
   import ArbTime._
 
   // Laws
-  checkAll("Semester", OrderLaws[Semester].order)
+  checkAll("Semester", OrderTests[Semester].order)
 
   test("Equality must be natural") {
     forAll { (a: Semester, b: Semester) =>

--- a/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -13,8 +13,8 @@ final class AngleSpec extends CatsSuite {
   import ArbAngle._
 
   // Laws
-  checkAll("Angle", GroupLaws[Angle].commutativeGroup)
-  checkAll("Angle", OrderLaws[Angle].eqv)
+  checkAll("Angle", CommutativeGroupTests[Angle].commutativeGroup)
+  checkAll("Angle", EqTests[Angle].eqv)
 
   test("Equality must be natural") {
     forAll { (a: Angle, b: Angle) =>

--- a/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -16,7 +16,7 @@ final class CoordinatesSpec extends CatsSuite {
   import ArbAngle._
 
   // Laws
-  checkAll("Coordinates", OrderLaws[Coordinates].eqv)
+  checkAll("Coordinates", EqTests[Coordinates].eqv)
 
   test("Equality must be natural") {
     forAll { (a: Coordinates, b: Coordinates) =>

--- a/modules/core/shared/src/test/scala/gem/math/DeclinationSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/DeclinationSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -14,7 +14,7 @@ final class DeclinationSpec extends CatsSuite {
   import ArbAngle._
 
   // Laws
-  checkAll("Declination", OrderLaws[Declination].order)
+  checkAll("Declination", OrderTests[Declination].order)
 
   test("Equality must be natural") {
     forAll { (a: Declination, b: Declination) =>

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
@@ -6,7 +6,7 @@ package gem.math
 import gem.arb._
 
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 
 import org.scalacheck.{ Arbitrary, Gen }
@@ -18,7 +18,7 @@ final class EphemerisCoordinatesSpec extends CatsSuite {
   import EphemerisCoordinatesSpec._
 
   // Laws
-  checkAll("EphemerisCoordinates", OrderLaws[EphemerisCoordinates].eqv)
+  checkAll("EphemerisCoordinates", EqTests[EphemerisCoordinates].eqv)
 
   test("Equality must be natural") {
     forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates) =>

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
@@ -7,7 +7,7 @@ import gem.arb._
 import gem.util.InstantMicros
 
 import cats.Eq
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -17,8 +17,8 @@ final class EphemerisSpec extends CatsSuite {
   import Ephemeris.Element
 
   // Laws
-  checkAll("Ephemeris", GroupLaws[Ephemeris].monoid)
-  checkAll("Ephemeris", OrderLaws[Ephemeris].eqv)
+  checkAll("Ephemeris", MonoidTests[Ephemeris].monoid)
+  checkAll("Ephemeris", EqTests[Ephemeris].eqv)
 
   test("Ephemeris.eq.naturality") {
     forAll { (a: Ephemeris, b: Ephemeris) =>

--- a/modules/core/shared/src/test/scala/gem/math/EpochSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EpochSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 import java.time.LocalDateTime
 
@@ -15,7 +15,7 @@ final class EpochSpec extends CatsSuite {
   import ArbTime._
 
   // Laws
-  checkAll("Epoch", OrderLaws[Epoch].eqv)
+  checkAll("Epoch", EqTests[Epoch].eqv)
 
   test("Epoch.eq.natural") {
     forAll { (a: Epoch, b: Epoch) =>

--- a/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -13,8 +13,8 @@ final class HourAngleSpec extends CatsSuite {
   import ArbAngle._
 
   // Laws
-  checkAll("HourAngle", GroupLaws[HourAngle].commutativeGroup)
-  checkAll("HourAngle", OrderLaws[HourAngle].eqv)
+  checkAll("HourAngle", CommutativeGroupTests[HourAngle].commutativeGroup)
+  checkAll("HourAngle", EqTests[HourAngle].eqv)
 
   test("Equality must be natural") {
     forAll { (a: HourAngle, b: HourAngle) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -13,8 +13,8 @@ final class OffsetPSpec extends CatsSuite {
   import ArbOffset._
 
   // Laws
-  checkAll("Offset.P", GroupLaws[Offset.P].commutativeGroup)
-  checkAll("Offset.P", OrderLaws[Offset.P].eqv)
+  checkAll("Offset.P", CommutativeGroupTests[Offset.P].commutativeGroup)
+  checkAll("Offset.P", EqTests[Offset.P].eqv)
 
   test("Equality must be natural") {
     forAll { (a: Offset.P, b: Offset.P) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -13,8 +13,8 @@ final class OffsetQSpec extends CatsSuite {
   import ArbOffset._
 
   // Laws
-  checkAll("Offset.Q", GroupLaws[Offset.Q].commutativeGroup)
-  checkAll("Offset.Q", OrderLaws[Offset.Q].eqv)
+  checkAll("Offset.Q", CommutativeGroupTests[Offset.Q].commutativeGroup)
+  checkAll("Offset.Q", EqTests[Offset.Q].eqv)
 
   test("Equality must be natural") {
     forAll { (a: Offset.Q, b: Offset.Q) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -13,8 +13,8 @@ final class OffsetSpec extends CatsSuite {
   import ArbOffset._
 
   // Laws
-  checkAll("Offset", GroupLaws[Offset].commutativeGroup)
-  checkAll("Offset", OrderLaws[Offset].eqv)
+  checkAll("Offset", CommutativeGroupTests[Offset].commutativeGroup)
+  checkAll("Offset", EqTests[Offset].eqv)
 
   test("Equality must be natural") {
     forAll { (a: Offset, b: Offset) =>

--- a/modules/core/shared/src/test/scala/gem/math/RightAscensionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/RightAscensionSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show, Order }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -13,7 +13,7 @@ final class RightAscensionSpec extends CatsSuite {
   import ArbRightAscension._
 
   // Laws
-  checkAll("RightAscension", OrderLaws[RightAscension].order)
+  checkAll("RightAscension", OrderTests[RightAscension].order)
 
   test("Equality must be natural") {
     forAll { (a: RightAscension, b: RightAscension) =>

--- a/modules/core/shared/src/test/scala/gem/math/WavelengthSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/WavelengthSpec.scala
@@ -5,7 +5,7 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show, Order }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import gem.arb._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -13,7 +13,7 @@ final class WavelengthSpec extends CatsSuite {
   import ArbWavelength._
 
   // Laws
-  checkAll("Wavelength", OrderLaws[Wavelength].eqv)
+  checkAll("Wavelength", EqTests[Wavelength].eqv)
 
   test("Equality must be natural") {
     forAll { (a: Wavelength, b: Wavelength) =>

--- a/modules/core/shared/src/test/scala/gem/util/EnumeratedSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/EnumeratedSpec.scala
@@ -7,7 +7,7 @@ package util
 import gem.arb._
 import gem.enum._
 import cats.tests.CatsSuite
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import scala.reflect.ClassTag
 
 final class EnumeratedSpec extends CatsSuite {
@@ -18,7 +18,7 @@ final class EnumeratedSpec extends CatsSuite {
              ct: ClassTag[A]
   ): Unit = {
     val name = ct.runtimeClass.getSimpleName
-    checkAll(name, OrderLaws[A].order)
+    checkAll(name, OrderTests[A].order)
     test(s"$name.enumerated.canonical") {
       val sorted   = en.all
       val shuffled = scala.util.Random.shuffle(sorted)

--- a/modules/core/shared/src/test/scala/gem/util/InstantMicrosSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/InstantMicrosSpec.scala
@@ -6,7 +6,7 @@ package util
 
 import gem.arb.ArbTime._
 
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 
 
@@ -14,7 +14,7 @@ import cats.tests.CatsSuite
 final class InstantMicrosSpec extends CatsSuite {
 
   // Laws
-  checkAll("InstantMicro", OrderLaws[InstantMicros].order)
+  checkAll("InstantMicro", OrderTests[InstantMicros].order)
 
   test("Construction should truncate Instant nanoseconds to microseconds") {
     forAll { (i: InstantMicros) =>

--- a/modules/core/shared/src/test/scala/gem/util/LocationSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/LocationSpec.scala
@@ -5,7 +5,7 @@ package gem
 package util
 
 import cats.{ Eq, Order }
-import cats.kernel.laws._
+import cats.kernel.laws.discipline._
 import cats.kernel.Comparison.{ GreaterThan => GT, LessThan => LT, EqualTo => EQ }
 import cats.tests.CatsSuite
 
@@ -13,7 +13,7 @@ import cats.tests.CatsSuite
 final class LocationSpec extends CatsSuite with Arbitraries {
 
   // Laws
-  checkAll("Location", OrderLaws[Location].order)
+  checkAll("Location", OrderTests[Location].order)
 
   test("Construction should trim trailing min values from Middle") {
     forAll { (l: Location.Middle) =>

--- a/modules/ctl/src/main/scala/hi/deploy.scala
+++ b/modules/ctl/src/main/scala/hi/deploy.scala
@@ -11,7 +11,6 @@ import gem.ctl.hi.common._
 
 import cats.implicits._
 import scala.util.matching.Regex
-import mouse.all._
 
 /** Constructors for `CtlIO` operations related to the `deploy` command. */
 object deploy {
@@ -138,7 +137,10 @@ object deploy {
                case Array("db", s)  => s
                case Array("gem", s) => s
                case _               => ""
-             } .map(_.parseInt.toOption.getOrElse(0)) .foldLeft(0)(_ max _) + 1
+             } .map { s =>
+               try s.toInt
+               catch { case _: NumberFormatException => 0 }
+             } .foldLeft(0)(_ max _) + 1
            }
       _ <- info(s"Deploy number for this host will be $n.")
     } yield n

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -183,7 +183,7 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       val p  = (mʹ.toList.traverse { case (ks, e) =>
         Stream.emits(e.toMap.toList).covary[ConnectionIO]
           .to(EphemerisDao.streamInsert(ks.key, ks.site))
-          .run
+          .runSync
       }) *> EphemerisDao.selectAll(ks.key, ks.site)
 
       e shouldEqual p.transact(xa).unsafeRunSync
@@ -199,13 +199,13 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       val p  = mʹ.toList.traverse { case (ks, e) =>
         Stream.emits(e.toMap.toList).covary[ConnectionIO]
           .to(EphemerisDao.streamInsert(ks.key, ks.site))
-          .run
+          .runSync
       }
 
       // Now stream update the ephemeris elements in e0 to those in e1
       val pʹ = p *> Stream.emits(e1.toMap.toList).covary[ConnectionIO]
                       .to(EphemerisDao.streamUpdate(ks.key, ks.site))
-                      .run
+                      .runSync
 
       // Select the values with the matching key and site, which should now be
       // updated

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -91,7 +91,7 @@ final case class HorizonsEphemerisUpdater(
 
     qs.foldMap(_.streamEphemeris)
       .through(standardAccelerationCompression)
-      .translateSync(λ[IO ~> ConnectionIO](_.liftIO[ConnectionIO]))
+      .translate(λ[IO ~> ConnectionIO](_.liftIO[ConnectionIO]))
   }
 
 
@@ -141,7 +141,7 @@ final case class HorizonsEphemerisUpdater(
              updateMeta(ctx.key, ctx.site, mʹ)
            }
       _ <- log.log(user, s"streamEphemeris(${ctx.key}, ${ctx.site}, $sem)") {
-             streamEphemeris(ctx.key, ctx.site, sem).to(sink).run
+             streamEphemeris(ctx.key, ctx.site, sem).to(sink).runSync
            }
     } yield ()
   }

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -18,7 +18,7 @@ import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.client.blaze.PooledHttp1Client
 import org.http4s.server.blaze.BlazeBuilder
-import org.http4s.util.StreamApp
+import org.http4s.util.{ ExitCode, StreamApp }
 import org.http4s.scalaxml.xml
 
 import java.net.URLEncoder
@@ -100,7 +100,7 @@ object ImportServer extends StreamApp[IO] {
   }
 
 
-  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, Nothing] = {
+  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
 
     val hostName = args match {
       case Nil       => "localhost"

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioParse.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioParse.scala
@@ -5,8 +5,8 @@ package gem.ocs2.pio
 
 import cats.Functor
 import cats.implicits._
+import gem.syntax.string._
 import java.time.{ Duration, Instant }
-import mouse.all._
 
 final case class PioParse[A](run: String => Option[A]) {
   def apply(s: String): Option[A] = run(s)
@@ -26,28 +26,28 @@ object PioParse {
   // ********  Primitives
 
   val bigDecimal: PioParse[BigDecimal] =
-    PioParse(s => Either.catchOnly[NumberFormatException](BigDecimal(s)).toOption)
+    PioParse(_.parseBigDecimalOption)
 
   val boolean: PioParse[Boolean] =
-    PioParse(_.parseBoolean.toOption)
+    PioParse(_.parseBooleanOption)
 
   val double: PioParse[Double] =
-    PioParse(_.parseDouble.toOption)
+    PioParse(_.parseDoubleOption)
 
   val short: PioParse[Short] =
-    PioParse(_.parseShort.toOption)
+    PioParse(_.parseShortOption)
 
   val int: PioParse[Int] =
-    PioParse(_.parseInt.toOption)
+    PioParse(_.parseIntOption)
 
   val positiveInt: PioParse[Int] =
-    PioParse(_.parseInt.toOption.filter(_ > 0))
+    PioParse(_.parseIntOption.filter(_ > 0))
 
   val positiveShort: PioParse[Short] =
-    PioParse(_.parseShort.toOption.filter(_ > 0))
+    PioParse(_.parseShortOption.filter(_ > 0))
 
   val long: PioParse[Long] =
-    PioParse(_.parseLong.toOption)
+    PioParse(_.parseLongOption)
 
   val string: PioParse[String] =
     PioParse(_.pure[Option])

--- a/modules/web/src/main/scala/Application.scala
+++ b/modules/web/src/main/scala/Application.scala
@@ -28,7 +28,7 @@ object Application {
      .replaceAll("\\.", "?")
 
   /** Gem application endpoints. */
-  def service: AuthedService[IO, GemService[IO]] =
+  def service: AuthedService[GemService[IO], IO] =
     AuthedService {
 
       // Select matching program ids and titles.

--- a/modules/web/src/main/scala/Gatekeeper.scala
+++ b/modules/web/src/main/scala/Gatekeeper.scala
@@ -14,7 +14,6 @@ import java.time.Instant
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
-import org.http4s.implicits._
 import org.http4s.server._
 
 /**
@@ -102,7 +101,7 @@ object Gatekeeper {
    * is a bit more complex than normal services because we must work in OptionT to handle the case
    * where `delegate` doesn't respond.
    */
-  def authenticate(env: Environment, delegate: AuthedService[IO, GemService[IO]]): HttpService[IO] =
+  def authenticate(env: Environment, delegate: AuthedService[GemService[IO], IO]): HttpService[IO] =
     Kleisli[OptionT[IO, ?], Request[IO], Response[IO]] {
       // curl -i -b gem.jwt=... localhost:8080/something/else
       case req =>


### PR DESCRIPTION
This updates gem to cats-1.0.0-RC1, which was all mechanical to accommodate some re-organizing in cats for consistency. Mouse has not yet been released for cats-1.0.0-RC1 so I removed the dependency and added a string syntax class, but we can add it back later if it seems like we need it.