### PR TITLE
Remove id from Observation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val http4sVersion       = "0.18.0-M5"
 lazy val jwtVersion          = "0.14.1"
 lazy val kpVersion           = "0.9.4"
 lazy val monocleVersion      = "1.5.0-cats-M2"
+lazy val mouseVersion        = "0.12"
 lazy val paradiseVersion     = "2.1.1"
 lazy val scalaCheckVersion   = "1.13.5"
 lazy val scalaParsersVersion = "1.0.6"
@@ -200,6 +201,7 @@ lazy val core = crossProject
       "org.typelevel"              %%% "cats-core"      % catsVersion,
       "org.typelevel"              %%% "cats-effect"    % catsEffectVersion,
       "org.typelevel"              %%% "cats-testkit"   % catsVersion % "test",
+      "org.typelevel"              %%% "mouse"          % mouseVersion,
       "com.chuusai"                %%% "shapeless"      % shapelessVersion,
       "org.tpolecat"               %%% "atto-core"      % attoVersion,
       "com.github.julien-truffaut" %%% "monocle-core"   % monocleVersion,

--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -18,7 +18,6 @@ import cats.implicits._
  * @group Program Model
  */
 final case class Observation[+S, +D](
-  id: Observation.Id,
   title: String,
   staticConfig: S,
   steps: List[D])

--- a/modules/core/shared/src/main/scala/gem/Program.scala
+++ b/modules/core/shared/src/main/scala/gem/Program.scala
@@ -6,13 +6,15 @@ package gem
 import cats.{ Applicative, Eval, Traverse }
 import cats.implicits._
 
+import scala.collection.immutable.TreeMap
+
 /**
  * A science program, the root data type in the science model, parameterized over the type of its
  * observations, typically `[[gem.Observation Observation[α,β]]]` for a fully-specified program,
  * or `Nothing` for a minimally-specified program.
  * @group Program Model
  */
-final case class Program[+A](id: Program.Id, title: String, observations: List[A])
+final case class Program[+A](id: Program.Id, title: String, observations: TreeMap[Observation.Index, A])
 
 object Program {
 
@@ -23,11 +25,13 @@ object Program {
   implicit val ProgramTraverse: Traverse[Program] =
     new Traverse[Program] {
       def foldLeft[A, B](fa: Program[A], b: B)(f: (B, A) => B): B =
-        fa.observations.foldLeft(b)(f)
+        fa.observations.values.toList.foldLeft(b)(f)
       def foldRight[A, B](fa: Program[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
-        fa.observations.foldRight(lb)(f)
+        fa.observations.values.toList.foldRight(lb)(f)
       def traverse[G[_]: Applicative, A, B](fa: Program[A])(f: A => G[B]): G[Program[B]] =
-        fa.observations.traverse(f).map(bs => fa.copy(observations = bs))
+        fa.observations.values.toList.traverse(f).map { bs =>
+          fa.copy(observations = TreeMap(fa.observations.keys.toList.zip(bs): _*))
+        }
     }
 
 }

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -85,27 +85,27 @@ trait Arbitraries extends gem.config.Arbitraries  {
 
   // Observation
 
-  def genObservationOf(i: Instrument, id: Observation.Id): Gen[Observation[StaticConfig, Step[DynamicConfig]]] =
+  def genObservationOf(i: Instrument): Gen[Observation[StaticConfig, Step[DynamicConfig]]] =
     for {
       t <- genTitle
       s <- genStaticConfigOf(i)
       d <- genSequenceOf(i)
-    } yield Observation(id, t, s, d)
+    } yield Observation(t, s, d)
 
-  def genObservation(id: Observation.Id): Gen[Observation[StaticConfig, Step[DynamicConfig]]] =
+  val genObservation: Gen[Observation[StaticConfig, Step[DynamicConfig]]] =
     for {
       i <- Gen.oneOf(
              Instrument.Flamingos2,
              Instrument.GmosN,
              Instrument.GmosS
            ) // Add more as they become available
-      o <- genObservationOf(i, id)
+      o <- genObservationOf(i)
     } yield o
 
-  def genObservationMap(pid: Program.Id, limit: Int): Gen[TreeMap[Observation.Index, Observation[StaticConfig, Step[DynamicConfig]]]] =
+  def genObservationMap(limit: Int): Gen[TreeMap[Observation.Index, Observation[StaticConfig, Step[DynamicConfig]]]] =
     for {
       count   <- Gen.choose(0, limit)
       obsIdxs <- Gen.listOfN(count, Gen.posNum[Int]).map(_.distinct.map(Observation.Index.unsafeFromInt))
-      obsList <- obsIdxs.traverse(idx => genObservation(Observation.Id(pid, idx)))
+      obsList <- obsIdxs.traverse(_ => genObservation)
     } yield TreeMap(obsIdxs.zip(obsList): _*)
 }

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -103,7 +103,7 @@ trait Arbitraries extends gem.config.Arbitraries  {
   def genObservationList(pid: Program.Id, limit: Int): Gen[List[Observation[StaticConfig, Step[DynamicConfig]]]] =
     for {
       count   <- Gen.choose(0, limit)
-      obsIds  <- Gen.listOfN(count, Gen.posNum[Int]).map(_.distinct.map(i => Observation.Id(pid, i)))
+      obsIds  <- Gen.listOfN(count, Gen.posNum[Int]).map(_.distinct.map(i => Observation.Id(pid, Observation.Index.unsafeFromInt(i))))
       obsList <- obsIds.traverse(genObservation)
     } yield obsList
 }

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -13,6 +13,8 @@ import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
 
+import scala.collection.immutable.TreeMap
+
 trait Arbitraries extends gem.config.Arbitraries  {
   import ArbEnumerated._
 
@@ -100,10 +102,10 @@ trait Arbitraries extends gem.config.Arbitraries  {
       o <- genObservationOf(i, id)
     } yield o
 
-  def genObservationList(pid: Program.Id, limit: Int): Gen[List[Observation[StaticConfig, Step[DynamicConfig]]]] =
+  def genObservationMap(pid: Program.Id, limit: Int): Gen[TreeMap[Observation.Index, Observation[StaticConfig, Step[DynamicConfig]]]] =
     for {
       count   <- Gen.choose(0, limit)
-      obsIds  <- Gen.listOfN(count, Gen.posNum[Int]).map(_.distinct.map(i => Observation.Id(pid, Observation.Index.unsafeFromInt(i))))
-      obsList <- obsIds.traverse(genObservation)
-    } yield obsList
+      obsIdxs <- Gen.listOfN(count, Gen.posNum[Int]).map(_.distinct.map(Observation.Index.unsafeFromInt))
+      obsList <- obsIdxs.traverse(idx => genObservation(Observation.Id(pid, idx)))
+    } yield TreeMap(obsIdxs.zip(obsList): _*)
 }

--- a/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
@@ -24,7 +24,7 @@ final class ObservationIdSpec extends CatsSuite {
   test("Equalty must act pairwise") {
     forAll { (a: Observation.Id, b: Observation.Id) =>
       Eq[Program.Id].eqv(a.pid, b.pid) &&
-      Eq[Int].eqv(a.index, b.index) shouldEqual Eq[Observation.Id].eqv(a, b)
+      Eq[Observation.Index].eqv(a.index, b.index) shouldEqual Eq[Observation.Id].eqv(a, b)
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/arb/Observation.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Observation.scala
@@ -7,6 +7,7 @@ package arb
 import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
 
 trait ArbObservation {
   import ArbProgramId._
@@ -16,11 +17,14 @@ trait ArbObservation {
       for {
         pid <- arbitrary[ProgramId]
         num <- choose(1, 100)
-      } yield Observation.Id(pid, num)
+      } yield Observation.Id(pid, Observation.Index.unsafeFromInt(num))
     }
 
+  implicit val cogObservationIdex: Cogen[Observation.Index] =
+    Cogen[Int].contramap(_.toInt)
+
   implicit val cogObservationId: Cogen[Observation.Id] =
-    Cogen[(ProgramId, Int)].contramap(oid => (oid.pid, oid.index))
+    Cogen[(ProgramId, Observation.Index)].contramap(oid => (oid.pid, oid.index))
 
 }
 object ArbObservation extends ArbObservation

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -86,7 +86,7 @@ object ObservationDao {
     // Observation.Index has a DISTINCT type due to its check constraint so we
     // need a fine-grained mapping here to satisfy the query checker.
     implicit val ObservationIndexMeta: Meta[Observation.Index] =
-      Distinct.integer("id_index").xmap(Observation.Index.unsafeFromInt, _.toInt)
+    Distinct.integer("id_index").xmap(Observation.Index.unsafeFromInt, _.toInt)
 
     def insert(oid: Observation.Id, o: Observation[StaticConfig, _], staticId: Int): Update0 =
       sql"""
@@ -101,7 +101,7 @@ object ObservationDao {
                       ${oid.index},
                       ${o.title},
                       $staticId,
-                      ${o.staticConfig.instrument : Instrument})
+                      ${o.staticConfig.instrument: Instrument})
       """.update
 
     def selectIds(pid: Program.Id): Query0[Observation.Id] =
@@ -124,9 +124,7 @@ object ObservationDao {
           FROM observation
          WHERE observation_id = ${id}
       """.query[(String, Instrument, Int)]
-         .map { case (t, i, s) =>
-           (Observation(id, t, i, Nil), s)
-         }
+        .map { case (t, i, s) => (Observation(t, i, Nil), s) }
 
     def selectAllFlat(pid: Program.Id): Query0[(Observation.Index, Observation[Instrument, Nothing], Int)] =
       sql"""
@@ -135,10 +133,9 @@ object ObservationDao {
          WHERE program_id = ${pid}
       ORDER BY observation_index
       """.query[(Short, String, Instrument, Int)]
-         .map { case (n, t, i, s) =>
-           val idx = Observation.Index.unsafeFromInt(n.toInt)
-           (idx, Observation(Observation.Id(pid, idx), t, i, Nil), s)
-         }
+        .map { case (n, t, i, s) =>
+          (Observation.Index.unsafeFromInt(n.toInt), Observation(t, i, Nil), s)
+        }
 
   }
 }

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -58,7 +58,7 @@ object ProgramDao {
     for {
       opn <- selectFlat(pid)
       os  <- ObservationDao.selectAll(pid)
-    } yield opn.map(_.copy(observations = TreeMap(os.map(o => (o.id.index, o)): _*)))
+    } yield opn.map(_.copy(observations = os))
 
   object Statements {
 

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -20,7 +20,7 @@ object ProgramDao {
 
   /** Insert a complete program. */
   def insert(p: Program[Observation[StaticConfig, Step[DynamicConfig]]]): ConnectionIO[Program.Id] =
-    insertFlat(p) <* p.observations.traverse(ObservationDao.insert)
+    insertFlat(p) <* p.observations.traverse(o => ObservationDao.insert(o.id, o))
 
   private def insertProgramIdSlice(pid: Program.Id): ConnectionIO[Int] =
     pid match {

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -24,8 +24,7 @@ object ProgramDao {
   /** Insert a complete program. */
   def insert(p: Program[Observation[StaticConfig, Step[DynamicConfig]]]): ConnectionIO[Program.Id] =
     insertFlat(p) <* p.observations.toList.traverse { case (i,o) =>
-      val oid = Observation.Id(p.id, i)
-      ObservationDao.insert(oid, o)
+      ObservationDao.insert(Observation.Id(p.id, i), o)
     }
 
   private def insertProgramIdSlice(pid: Program.Id): ConnectionIO[Int] =

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -5,7 +5,9 @@ package gem.dao
 
 import cats.effect.IO
 import doobie._, doobie.implicits._
-import gem.{ Program, Step }
+import gem.{ Observation, Program, Step }
+
+import scala.collection.immutable.TreeMap
 
 /** Base trait for DAO test cases.
   */
@@ -24,8 +26,8 @@ trait DaoTest extends gem.Arbitraries {
 
   def withProgram[A](test: ConnectionIO[A]): A =
     (for {
-      _ <- ProgramDao.insertFlat(Program(pid, "Test Prog", List.empty[Step[Nothing]]))
+      _ <- ProgramDao.insertFlat(Program(pid, "Test Prog", TreeMap.empty[Observation.Index, Step[Nothing]]))
       a <- test
     } yield a).transact(xa).unsafeRunSync()
-    
+
 }

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -79,10 +79,10 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
         for {
           _ <- obsListIn.traverse(o => ObservationDao.insert(o.id, o))
           o <- ObservationDao.selectAll(pid)
-        } yield o
+        } yield o.values.toList
       }
 
-      obsListOut.sortBy(_.id) shouldEqual obsListIn.sortBy(_.id)
+      obsListOut shouldEqual obsListIn.sortBy(_.id)
     }
   }
 

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -16,7 +16,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     forAll(genObservationList(pid, limit = 50)) { obsList =>
       val oids = withProgram {
         for {
-          _ <- obsList.traverse(ObservationDao.insert)
+          _ <- obsList.traverse(o => ObservationDao.insert(o.id, o))
           o <- ObservationDao.selectIds(pid)
         } yield o
       }
@@ -34,7 +34,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     forAll(genObservation(oid)) { obsIn =>
       val obsOut = withProgram {
         for {
-          _ <- ObservationDao.insert(obsIn)
+          _ <- ObservationDao.insert(oid, obsIn)
           o <- ObservationDao.selectFlat(oid)
         } yield o
       }
@@ -49,7 +49,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     forAll(genObservation(oid)) { obsIn =>
       val obsOut = withProgram {
         for {
-          _ <- ObservationDao.insert(obsIn)
+          _ <- ObservationDao.insert(oid, obsIn)
           o <- ObservationDao.selectStatic(oid)
         } yield o
       }
@@ -64,7 +64,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     forAll(genObservation(oid)) { obsIn =>
       val obsOut = withProgram {
         for {
-          _ <- ObservationDao.insert(obsIn)
+          _ <- ObservationDao.insert(oid, obsIn)
           o <- ObservationDao.select(oid)
         } yield o
       }
@@ -77,7 +77,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     forAll(genObservationList(pid, limit = 50)) { obsListIn =>
       val obsListOut = withProgram {
         for {
-          _ <- obsListIn.traverse(ObservationDao.insert)
+          _ <- obsListIn.traverse(o => ObservationDao.insert(o.id, o))
           o <- ObservationDao.selectAll(pid)
         } yield o
       }

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.Matchers._
 class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
 
   property("ObservationDao should select all observation ids for a program") {
-    forAll(genObservationMap(pid, limit = 50)) { obsMap =>
+    forAll(genObservationMap(limit = 50)) { obsMap =>
       val oids = withProgram {
         for {
           _ <- obsMap.toList.traverse { case (i,o) => ObservationDao.insert(Observation.Id(pid, i), o) }
@@ -31,7 +31,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("ObservationDao should select flat observations") {
     val oid = Observation.Id(pid, One)
 
-    forAll(genObservation(oid)) { obsIn =>
+    forAll(genObservation) { obsIn =>
       val obsOut = withProgram {
         for {
           _ <- ObservationDao.insert(oid, obsIn)
@@ -46,7 +46,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("ObservationDao should select static observations") {
     val oid = Observation.Id(pid, One)
 
-    forAll(genObservation(oid)) { obsIn =>
+    forAll(genObservation) { obsIn =>
       val obsOut = withProgram {
         for {
           _ <- ObservationDao.insert(oid, obsIn)
@@ -61,7 +61,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("ObservationDao should roundtrip complete observations") {
     val oid = Observation.Id(pid, One)
 
-    forAll(genObservation(oid)) { obsIn =>
+    forAll(genObservation) { obsIn =>
       val obsOut = withProgram {
         for {
           _ <- ObservationDao.insert(oid, obsIn)
@@ -74,7 +74,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should roundtrip complete observation lists") {
-    forAll(genObservationMap(pid, limit = 50)) { obsMapIn =>
+    forAll(genObservationMap(limit = 50)) { obsMapIn =>
       val obsMapOut = withProgram {
         for {
           _ <- obsMapIn.toList.traverse { case (i,o) => ObservationDao.insert(Observation.Id(pid, i), o) }

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -13,15 +13,15 @@ import org.scalatest.Matchers._
 class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
 
   property("ObservationDao should select all observation ids for a program") {
-    forAll(genObservationList(pid, limit = 50)) { obsList =>
+    forAll(genObservationMap(pid, limit = 50)) { obsMap =>
       val oids = withProgram {
         for {
-          _ <- obsList.traverse(o => ObservationDao.insert(o.id, o))
+          _ <- obsMap.toList.traverse { case (i,o) => ObservationDao.insert(Observation.Id(pid, i), o) }
           o <- ObservationDao.selectIds(pid)
         } yield o
       }
 
-      oids.toSet shouldEqual obsList.map(_.id).toSet
+      oids.toSet shouldEqual obsMap.keys.map(idx => Observation.Id(pid, idx)).toSet
     }
   }
 
@@ -74,15 +74,15 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should roundtrip complete observation lists") {
-    forAll(genObservationList(pid, limit = 50)) { obsListIn =>
-      val obsListOut = withProgram {
+    forAll(genObservationMap(pid, limit = 50)) { obsMapIn =>
+      val obsMapOut = withProgram {
         for {
-          _ <- obsListIn.traverse(o => ObservationDao.insert(o.id, o))
+          _ <- obsMapIn.toList.traverse { case (i,o) => ObservationDao.insert(Observation.Id(pid, i), o) }
           o <- ObservationDao.selectAll(pid)
-        } yield o.values.toList
+        } yield o
       }
 
-      obsListOut shouldEqual obsListIn.sortBy(_.id)
+      obsMapOut shouldEqual obsMapIn
     }
   }
 

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -25,8 +25,11 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     }
   }
 
+  val One: Observation.Index =
+    Observation.Index.unsafeFromInt(1)
+
   property("ObservationDao should select flat observations") {
-    val oid = Observation.Id(pid, 1)
+    val oid = Observation.Id(pid, One)
 
     forAll(genObservation(oid)) { obsIn =>
       val obsOut = withProgram {
@@ -41,7 +44,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should select static observations") {
-    val oid = Observation.Id(pid, 1)
+    val oid = Observation.Id(pid, One)
 
     forAll(genObservation(oid)) { obsIn =>
       val obsOut = withProgram {
@@ -56,7 +59,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should roundtrip complete observations") {
-    val oid = Observation.Id(pid, 1)
+    val oid = Observation.Id(pid, One)
 
     forAll(genObservation(oid)) { obsIn =>
       val obsOut = withProgram {

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -90,7 +90,7 @@ class SmartGcalSpec extends FlatSpec with Matchers with DaoTest {
     ss.values.toList shouldEqual lookup(m).map(Step.Gcal(f2, _))
   }
 
-  private val oid = Observation.Id(pid, 1)
+  private val oid = Observation.Id(pid, Observation.Index.unsafeFromInt(1))
 
   private def doTest[A](test: ConnectionIO[A]): A =
     withProgram {

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -95,7 +95,7 @@ class SmartGcalSpec extends FlatSpec with Matchers with DaoTest {
   private def doTest[A](test: ConnectionIO[A]): A =
     withProgram {
       for {
-        _ <- ObservationDao.insert(oid, Observation(oid, "SmartGcalSpec Obs", StaticConfig.F2.Default, List.empty[Step[DynamicConfig]]))
+        _ <- ObservationDao.insert(oid, Observation("SmartGcalSpec Obs", StaticConfig.F2.Default, List.empty[Step[DynamicConfig]]))
         a <- test
       } yield a
     }

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -95,7 +95,7 @@ class SmartGcalSpec extends FlatSpec with Matchers with DaoTest {
   private def doTest[A](test: ConnectionIO[A]): A =
     withProgram {
       for {
-        _ <- ObservationDao.insert(Observation(oid, "SmartGcalSpec Obs", StaticConfig.F2.Default, List.empty[Step[DynamicConfig]]))
+        _ <- ObservationDao.insert(oid, Observation(oid, "SmartGcalSpec Obs", StaticConfig.F2.Default, List.empty[Step[DynamicConfig]]))
         a <- test
       } yield a
     }

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -12,18 +12,23 @@ import gem.math._
 import java.time.Duration
 import org.scalatest._
 
+import scala.collection.immutable.TreeMap
+
+
 class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
 
   "StepDao" should "serialize telescope configurations properly" in {
+
+    val idx  = Observation.Index.unsafeFromInt(1)
 
     // We specifically want to test round-tripping of telescope offsets.
     val pid  = Program.Id.unsafeFromString("GS-1234A-Q-1")
     val orig = Program(
       pid,
       "Untitled Prog",
-      List(
+      TreeMap(idx ->
         Observation(
-          Observation.Id(pid, Observation.Index.unsafeFromInt(1)),
+          Observation.Id(pid, idx),
           "Untitled Obs",
           StaticConfig.F2(MosPreImaging.IsNotMosPreImaging),
           List(
@@ -47,7 +52,7 @@ class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
       )
     )
 
-    // We should be able to round=trip the program.
+    // We should be able to round-trip the program.
     import ProgramDao._
     val rted = (insert(orig) flatMap selectFull).transact(xa).unsafeRunSync
     rted shouldEqual Some(orig)

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -23,7 +23,7 @@ class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
       "Untitled Prog",
       List(
         Observation(
-          Observation.Id(pid, 1),
+          Observation.Id(pid, Observation.Index.unsafeFromInt(1)),
           "Untitled Obs",
           StaticConfig.F2(MosPreImaging.IsNotMosPreImaging),
           List(

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -28,7 +28,6 @@ class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
       "Untitled Prog",
       TreeMap(idx ->
         Observation(
-          Observation.Id(pid, idx),
           "Untitled Obs",
           StaticConfig.F2(MosPreImaging.IsNotMosPreImaging),
           List(

--- a/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
@@ -10,13 +10,16 @@ import gem._
 import gem.enum.ProgramRole
 import org.scalatest._
 
+import scala.collection.immutable.TreeMap
+
+
 class UserDaoSpec extends FlatSpec with Matchers with DaoTest {
 
   private val pid1 = Program.Id.unsafeFromString("GS-1234A-Q-1")
   private val pid2 = Program.Id.unsafeFromString("GS-1234A-Q-3")
 
-  private val prog1 = Program(pid1, "prog1", Nil)
-  private val prog2 = Program(pid2, "prog2", Nil)
+  private val prog1 = Program(pid1, "prog1", TreeMap.empty)
+  private val prog2 = Program(pid2, "prog2", TreeMap.empty)
 
   private val user1 =
     User[ProgramRole]("bob", "Bob", "Dobbs", "bob@dobbs.com", false,

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -16,6 +16,8 @@ import gem.math._
 import java.time.LocalDate
 import org.scalatest._
 
+import scala.collection.immutable.TreeMap
+
 
 /** Trait for tests that check statement syntax and mappings. */
 trait Check extends FlatSpec with Matchers with IOChecker {
@@ -52,7 +54,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, 0)
     val user             = User[Nothing]("", "", "", "", false, Map.empty)
     val observation      = Observation[StaticConfig, Nothing](observationId, "", StaticConfig.F2.Default, Nil)
-    val program          = Program(programId, "", Nil)
+    val program          = Program(programId, "", TreeMap.empty)
     val f2SmartGcalKey   = DynamicConfig.F2.Default.key
     val gcalLampType     = GcalLampType.Arc
     val gcalBaselineType = GcalBaselineType.Day

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -41,7 +41,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val programType      = ProgramType.C
     val dailyProgramId   = Program.Id.Daily(site, DailyProgramType.ENG, LocalDate.now())
     val scienceProgramId = Program.Id.Science(site, semester, programType, 0)
-    val observationId    = Observation.Id(programId, 0)
+    val observationId    = Observation.Id(programId, Observation.Index.unsafeFromInt(1))
     val datasetLabel     = Dataset.Label(observationId, 0)
     val dataset          = Dataset(datasetLabel, "", instant)
     val eventType        = EventType.Abort

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -53,7 +53,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val gcalShutter      = GcalShutter.Open
     val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, 0)
     val user             = User[Nothing]("", "", "", "", false, Map.empty)
-    val observation      = Observation[StaticConfig, Nothing](observationId, "", StaticConfig.F2.Default, Nil)
+    val observation      = Observation[StaticConfig, Nothing]("", StaticConfig.F2.Default, Nil)
     val program          = Program(programId, "", TreeMap.empty)
     val f2SmartGcalKey   = DynamicConfig.F2.Default.key
     val gcalLampType     = GcalLampType.Arc

--- a/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
@@ -7,7 +7,7 @@ package check
 class ObservationCheck extends Check {
   import ObservationDao.Statements._
   "ObservationDao.Statements" should
-            "insert"         in check(insert(Dummy.observation, 0))
+            "insert"         in check(insert(Dummy.observationId, Dummy.observation, 0))
   it should "selectIds"      in check(selectIds(Dummy.programId))
   it should "selectStaticId" in check(selectStaticId(Dummy.observationId))
   it should "selectFlat"     in check(selectFlat(Dummy.observationId))

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -12,6 +12,7 @@ import gem.util.Enumerated
 import io.circe._
 import io.circe.syntax._
 import java.time.Duration
+import scala.collection.immutable.TreeMap
 
 // These json codecs are provided for primitive types that have no natural mapping that would
 // otherwise be inferred via argonaut-shapeless. For now we'll treat the JSON format as an
@@ -78,6 +79,12 @@ package object json {
     Encoder[Map[String, A]].contramap(_.map { case (k, v) => (k.format, v) })
   implicit def programIdKeyedMapDecoder[A: Decoder]: Decoder[Map[Program.Id, A]] =
     Decoder[Map[String, A]].map(_.map { case (k, v) => (Program.Id.unsafeFromString(k), v) })
+
+  // Codec for maps keyed by Observation.Index
+  implicit def observationIndexMapEncoder[A: Encoder]: Encoder[TreeMap[Observation.Index, A]] =
+    Encoder[TreeMap[Int, A]].contramap(_.map { case (k, v) => (k.toInt, v) })
+  implicit def observationIndexMapDecoder[A: Decoder]: Decoder[TreeMap[Observation.Index, A]] =
+    Decoder[TreeMap[Int, A]].map(_.map { case (k, v) => (Observation.Index.unsafeFromInt(k), v) })
 
   // GmosCustomRoiEntry as a quad of shorts
   implicit val GmosCustomRoiEntryEncoder: Encoder[GmosCustomRoiEntry] =

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -33,6 +33,10 @@ package object json {
   val AngleAsSignedArcsecondsEncoder: Encoder[Angle] = Encoder[BigDecimal].contramap(_.toSignedArcseconds)
   val AngleAsSignedArcsecondsDecoder: Decoder[Angle] = Decoder[BigDecimal].map(Angle.fromSignedArcseconds)
 
+  // Observation.Index to Integer.
+  implicit val ObservationIndexEncoder: Encoder[Observation.Index] = Encoder[Int].contramap(_.toInt)
+  implicit val ObservationIndexDecoder: Decoder[Observation.Index] = Decoder[Int].map(Observation.Index.unsafeFromInt)
+
   // Wavelength mapping to integral Angstroms.
   implicit val WavelengthEncoder: Encoder[Wavelength] = Encoder[Int].contramap(_.toAngstroms)
   implicit val WavelengthDecoder: Decoder[Wavelength] = Decoder[Int].map(Wavelength.unsafeFromAngstroms)

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -56,11 +56,10 @@ object Decoders {
   implicit val ObservationDecoder: PioDecoder[Observation[StaticConfig, Step[DynamicConfig]]] =
     PioDecoder { n =>
       for {
-        id <- (n \! "@name"           ).decode[Observation.Id]
         t  <- (n \! "data" \? "#title").decodeOrZero[String]
         st <- (n \! "sequence"        ).decode[StaticConfig](StaticDecoder)
         sq <- (n \! "sequence"        ).decode[List[Step[DynamicConfig]]](SequenceDecoder)
-      } yield Observation(id, t, st, sq)
+      } yield Observation(t, st, sq)
     }
 
   implicit val ProgramDecoder: PioDecoder[Program[Observation[StaticConfig, Step[DynamicConfig]]]] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -13,6 +13,9 @@ import gem.ocs2.pio.PioDecoder.fromParse
 
 import java.time.Instant
 
+import scala.collection.immutable.TreeMap
+
+
 /** `PioDecoder` instances for our model types.
   */
 object Decoders {
@@ -45,6 +48,11 @@ object Decoders {
       (n \\* "obsExecLog" \\* "&datasets" \\* "&dataset").decode[Dataset]
     }
 
+  implicit val ObservationIndexDecoder: PioDecoder[Observation.Index] =
+    PioDecoder { n =>
+      (n \! "@name").decode[Observation.Id].map(_.index)
+    }
+
   implicit val ObservationDecoder: PioDecoder[Observation[StaticConfig, Step[DynamicConfig]]] =
     PioDecoder { n =>
       for {
@@ -60,7 +68,8 @@ object Decoders {
       for {
         id <- (n \! "@name"           ).decode[Program.Id]
         t  <- (n \! "data" \? "#title").decodeOrZero[String]
+        is <- (n \\* "observation"    ).decode[Observation.Index]
         os <- (n \\* "observation"    ).decode[Observation[StaticConfig, Step[DynamicConfig]]]
-      } yield Program(id, t, os)
+      } yield Program(id, t, TreeMap(is.zip(os): _*))
     }
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -64,7 +64,7 @@ final class ImportServer(ocsHost: String) {
 
   def importObservation(obsIdStr: String): IO[Response[IO]] = {
     val checkId = Observation.Id.fromString(obsIdStr) toRight badRequest(obsIdStr, "observation")
-    checkId.as { fetchDecodeAndStore[Obs](obsIdStr, Importer.importObservation) }.merge
+    checkId.map { oid => fetchDecodeAndStore[Obs](obsIdStr, Importer.importObservation(oid, _, _)) }.merge
   }
 
   def importProgram(pidStr: String): IO[Response[IO]] = {

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -37,7 +37,7 @@ object Importer extends DoobieClient {
       for {
         _ <- ignoreUniqueViolation(ProgramDao.insertFlat(Program[Nothing](o.id.pid, "", Nil)).as(1))
         _ <- l.log(u, s"remove observation ${o.id}"   )(rmObservation           )
-        _ <- l.log(u, s"insert new version of ${o.id}")(ObservationDao.insert(o))
+        _ <- l.log(u, s"insert new version of ${o.id}")(ObservationDao.insert(o.id, o))
         _ <- l.log(u, s"write datasets for ${o.id}"   )(writeDatasets           )
       } yield ()
   }


### PR DESCRIPTION
This is a fairly mechanical refactoring to implement issue #88.  The idea is that observations should not keep up with their own ids because it references the program id and creates an opportunity for inconsistency--a program could contain an observation whose id references a different program.

Similarly, a program should keep its observations in a map keyed by number rather than in a `List`, since nothing stops two observations with the same number from appearing in today's model (or the same observation appearing twice).

I didn't change the database model because I think it probably makes sense to keep the observation id in the observation table.  Otherwise queries involving observations become more complicated.

I chose a `TreeMap` instead of a hash map in order to keep a sensible `Traverse[Program]` implementation.