### PR TITLE
JSON support for Target

### DIFF
--- a/modules/json/src/test/scala/gem/json/CompilationTest.scala
+++ b/modules/json/src/test/scala/gem/json/CompilationTest.scala
@@ -34,6 +34,7 @@ import gem.util.Enumerated
   assertCodec[User[ProgramRole]]
   assertCodec[StaticConfig]
   assertCodec[DynamicConfig]
+  assertCodec[Target]
 
   // These compile but take a very long time. Disabled for now, we may need to do some steps
   // of the derivation by hand to make this viable.


### PR DESCRIPTION
Trying to add a `TargetEnvironment` to an `Observation`, I came across an issue with JSON support. `Target` was missing the required codec definitions.  This turned out to be a little more involved than I assumed because:

* We cannot have a single implicit `Angle` codec because there are so many different contexts in which `Angle` is used and each needs its own representation.

* There is some issue with deriving codecs for `Map[K, V]` even when there are codecs for `K` and `V`.  I'm probably doing something wrong but I ended up having to write them out explicitly as lists of tuples.

At any rate, I submit this PR for further discussion.  Maybe we want to do this differently now and not rely so much on auto-derivation?

PS, I'm not sure what's up with the `PublicInference` warts that I had to turn off.  I think it might be a bug.