### PR TITLE
JulianDate

### DIFF
--- a/modules/core/shared/src/main/scala/gem/math/Epoch.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Epoch.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import gem.parser.EpochParsers
 import gem.syntax.parser._
 import java.time._
-import scala.math.floor
 
 /**
  * An epoch, the astronomer's equivalent of `Instant`, based on a fractional year in some temporal
@@ -110,18 +109,8 @@ object Epoch {
      * Convert a `LocalDateTime` to a fractional Julian day.
      * @see The Wikipedia [[https://en.wikipedia.org/wiki/Julian_day article]]
      */
-    def toJulianDay(dt: LocalDateTime): Double = {
-      val a = floor((14.0 - dt.getMonthValue) / 12.0)
-      val y = dt.getYear + 4800.0 - a
-      val m = dt.getMonthValue + 12 * a - 3.0
-      dt.getDayOfMonth +
-      floor((153.0 * m + 2.0) / 5.0) +
-      365 * y +
-      floor(y / 4.0) -
-      floor(y / 100.0) +
-      floor(y / 400.0) -
-      32045.0
-    }
+    def toJulianDay(dt: LocalDateTime): Double =
+      JulianDate.ofLocalDateTime(dt).dayNumber.toDouble
 
     implicit val SchemeEq: Eq[Scheme] =
       Eq.fromUniversalEquals

--- a/modules/core/shared/src/main/scala/gem/math/JulianDate.scala
+++ b/modules/core/shared/src/main/scala/gem/math/JulianDate.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{Eq, Show}
+
+import java.time.{Instant, LocalDateTime}
+import java.time.ZoneOffset.UTC
+
+/** Astronomical time representation of continuous days since noon, November 24,
+  * 4714 BC.
+  *
+  * @param dayNumber      whole Julian Day number
+  * @param nanoAdjustment fraction of a day adjustment in nanoseconds
+  *
+  * @see The Wikipedia [[https://en.wikipedia.org/wiki/Julian_day article]]
+  */
+sealed abstract case class JulianDate(
+  dayNumber:      Int,
+  nanoAdjustment: Long
+) {
+
+  import JulianDate.{ NanoPerDay, MaxAdjustment, MinAdjustment }
+
+  // Guaranteed by the JulianDate constructors, double checked here.
+  assert(dayNumber      >= 0,             s"dayNumber >= 0")
+  assert(nanoAdjustment >= MinAdjustment, s"nanoAdjustment >= $MinAdjustment")
+  assert(nanoAdjustment <= MaxAdjustment, s"nanoAdjustment <= $MaxAdjustment")
+
+
+  /** Julian date value as a Double, including Julian Day Number and fractional
+    * day since the preceding noon.
+    */
+  val toDouble: Double =
+    dayNumber + nanoAdjustment.toDouble / NanoPerDay.toDouble
+}
+
+
+object JulianDate {
+
+  // One half day of seconds, ignoring leap seconds since Java time API ignores
+  // them as well.
+  private val SecPerDay: Int      = 86400
+  private val SecPerHalfDay: Int  = 43200
+
+  private val Billion: Int        = 1000000000
+  private val NanoPerDay: Long    = SecPerDay.toLong * Billion.toLong
+
+  private val MinAdjustment: Long = -SecPerHalfDay.toLong * Billion.toLong
+  private val MaxAdjustment: Long =  SecPerHalfDay.toLong * Billion.toLong - 1
+
+  /** Convert an `Instant` to a Julian Date.
+    */
+  def ofInstant(i: Instant): JulianDate =
+    ofLocalDateTime(LocalDateTime.ofInstant(i, UTC))
+
+  /** JulianDate from a `LocalDateTime` assumed to represent a time at UTC.
+    */
+  def ofLocalDateTime(ldt: LocalDateTime): JulianDate = {
+    val y   = ldt.getYear
+    val m   = ldt.getMonthValue
+    val d   = ldt.getDayOfMonth
+
+    // Yes, integer division.  -1 for Jan and Feb. 0 for Mar - Dec.
+    val t   = (m - 14) / 12
+
+    // Julian Day Number (integer division).
+    val jdn = (1461 * (y + 4800 + t))       /  4 +
+              ( 367 * (m - 2 - 12 * t))     / 12 -
+              (   3 * ((y + 4900 + t)/100)) /  4 +
+              d - 32075
+
+    // Whole seconds since midnight
+    val secs = ldt.getHour * 3600 + ldt.getMinute * 60 + ldt.getSecond
+    val adj  = (secs - SecPerHalfDay).toLong * Billion + ldt.getNano
+
+    new JulianDate(jdn, adj) {}
+  }
+
+  implicit val JulianDateEq: Eq[JulianDate] =
+    Eq.fromUniversalEquals
+
+  implicit val JulianDateShow: Show[JulianDate] =
+    Show.fromToString
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/JulianDate.scala
+++ b/modules/core/shared/src/main/scala/gem/math/JulianDate.scala
@@ -3,7 +3,8 @@
 
 package gem.math
 
-import cats.{Eq, Show}
+import cats.{ Order, Show }
+import cats.implicits._
 
 import java.time.{Instant, LocalDateTime}
 import java.time.ZoneOffset.UTC
@@ -62,6 +63,11 @@ object JulianDate {
     val m   = ldt.getMonthValue
     val d   = ldt.getDayOfMonth
 
+    // Julian Day Number algorithm from:
+    // Fliegel, H.F. and Van Flandern, T.C. (1968). "A Machine Algorithm for
+    // Processing Calendar Dates" Communications of the Association of Computing
+    // Machines ll, 6sT.
+
     // Yes, integer division.  -1 for Jan and Feb. 0 for Mar - Dec.
     val t   = (m - 14) / 12
 
@@ -78,8 +84,8 @@ object JulianDate {
     new JulianDate(jdn, adj) {}
   }
 
-  implicit val JulianDateEq: Eq[JulianDate] =
-    Eq.fromUniversalEquals
+  implicit val JulianDateOrder: Order[JulianDate] =
+    Order.by(jd => (jd.dayNumber, jd.nanoAdjustment))
 
   implicit val JulianDateShow: Show[JulianDate] =
     Show.fromToString

--- a/modules/core/shared/src/test/scala/gem/arb/JulianDate.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/JulianDate.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.JulianDate
+
+import java.time.LocalDateTime
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+
+trait ArbJulianDate {
+  import ArbTime._
+
+  implicit val arbJulianDate: Arbitrary[JulianDate] =
+    Arbitrary {
+      arbitrary[LocalDateTime].map(JulianDate.ofLocalDateTime)
+    }
+}
+
+object ArbJulianDate extends ArbJulianDate

--- a/modules/core/shared/src/test/scala/gem/arb/JulianDate.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/JulianDate.scala
@@ -19,6 +19,9 @@ trait ArbJulianDate {
     Arbitrary {
       arbitrary[LocalDateTime].map(JulianDate.ofLocalDateTime)
     }
+
+  implicit val cogJulianDate: Cogen[JulianDate] =
+    Cogen[(Int, Long)].contramap(jd => (jd.dayNumber, jd.nanoAdjustment))
 }
 
 object ArbJulianDate extends ArbJulianDate

--- a/modules/core/shared/src/test/scala/gem/math/JulianDateSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/JulianDateSpec.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import gem.arb._
+
+import java.time.LocalDateTime
+
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class JulianDateSpec extends CatsSuite {
+
+  import ArbJulianDate._
+  import ArbTime._
+
+  test("JulianDate.eq.natural") {
+    forAll { (a: JulianDate, b: JulianDate) =>
+      a.equals(b) shouldEqual Eq[JulianDate].eqv(a, b)
+    }
+  }
+
+  test("JulianDate.show.natural") {
+    forAll { (a: JulianDate) =>
+      a.toString shouldEqual Show[JulianDate].show(a)
+    }
+  }
+
+  // Old Epoch.Scheme.toJulianDay algorithm
+  private def oldEpochSchemeJulianDate(dt: LocalDateTime): Double = {
+    import scala.math.floor
+
+    val a = floor((14.0 - dt.getMonthValue) / 12.0)
+    val y = dt.getYear + 4800.0 - a
+    val m = dt.getMonthValue + 12 * a - 3.0
+    dt.getDayOfMonth +
+    floor((153.0 * m + 2.0) / 5.0) +
+    365 * y +
+    floor(y / 4.0) -
+    floor(y / 100.0) +
+    floor(y / 400.0) -
+    32045.0
+  }
+
+  test("JulianDate.dayNumber matches old calculation") {
+    forAll { (ldt: LocalDateTime) =>
+      val jd0 = oldEpochSchemeJulianDate(ldt)
+      val jd1 = JulianDate.ofLocalDateTime(ldt).dayNumber.toDouble
+
+      jd0 shouldEqual jd1
+    }
+  }
+
+  test("Some specific dates compared to USNO calculations") {
+
+    val tests = List(
+      (LocalDateTime.of(1918, 11, 11, 11,  0,  0), 2421908.958333),
+      (LocalDateTime.of(1969,  7, 21,  2, 56, 15), 2440423.622396),
+      (LocalDateTime.of(2001,  9, 11,  8, 46,  0), 2452163.865278),
+      (LocalDateTime.of(2345,  6,  7, 12,  0,  0), 2577711.000000)
+    )
+
+    tests.foreach { case (ldt, expected) =>
+      val jd  = JulianDate.ofLocalDateTime(ldt)
+      assert((expected - jd.toDouble).abs <= 0.000001)
+    }
+  }
+}

--- a/modules/core/shared/src/test/scala/gem/math/JulianDateSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/JulianDateSpec.scala
@@ -3,8 +3,10 @@
 
 package gem.math
 
-import cats.tests.CatsSuite
 import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
 import gem.arb._
 
 import java.time.LocalDateTime
@@ -15,6 +17,9 @@ final class JulianDateSpec extends CatsSuite {
 
   import ArbJulianDate._
   import ArbTime._
+
+  // Laws
+  checkAll("JulianDate", OrderTests[JulianDate].order)
 
   test("JulianDate.eq.natural") {
     forAll { (a: JulianDate, b: JulianDate) =>
@@ -55,6 +60,7 @@ final class JulianDateSpec extends CatsSuite {
 
   test("Some specific dates compared to USNO calculations") {
 
+    // See http://aa.usno.navy.mil/data/docs/JulianDate.php
     val tests = List(
       (LocalDateTime.of(1918, 11, 11, 11,  0,  0), 2421908.958333),
       (LocalDateTime.of(1969,  7, 21,  2, 56, 15), 2440423.622396),


### PR DESCRIPTION
The TCS export of ephemeris data requires the equivalent Julian Date for each ephemeris element.  I noticed that the code we have for this in `Epoch.Scheme` computes the Julian Day Number, but not the Julian Date itself (which includes the fractional day) so I decided to add a `JulianDate` class.