### PR TITLE
update gem to expose ports properly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,9 +28,9 @@ def imageManifest = ImageManifest.current("postgres:9.6.0").unsafeRunSync
 version in ThisBuild := imageManifest.formatVersion
 
 // check for library updates whenever the project is [re]load
-onLoad in Global := { s => 
+onLoad in Global := { s =>
   if (sys.props.contains("gem.skipDependencyUpdates")) s
-  else "dependencyUpdates" :: s 
+  else "dependencyUpdates" :: s
 }
 
 cancelable in Global := true
@@ -367,7 +367,7 @@ lazy val main = project
   .settings(
     packageName in Docker := "gem",
     dockerBaseImage       := "openjdk:8u141",
-    dockerExposedPorts    := List(6666),
+    dockerExposedPorts    := List(9090, 9091),
     dockerRepository      := Some("sbfocsdev-lv1.cl.gemini.edu"),
     dockerLabels          := imageManifest.labels,
 

--- a/modules/ctl/src/main/scala/hi/Containers.scala
+++ b/modules/ctl/src/main/scala/hi/Containers.scala
@@ -46,7 +46,8 @@ object Containers {
                 "--label", s"gem.role=gem",
                 // "--health-cmd", if (r) "\"nc -z localhost 6666\""
                 //                 else     "nc -z localhost 6666",
-                "--publish", s"1234:6666",
+                "--publish", s"9090:9090",
+                "--publish", s"9091:9091",
                 "--env",     s"GEM_DB_URL=jdbc:postgresql://$version-P/gem",
                 iGem.hash
               ).require { case Output(0, List(s)) => Container(s) }

--- a/modules/telnetd/src/main/scala/TelnetdConfiguration.scala
+++ b/modules/telnetd/src/main/scala/TelnetdConfiguration.scala
@@ -8,6 +8,6 @@ final case class TelnetdConfiguration(port: Int)
 object TelnetdConfiguration {
 
   val forTesting: TelnetdConfiguration =
-    apply(6666)
+    apply(9091)
 
 }

--- a/modules/web/src/main/scala/WebConfiguration.scala
+++ b/modules/web/src/main/scala/WebConfiguration.scala
@@ -28,8 +28,8 @@ object WebConfiguration {
         ttlSeconds = 60 * 5
       ),
       webServer = WebServer(
-        port = 8080,
-        host = "localhost"
+        port = 9090,
+        host = "0.0.0.0"
       ),
       log = Log(
         name            = "web",


### PR DESCRIPTION
This changes the internal and docker-exposed ports to be `9090` (http) and `9091` (telnet) so that's consistent now. Also had to publish the web service on `0.0.0.0` to make it externally visible. Once this is merged the services should be visible on `sbfocstest-lv1`.