### PR TITLE
User Targets

### DIFF
--- a/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
+++ b/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+/** Collection of targets associated with an observation.
+  */
+final case class TargetEnvironment(
+  /* asterism, */
+  /* guide stars, */
+  userTargets: Set[UserTarget]
+)

--- a/modules/core/shared/src/main/scala/gem/UserTarget.scala
+++ b/modules/core/shared/src/main/scala/gem/UserTarget.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.enum.UserTargetType
+
+/** Pairs a `Target` and a `UserTargetType`.
+  */
+final case class UserTarget(target: Target, targetType: UserTargetType)

--- a/modules/core/shared/src/main/scala/gem/enum/UserTargetType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/UserTargetType.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.syntax.eq._
+import cats.instances.string._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for user target type.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class UserTargetType(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object UserTargetType {
+
+  /** @group Constructors */ case object BlindOffset extends UserTargetType("BlindOffset", "Blind Offset", "Blind Offset", false)
+  /** @group Constructors */ case object OffAxis extends UserTargetType("OffAxis", "Off Axis", "Off Axis", false)
+  /** @group Constructors */ case object TuningStar extends UserTargetType("TuningStar", "Tuning Star", "Tuning Star", false)
+  /** @group Constructors */ case object Other extends UserTargetType("Other", "Other", "Other", false)
+
+  /** All members of UserTargetType, in canonical order. */
+  val all: List[UserTargetType] =
+    List(BlindOffset, OffAxis, TuningStar, Other)
+
+  /** Select the member of UserTargetType with the given tag, if any. */
+  def fromTag(s: String): Option[UserTargetType] =
+    all.find(_.tag === s)
+
+  /** Select the member of UserTargetType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): UserTargetType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val UserTargetTypeEnumerated: Enumerated[UserTargetType] =
+    new Enumerated[UserTargetType] {
+      def all = UserTargetType.all
+      def tag(a: UserTargetType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/arb/ProperMotion.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ProperMotion.scala
@@ -7,9 +7,9 @@ package arb
 import gem.math._
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen.{ chooseNum, const, oneOf }
 
 trait ArbProperMotion {
-  import ArbAngle._
   import ArbEpoch._
   import ArbCoordinates._
   import ArbOffset._
@@ -22,7 +22,11 @@ trait ArbProperMotion {
         ap <- arbitrary[Epoch]
         pv <- arbitrary[Option[Offset]]
         rv <- arbitrary[Option[RadialVelocity]]
-        px <- arbitrary[Option[Angle]]
+        px <- oneOf(
+                const(Option.empty[Angle]),
+                // Limit to a value that will fit in numeric(9,3) milliseconds.
+                chooseNum(-999999000L, 999999000L).map(µas => Some(Angle.fromMicroarcseconds(µas)))
+              )
       } yield ProperMotion(cs, ap, pv, rv, px)
     }
 

--- a/modules/core/shared/src/test/scala/gem/arb/Target.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Target.scala
@@ -14,7 +14,7 @@ trait ArbTarget {
   implicit val arbTarget: Arbitrary[Target] =
     Arbitrary {
       for {
-        n <- Gen.alphaStr
+        n <- Gen.alphaStr.map(_.take(64))
         t <- arbitrary[Track]
       } yield Target(n, t)
     }

--- a/modules/core/shared/src/test/scala/gem/arb/Target.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Target.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbTarget {
+
+  import ArbTrack._
+
+  implicit val arbTarget: Arbitrary[Target] =
+    Arbitrary {
+      for {
+        n <- Gen.alphaStr
+        t <- arbitrary[Track]
+      } yield Target(n, t)
+    }
+}
+
+object ArbTarget extends ArbTarget

--- a/modules/core/shared/src/test/scala/gem/arb/Track.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Track.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Site
+import gem.math._
+
+import gem.Track.{ Nonsidereal, Sidereal }
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbTrack {
+  import ArbProperMotion._
+  import ArbEnumerated._
+  import ArbEphemeris._
+  import ArbEphemerisKey._
+
+  implicit val arbSidereal: Arbitrary[Track.Sidereal] =
+    Arbitrary {
+      arbitrary[ProperMotion].map(Sidereal(_))
+    }
+
+  implicit val arbNonsidereal: Arbitrary[Track.Nonsidereal] =
+    Arbitrary {
+      for {
+        key  <- arbitrary[EphemerisKey]
+        eph  <- arbitrary[Ephemeris]
+        site <- arbitrary[Site]
+      } yield Nonsidereal(key, Map(site -> eph))
+    }
+
+  implicit val arbTrack: Arbitrary[Track] =
+    Arbitrary {
+      Gen.oneOf(arbitrary[Sidereal], arbitrary[Nonsidereal])
+    }
+}
+
+object ArbTrack extends ArbTrack

--- a/modules/core/shared/src/test/scala/gem/arb/UserTarget.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/UserTarget.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.UserTargetType
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbUserTarget {
+
+  import ArbEnumerated._
+  import ArbTarget._
+
+  implicit val arbUserTarget: Arbitrary[UserTarget] =
+    Arbitrary {
+      for {
+        t <- arbitrary[Target]
+        y <- arbitrary[UserTargetType]
+      } yield UserTarget(t, y)
+    }
+}
+
+object ArbUserTarget extends ArbUserTarget

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.dao.meta._
+import gem.enum.UserTargetType
+
+import doobie._, doobie.implicits._
+
+
+object UserTargetDao {
+
+  import EnumeratedMeta._
+  import ObservationIdMeta._
+
+  def insert(userTarget: UserTarget, oid: Observation.Id): ConnectionIO[Int] =
+    for {
+      tid <- TargetDao.insert(userTarget.target)
+      uid <- Statements.insert(tid, userTarget.targetType, oid).withUniqueGeneratedKeys[Int]("user_target_id")
+    } yield uid
+
+  object Statements {
+    def insert(targetId: Int, targetType: UserTargetType, oid: Observation.Id): Update0 =
+      sql"""
+        INSERT INTO user_target (
+          target_id,
+          user_target_type,
+          observation_id
+        ) VALUES (
+          $targetId,
+          $targetType,
+          $oid
+        )
+      """.update
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -27,7 +27,7 @@ object UserTargetDao {
   def insert(userTarget: UserTarget, oid: Observation.Id): ConnectionIO[Int] =
     for {
       tid <- TargetDao.insert(userTarget.target)
-      uid <- Statements.insert(tid, userTarget.targetType, oid).withUniqueGeneratedKeys[Int]("user_target_id")
+      uid <- Statements.insert(tid, userTarget.targetType, oid).withUniqueGeneratedKeys[Int]("id")
     } yield uid
 
   def select(id: Int): ConnectionIO[Option[UserTarget]] =

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.config.{ DynamicConfig, StaticConfig }
+
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.Matchers._
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+
+
+class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
+  import gem.arb.ArbUserTarget._
+
+  implicit val arbObservation: Arbitrary[Observation[StaticConfig, Step[DynamicConfig]]] =
+    Arbitrary {
+      genObservation
+    }
+
+  // TODO: We will need to figure out what to do about ephemeris.  It isn't
+  // stored when you write a Target with TargetDao, or loaded when you read one.
+  def stripEphemeris(ut: UserTarget): UserTarget =
+    ut match {
+      case UserTarget(Target(n, Track.Nonsidereal(id, _)), utt) =>
+        // TODO: Use lenses once we figure out what we're doing
+        UserTarget(Target(n, Track.Nonsidereal(id, Map.empty)), utt)
+
+      case _                                                    =>
+        ut
+    }
+
+
+  property("UserTargetDao should roundtrip-ish") {
+    forAll { (obs: Observation[StaticConfig, Step[DynamicConfig]], ut: UserTarget) =>
+      val oid = Observation.Id(pid, Observation.Index.unsafeFromInt(1))
+
+      val utʹ = withProgram {
+        for {
+          _  <- ObservationDao.insert(oid, obs)
+          id <- UserTargetDao.insert(stripEphemeris(ut), oid)
+          uʹ <- UserTargetDao.select(id)
+        } yield uʹ
+      }
+
+      Some(stripEphemeris(ut)) shouldEqual utʹ
+    }
+  }
+}

--- a/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
@@ -10,6 +10,8 @@ class UserTargetCheck extends Check {
   import UserTargetDao.Statements._
 
   "UserTargetDao.Statements" should
-            "insert" in check(insert(0, Other, Dummy.observationId))
+            "insert"    in check(insert(0, Other, Dummy.observationId))
+  it should "select"    in check(select(0))
+  it should "selectAll" in check(selectAll(Dummy.observationId))
 
 }

--- a/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.enum.UserTargetType.Other
+
+class UserTargetCheck extends Check {
+  import UserTargetDao.Statements._
+
+  "UserTargetDao.Statements" should
+            "insert" in check(insert(0, Other, Dummy.observationId))
+
+}

--- a/modules/sql/src/main/resources/db/migration/V036__User_Targets.sql
+++ b/modules/sql/src/main/resources/db/migration/V036__User_Targets.sql
@@ -2,6 +2,12 @@
 -- Adds user targets to the model.
 --
 
+
+-- User Target Type
+--
+-- An enumeration of the various uses of target positions associated with an
+-- observation apart from the main science targets.
+
 CREATE TABLE e_user_target_type (
   id         identifier            PRIMARY KEY,
   short_name character varying(20) NOT NULL,
@@ -18,3 +24,15 @@ TuningStar	Tuning Star	Tuning Star	f
 Other	Other	Other	f
 \.
 
+
+-- User Target Table
+-- Associates a target, user target type, and an observation.
+
+CREATE TABLE user_target (
+  user_target_id   SERIAL                PRIMARY KEY,
+  target_id        integer               NOT NULL REFERENCES target(id),
+  user_target_type identifier            NOT NULL REFERENCES e_user_target_type(id),
+  observation_id   character varying(40) NOT NULL REFERENCES observation ON DELETE CASCADE
+);
+
+ALTER TABLE user_target OWNER TO postgres;

--- a/modules/sql/src/main/resources/db/migration/V036__User_Targets.sql
+++ b/modules/sql/src/main/resources/db/migration/V036__User_Targets.sql
@@ -29,7 +29,7 @@ Other	Other	Other	f
 -- Associates a target, user target type, and an observation.
 
 CREATE TABLE user_target (
-  user_target_id   SERIAL                PRIMARY KEY,
+  id               SERIAL                PRIMARY KEY,
   target_id        integer               NOT NULL REFERENCES target(id),
   user_target_type identifier            NOT NULL REFERENCES e_user_target_type(id),
   observation_id   character varying(40) NOT NULL REFERENCES observation ON DELETE CASCADE

--- a/modules/sql/src/main/resources/db/migration/V036__User_Targets.sql
+++ b/modules/sql/src/main/resources/db/migration/V036__User_Targets.sql
@@ -1,0 +1,20 @@
+--
+-- Adds user targets to the model.
+--
+
+CREATE TABLE e_user_target_type (
+  id         identifier            PRIMARY KEY,
+  short_name character varying(20) NOT NULL,
+  long_name  character varying(20) NOT NULL,
+  obsolete   boolean               NOT NULL
+);
+
+ALTER TABLE e_user_target_type OWNER TO postgres;
+
+COPY e_user_target_type (id, short_name, long_name, obsolete) FROM stdin;
+BlindOffset	Blind Offset	Blind Offset	f
+OffAxis	Off Axis	Off Axis	f
+TuningStar	Tuning Star	Tuning Star	f
+Other	Other	Other	f
+\.
+

--- a/modules/sql/src/main/resources/db/migration/V037__User_Targets.sql
+++ b/modules/sql/src/main/resources/db/migration/V037__User_Targets.sql
@@ -9,10 +9,10 @@
 -- observation apart from the main science targets.
 
 CREATE TABLE e_user_target_type (
-  id         identifier            PRIMARY KEY,
-  short_name character varying(20) NOT NULL,
-  long_name  character varying(20) NOT NULL,
-  obsolete   boolean               NOT NULL
+  id         identifier PRIMARY KEY,
+  short_name TEXT       NOT NULL,
+  long_name  TEXT       NOT NULL,
+  obsolete   boolean    NOT NULL
 );
 
 ALTER TABLE e_user_target_type OWNER TO postgres;
@@ -29,10 +29,10 @@ Other	Other	Other	f
 -- Associates a target, user target type, and an observation.
 
 CREATE TABLE user_target (
-  id               SERIAL                PRIMARY KEY,
-  target_id        integer               NOT NULL REFERENCES target(id),
-  user_target_type identifier            NOT NULL REFERENCES e_user_target_type(id),
-  observation_id   character varying(40) NOT NULL REFERENCES observation ON DELETE CASCADE
+  id               SERIAL     PRIMARY KEY,
+  target_id        integer    NOT NULL REFERENCES target(id),
+  user_target_type identifier NOT NULL REFERENCES e_user_target_type(id),
+  observation_id   TEXT       NOT NULL REFERENCES observation ON DELETE CASCADE
 );
 
 ALTER TABLE user_target OWNER TO postgres;

--- a/modules/sql/src/main/scala/enum/TargetEnums.scala
+++ b/modules/sql/src/main/scala/enum/TargetEnums.scala
@@ -33,6 +33,11 @@ object TargetEnums {
       EnumDef.fromQuery("MagnitudeBand", "magnitude band") {
         type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'center -> Int, 'width -> Int, 'magnitudeSystem -> MagnitudeSystem`.T
         sql"""SELECT id, id tag, short_name, long_name, center, width, default_system FROM e_magnitude_band""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("UserTargetType", "user target type") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_user_target_type".query[(String, R)]
       }
 
     )


### PR DESCRIPTION
This PR is sort of half-done, pending the outcome of Issue #176.  It adds a `UserTarget` type in an initial placeholder `TargetEnvironment` along with a mini DAO to get us started.  My plan was to include a `TargetEnvironment` in each `Observation` but before I hook it up, I thought we should figure out what to do about #176.