### PR TITLE
Replace Floating types by arbitrary precision decimals

### DIFF
--- a/modules/core/shared/src/main/scala/gem/enum/GmosCustomSlitWidth.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosCustomSlitWidth.scala
@@ -22,12 +22,12 @@ sealed abstract class GmosCustomSlitWidth(
 object GmosCustomSlitWidth {
 
   /** @group Constructors */ case object CustomWidth_0_25 extends GmosCustomSlitWidth("CustomWidth_0_25", "0.25", "0.25 arcsec", gem.math.Angle.fromDoubleArcseconds(0.25))
-  /** @group Constructors */ case object CustomWidth_0_50 extends GmosCustomSlitWidth("CustomWidth_0_50", "0.50", "0.50 arcsec", gem.math.Angle.fromDoubleArcseconds(0.5))
+  /** @group Constructors */ case object CustomWidth_0_50 extends GmosCustomSlitWidth("CustomWidth_0_50", "0.50", "0.50 arcsec", gem.math.Angle.fromDoubleArcseconds(0.50))
   /** @group Constructors */ case object CustomWidth_0_75 extends GmosCustomSlitWidth("CustomWidth_0_75", "0.75", "0.75 arcsec", gem.math.Angle.fromDoubleArcseconds(0.75))
-  /** @group Constructors */ case object CustomWidth_1_00 extends GmosCustomSlitWidth("CustomWidth_1_00", "1.00", "1.00 arcsec", gem.math.Angle.fromDoubleArcseconds(1.0))
-  /** @group Constructors */ case object CustomWidth_1_50 extends GmosCustomSlitWidth("CustomWidth_1_50", "1.50", "1.50 arcsec", gem.math.Angle.fromDoubleArcseconds(1.5))
-  /** @group Constructors */ case object CustomWidth_2_00 extends GmosCustomSlitWidth("CustomWidth_2_00", "2.00", "2.00 arcsec", gem.math.Angle.fromDoubleArcseconds(2.0))
-  /** @group Constructors */ case object CustomWidth_5_00 extends GmosCustomSlitWidth("CustomWidth_5_00", "5.00", "5.00 arcsec", gem.math.Angle.fromDoubleArcseconds(5.0))
+  /** @group Constructors */ case object CustomWidth_1_00 extends GmosCustomSlitWidth("CustomWidth_1_00", "1.00", "1.00 arcsec", gem.math.Angle.fromDoubleArcseconds(1.00))
+  /** @group Constructors */ case object CustomWidth_1_50 extends GmosCustomSlitWidth("CustomWidth_1_50", "1.50", "1.50 arcsec", gem.math.Angle.fromDoubleArcseconds(1.50))
+  /** @group Constructors */ case object CustomWidth_2_00 extends GmosCustomSlitWidth("CustomWidth_2_00", "2.00", "2.00 arcsec", gem.math.Angle.fromDoubleArcseconds(2.00))
+  /** @group Constructors */ case object CustomWidth_5_00 extends GmosCustomSlitWidth("CustomWidth_5_00", "5.00", "5.00 arcsec", gem.math.Angle.fromDoubleArcseconds(5.00))
 
   /** All members of GmosCustomSlitWidth, in canonical order. */
   val all: List[GmosCustomSlitWidth] =

--- a/modules/core/shared/src/main/scala/gem/enum/GmosDetector.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosDetector.scala
@@ -26,7 +26,7 @@ sealed abstract class GmosDetector(
 
 object GmosDetector {
 
-  /** @group Constructors */ case object E2V extends GmosDetector("E2V", "E2V", "E2V", gem.math.Angle.fromDoubleArcseconds(0.0727), gem.math.Angle.fromDoubleArcseconds(0.073), 1536, 6144, 4608, 4)
+  /** @group Constructors */ case object E2V extends GmosDetector("E2V", "E2V", "E2V", gem.math.Angle.fromDoubleArcseconds(0.0727), gem.math.Angle.fromDoubleArcseconds(0.0730), 1536, 6144, 4608, 4)
   /** @group Constructors */ case object HAMAMATSU extends GmosDetector("HAMAMATSU", "Hamamatsu", "Hamamatsu", gem.math.Angle.fromDoubleArcseconds(0.0809), gem.math.Angle.fromDoubleArcseconds(0.0809), 1392, 6144, 4224, 5)
 
   /** All members of GmosDetector, in canonical order. */

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthFpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthFpu.scala
@@ -22,21 +22,21 @@ sealed abstract class GmosNorthFpu(
 object GmosNorthFpu {
 
   /** @group Constructors */ case object Longslit1 extends GmosNorthFpu("Longslit1", "0.25arcsec", "Longslit 0.25 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.25)))
-  /** @group Constructors */ case object Longslit2 extends GmosNorthFpu("Longslit2", "0.50arcsec", "Longslit 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.5)))
+  /** @group Constructors */ case object Longslit2 extends GmosNorthFpu("Longslit2", "0.50arcsec", "Longslit 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.50)))
   /** @group Constructors */ case object Longslit3 extends GmosNorthFpu("Longslit3", "0.75arcsec", "Longslit 0.75 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.75)))
-  /** @group Constructors */ case object Longslit4 extends GmosNorthFpu("Longslit4", "1.0arcsec", "Longslit 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.0)))
-  /** @group Constructors */ case object Longslit5 extends GmosNorthFpu("Longslit5", "1.5arcsec", "Longslit 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.5)))
-  /** @group Constructors */ case object Longslit6 extends GmosNorthFpu("Longslit6", "2.0arcsec", "Longslit 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.0)))
-  /** @group Constructors */ case object Longslit7 extends GmosNorthFpu("Longslit7", "5.0arcsec", "Longslit 5.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(5.0)))
+  /** @group Constructors */ case object Longslit4 extends GmosNorthFpu("Longslit4", "1.0arcsec", "Longslit 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object Longslit5 extends GmosNorthFpu("Longslit5", "1.5arcsec", "Longslit 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object Longslit6 extends GmosNorthFpu("Longslit6", "2.0arcsec", "Longslit 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.00)))
+  /** @group Constructors */ case object Longslit7 extends GmosNorthFpu("Longslit7", "5.0arcsec", "Longslit 5.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(5.00)))
   /** @group Constructors */ case object Ifu1 extends GmosNorthFpu("Ifu1", "IFU-2", "IFU 2 Slits", Option.empty[gem.math.Angle])
   /** @group Constructors */ case object Ifu2 extends GmosNorthFpu("Ifu2", "IFU-B", "IFU Left Slit (blue)", Option.empty[gem.math.Angle])
   /** @group Constructors */ case object Ifu3 extends GmosNorthFpu("Ifu3", "IFU-R", "IFU Right Slit (red)", Option.empty[gem.math.Angle])
   /** @group Constructors */ case object Ns0 extends GmosNorthFpu("Ns0", "NS0.25arcsec", "N and S 0.25 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.25)))
-  /** @group Constructors */ case object Ns1 extends GmosNorthFpu("Ns1", "NS0.5arcsec", "N and S 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.5)))
+  /** @group Constructors */ case object Ns1 extends GmosNorthFpu("Ns1", "NS0.5arcsec", "N and S 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.50)))
   /** @group Constructors */ case object Ns2 extends GmosNorthFpu("Ns2", "NS0.75arcsec", "N and S 0.75 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.75)))
-  /** @group Constructors */ case object Ns3 extends GmosNorthFpu("Ns3", "NS1.0arcsec", "N and S 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.0)))
-  /** @group Constructors */ case object Ns4 extends GmosNorthFpu("Ns4", "NS1.5arcsec", "N and S 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.5)))
-  /** @group Constructors */ case object Ns5 extends GmosNorthFpu("Ns5", "NS2.0arcsec", "N and S 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.0)))
+  /** @group Constructors */ case object Ns3 extends GmosNorthFpu("Ns3", "NS1.0arcsec", "N and S 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object Ns4 extends GmosNorthFpu("Ns4", "NS1.5arcsec", "N and S 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object Ns5 extends GmosNorthFpu("Ns5", "NS2.0arcsec", "N and S 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.00)))
 
   /** All members of GmosNorthFpu, in canonical order. */
   val all: List[GmosNorthFpu] =

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthFpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthFpu.scala
@@ -22,12 +22,12 @@ sealed abstract class GmosSouthFpu(
 object GmosSouthFpu {
 
   /** @group Constructors */ case object Longslit1 extends GmosSouthFpu("Longslit1", "0.25arcsec", "Longslit 0.25 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.25)))
-  /** @group Constructors */ case object Longslit2 extends GmosSouthFpu("Longslit2", "0.50arcsec", "Longslit 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.5)))
+  /** @group Constructors */ case object Longslit2 extends GmosSouthFpu("Longslit2", "0.50arcsec", "Longslit 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.50)))
   /** @group Constructors */ case object Longslit3 extends GmosSouthFpu("Longslit3", "0.75arcsec", "Longslit 0.75 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.75)))
-  /** @group Constructors */ case object Longslit4 extends GmosSouthFpu("Longslit4", "1.0arcsec", "Longslit 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.0)))
-  /** @group Constructors */ case object Longslit5 extends GmosSouthFpu("Longslit5", "1.5arcsec", "Longslit 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.5)))
-  /** @group Constructors */ case object Longslit6 extends GmosSouthFpu("Longslit6", "2.0arcsec", "Longslit 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.0)))
-  /** @group Constructors */ case object Longslit7 extends GmosSouthFpu("Longslit7", "5.0arcsec", "Longslit 5.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(5.0)))
+  /** @group Constructors */ case object Longslit4 extends GmosSouthFpu("Longslit4", "1.0arcsec", "Longslit 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object Longslit5 extends GmosSouthFpu("Longslit5", "1.5arcsec", "Longslit 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object Longslit6 extends GmosSouthFpu("Longslit6", "2.0arcsec", "Longslit 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.00)))
+  /** @group Constructors */ case object Longslit7 extends GmosSouthFpu("Longslit7", "5.0arcsec", "Longslit 5.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(5.00)))
   /** @group Constructors */ case object Ifu1 extends GmosSouthFpu("Ifu1", "IFU-2", "IFU 2 Slits", Option.empty[gem.math.Angle])
   /** @group Constructors */ case object Ifu2 extends GmosSouthFpu("Ifu2", "IFU-B", "IFU Left Slit (blue)", Option.empty[gem.math.Angle])
   /** @group Constructors */ case object Ifu3 extends GmosSouthFpu("Ifu3", "IFU-R", "IFU Right Slit (red)", Option.empty[gem.math.Angle])
@@ -35,11 +35,11 @@ object GmosSouthFpu {
   /** @group Constructors */ case object IfuN extends GmosSouthFpu("IfuN", "IFU-NS-2", "IFU N and S 2 Slits", Option.empty[gem.math.Angle])
   /** @group Constructors */ case object IfuNB extends GmosSouthFpu("IfuNB", "IFU-NS-B", "IFU N and S Left Slit (blue)", Option.empty[gem.math.Angle])
   /** @group Constructors */ case object IfuNR extends GmosSouthFpu("IfuNR", "IFU-NS-R", "IFU N and S Right Slit (red)", Option.empty[gem.math.Angle])
-  /** @group Constructors */ case object Ns1 extends GmosSouthFpu("Ns1", "NS0.5arcsec", "N and S 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.5)))
+  /** @group Constructors */ case object Ns1 extends GmosSouthFpu("Ns1", "NS0.5arcsec", "N and S 0.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.50)))
   /** @group Constructors */ case object Ns2 extends GmosSouthFpu("Ns2", "NS0.75arcsec", "N and S 0.75 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(0.75)))
-  /** @group Constructors */ case object Ns3 extends GmosSouthFpu("Ns3", "NS1.0arcsec", "N and S 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.0)))
-  /** @group Constructors */ case object Ns4 extends GmosSouthFpu("Ns4", "NS1.5arcsec", "N and S 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.5)))
-  /** @group Constructors */ case object Ns5 extends GmosSouthFpu("Ns5", "NS2.0arcsec", "N and S 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.0)))
+  /** @group Constructors */ case object Ns3 extends GmosSouthFpu("Ns3", "NS1.0arcsec", "N and S 1.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object Ns4 extends GmosSouthFpu("Ns4", "NS1.5arcsec", "N and S 1.50 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object Ns5 extends GmosSouthFpu("Ns5", "NS2.0arcsec", "N and S 2.00 arcsec", Some(gem.math.Angle.fromDoubleArcseconds(2.00)))
 
   /** All members of GmosSouthFpu, in canonical order. */
   val all: List[GmosSouthFpu] =

--- a/modules/core/shared/src/main/scala/gem/enum/Site.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Site.scala
@@ -25,7 +25,7 @@ sealed abstract class Site(
 
 object Site {
 
-  /** @group Constructors */ case object GN extends Site("GN", "GN", "Gemini North", "Mauna Kea", gem.math.Angle.fromDoubleDegrees(19.8238068), gem.math.Angle.fromDoubleDegrees(-155.469055), 4213, java.time.ZoneId.of("Pacific/Honolulu"))
+  /** @group Constructors */ case object GN extends Site("GN", "GN", "Gemini North", "Mauna Kea", gem.math.Angle.fromDoubleDegrees(19.8238068), gem.math.Angle.fromDoubleDegrees(-155.4690550), 4213, java.time.ZoneId.of("Pacific/Honolulu"))
   /** @group Constructors */ case object GS extends Site("GS", "GS", "Gemini South", "Cerro Pachon", gem.math.Angle.fromDoubleDegrees(-30.2407494), gem.math.Angle.fromDoubleDegrees(-70.7366867), 2722, java.time.ZoneId.of("America/Santiago"))
 
   /** All members of Site, in canonical order. */

--- a/modules/sql/src/main/resources/db/migration/V034__Replace_Floating.sql
+++ b/modules/sql/src/main/resources/db/migration/V034__Replace_Floating.sql
@@ -1,0 +1,17 @@
+--
+-- Replace double and real by numeric(m,n)
+--
+
+ALTER TABLE e_site
+      ALTER COLUMN longitude TYPE numeric(10,7),
+      ALTER COLUMN latitude  TYPE numeric(10,7);
+
+-- Some precision is lost during conversion
+UPDATE e_site SET longitude = -155.469055, latitude =  19.8238068 WHERE id = 'GN';
+UPDATE e_site SET longitude = -70.7366867, latitude = -30.2407494 WHERE id = 'GS';
+
+ALTER TABLE e_f2_lyot_wheel
+      ALTER COLUMN plate_scale TYPE numeric(4,3),
+      ALTER COLUMN pixel_scale TYPE numeric(3,2);
+
+ALTER TABLE e_f2_read_mode ALTER COLUMN read_noise TYPE numeric(3,1);

--- a/modules/sql/src/main/scala/Angle.scala
+++ b/modules/sql/src/main/scala/Angle.scala
@@ -6,15 +6,15 @@ package gem.sql
 /** Minimal Angle classes to support reading from the enum tables without depending on core. */
 object Angle {
 
-  final case class Arcseconds(toArcsecs: Double)
+  final case class Arcseconds(toArcsecs: BigDecimal)
   object Arcseconds {
-    def fromArcsecs(d: Double): Arcseconds =
+    def fromArcsecs(d: BigDecimal): Arcseconds =
       Arcseconds(d)
   }
 
-  final case class Degrees(toDegrees: Double)
+  final case class Degrees(toDegrees: BigDecimal)
   object Degrees {
-    def fromDegrees(d: Double): Degrees =
+    def fromDegrees(d: BigDecimal): Degrees =
       Degrees(d)
   }
 

--- a/modules/sql/src/main/scala/package.scala
+++ b/modules/sql/src/main/scala/package.scala
@@ -13,10 +13,10 @@ package object sql {
     Meta[Long].xmap(Duration.ofMillis, _.toMillis)
 
   implicit val ArcsecondsMeta: Meta[Arcseconds] =
-    Meta[Double].xmap(Arcseconds.fromArcsecs, _.toArcsecs)
+    Meta[BigDecimal].xmap(Arcseconds.fromArcsecs, _.toArcsecs)
 
   implicit val DegreesMeta: Meta[Degrees] =
-    Meta[Double].xmap(Degrees.fromDegrees, _.toDegrees)
+    Meta[BigDecimal].xmap(Degrees.fromDegrees, _.toDegrees)
 
   implicit val WavelengthNmMeta: Meta[Wavelength.Nm] =
     Meta[BigDecimal].xmap(Wavelength.fromNm, _.toBigDecimal)


### PR DESCRIPTION
I think I got all the floating types but I may have missed some. Do you any way to make sure there are no `double`s or `real`s in an entire postgres database?

Fixes #162.