### PR TITLE
Database-safe Timestamps

### DIFF
--- a/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
@@ -18,9 +18,10 @@ import monocle.macros.Lenses
   *                asteroid ephemeris data fetched from horizons)
   */
 @Lenses final case class EphemerisMeta(
-                                        lastUpdate: Timestamp,
-                                        lastUpdateCheck: Timestamp,
-                                        solnRef: Option[HorizonsSolutionRef])
+  lastUpdate: Timestamp,
+  lastUpdateCheck: Timestamp,
+  solnRef: Option[HorizonsSolutionRef]
+)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object EphemerisMeta {

--- a/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
@@ -3,7 +3,7 @@
 
 package gem
 
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.{ Eq, Show }
 
@@ -18,9 +18,9 @@ import monocle.macros.Lenses
   *                asteroid ephemeris data fetched from horizons)
   */
 @Lenses final case class EphemerisMeta(
-  lastUpdate: InstantMicros,
-  lastUpdateCheck: InstantMicros,
-  solnRef: Option[HorizonsSolutionRef])
+                                        lastUpdate: Timestamp,
+                                        lastUpdateCheck: Timestamp,
+                                        solnRef: Option[HorizonsSolutionRef])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object EphemerisMeta {

--- a/modules/core/shared/src/main/scala/gem/Track.scala
+++ b/modules/core/shared/src/main/scala/gem/Track.scala
@@ -5,7 +5,7 @@ package gem
 
 import gem.enum.Site
 import gem.math._
-import gem.util.InstantMicros
+import gem.util.Timestamp
 import java.time.Instant
 
 /**
@@ -42,7 +42,7 @@ object Track {
 
     override def at(time: Instant, s: Site): Option[Coordinates] =
       for {
-        i <- InstantMicros.clip(time)
+        i <- Timestamp.fromInstant(time)
         e <- ephemeris(s)
         c <- e.get(i)
       } yield c.coord

--- a/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
@@ -3,7 +3,7 @@
 
 package gem.math
 
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.{ Eq, Foldable, Monoid }
 import cats.implicits._
@@ -14,7 +14,7 @@ import scala.collection.immutable.TreeMap
  * Time-parameterized coordinates over a fixed interval, defined pairwise. Coordinates that fall
  * between known instants are interpolated.
  */
-sealed abstract case class Ephemeris private (toMap: TreeMap[InstantMicros, EphemerisCoordinates]) {
+sealed abstract case class Ephemeris private (toMap: TreeMap[Timestamp, EphemerisCoordinates]) {
   import Ephemeris.Element
 
   // N.B. this case class is abstract and has a private ctor because we want to keep construction of
@@ -29,7 +29,7 @@ sealed abstract case class Ephemeris private (toMap: TreeMap[InstantMicros, Ephe
     toMap.lastOption
 
   /** Coordinates at time `t`, exact if known, interpolated if `bracket(t)` is known. */
-  def get(t: InstantMicros): Option[EphemerisCoordinates] =
+  def get(t: Timestamp): Option[EphemerisCoordinates] =
     toMap.get(t) orElse bracket(t).map { case ((a, ca), (b, cb)) =>
       val (iʹ, aʹ, bʹ) = (t.toEpochMilli, a.toEpochMilli, b.toEpochMilli)
       val factor = (iʹ - aʹ).toDouble / (bʹ - aʹ).toDouble
@@ -40,7 +40,7 @@ sealed abstract case class Ephemeris private (toMap: TreeMap[InstantMicros, Ephe
    * Greatest lower and least upper bounds of `t`; i.e., the closest elements on either side,
    * inclusive (so if `t` is present then `bracket(t) = (t, t)`).
    */
-  def bracket(t: InstantMicros): Option[(Element, Element)] =
+  def bracket(t: Timestamp): Option[(Element, Element)] =
     (toMap.to(t).lastOption, toMap.from(t).headOption).tupled
 
   /** The sum of this ephemeris and `e`, taking values from `e` in the case of overlap. */
@@ -51,7 +51,7 @@ sealed abstract case class Ephemeris private (toMap: TreeMap[InstantMicros, Ephe
 object Ephemeris {
 
   /** An ephemeris element. */
-  type Element = (InstantMicros, EphemerisCoordinates)
+  type Element = (Timestamp, EphemerisCoordinates)
 
   /** The empty ephemeris. */
   val Empty: Ephemeris = apply()

--- a/modules/core/shared/src/main/scala/gem/util/Timestamp.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Timestamp.scala
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit.MICROS
 /** Timestamp wraps a `java.util.Instant` that is truncated to microsecond
   * resolution.  This allows Timestamps to roundtrip to/from the database
   * where only microsecond resolution is supported.  In addition the min
-  * and max instants that are supported are determined by th postgres limit for
+  * and max instants that are supported are determined by the postgres limit for
   * timestamps.
   *
   * @param toInstant

--- a/modules/core/shared/src/test/scala/gem/arb/Ephemeris.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Ephemeris.scala
@@ -5,7 +5,7 @@ package gem
 package arb
 
 import gem.math.{ Coordinates, Ephemeris, EphemerisCoordinates, Offset }
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import org.scalacheck._
 import org.scalacheck.Gen._
@@ -28,7 +28,7 @@ trait ArbEphemeris {
   implicit val arbElement: Arbitrary[Element] =
     Arbitrary {
       for {
-        t <- arbitrary[InstantMicros]
+        t <- arbitrary[Timestamp]
         c <- arbitrary[EphemerisCoordinates]
       } yield (t, c)
     }
@@ -45,7 +45,7 @@ trait ArbEphemeris {
     Cogen[(Coordinates, Offset)].contramap(co => (co.coord, co.delta))
 
   implicit val cogEphemeris: Cogen[Ephemeris] =
-    Cogen[Map[InstantMicros, EphemerisCoordinates]].contramap(_.toMap)
+    Cogen[Map[Timestamp, EphemerisCoordinates]].contramap(_.toMap)
 
 }
 object ArbEphemeris extends ArbEphemeris

--- a/modules/core/shared/src/test/scala/gem/arb/EphemerisMeta.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/EphemerisMeta.scala
@@ -4,7 +4,7 @@
 package gem
 package arb
 
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
@@ -21,8 +21,8 @@ trait ArbEphemerisMeta {
   implicit val arbEphemerisMeta: Arbitrary[EphemerisMeta] =
     Arbitrary {
       for {
-        u <- arbitrary[InstantMicros]
-        c <- arbitrary[InstantMicros]
+        u <- arbitrary[Timestamp]
+        c <- arbitrary[Timestamp]
         s <- arbitrary[Option[HorizonsSolutionRef]]
       } yield EphemerisMeta(u, c, s)
     }

--- a/modules/core/shared/src/test/scala/gem/arb/Time.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Time.scala
@@ -65,7 +65,12 @@ trait ArbTime {
     Arbitrary(arbitrary[ZonedDateTime].map(_.toInstant))
 
   implicit val arbInstantMicros: Arbitrary[InstantMicros] =
-    Arbitrary(arbitrary[Instant].map(InstantMicros.truncate))
+    Arbitrary {
+      for {
+        m <- Gen.choose(0L, Duration.between(InstantMicros.Min.toInstant, InstantMicros.Max.toInstant).toMillis)
+        u <- Gen.choose(0, 999L)
+      } yield InstantMicros.Min.plusMillis(m).flatMap(_.plusMicros(u)).getOrElse(InstantMicros.Min)
+    }
 
   implicit val arbDuration: Arbitrary[Duration] =
     Arbitrary {

--- a/modules/core/shared/src/test/scala/gem/arb/Time.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Time.scala
@@ -4,7 +4,7 @@
 package gem
 package arb
 
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import org.scalacheck._
 import org.scalacheck.Gen._
@@ -64,12 +64,12 @@ trait ArbTime {
   implicit val arbInstant: Arbitrary[Instant] =
     Arbitrary(arbitrary[ZonedDateTime].map(_.toInstant))
 
-  implicit val arbInstantMicros: Arbitrary[InstantMicros] =
+  implicit val arbTimestamp: Arbitrary[Timestamp] =
     Arbitrary {
       for {
-        m <- Gen.choose(0L, Duration.between(InstantMicros.Min.toInstant, InstantMicros.Max.toInstant).toMillis)
+        m <- Gen.choose(0L, Duration.between(Timestamp.Min.toInstant, Timestamp.Max.toInstant).toMillis)
         u <- Gen.choose(0, 999L)
-      } yield InstantMicros.Min.plusMillis(m).flatMap(_.plusMicros(u)).getOrElse(InstantMicros.Min)
+      } yield Timestamp.Min.plusMillis(m).flatMap(_.plusMicros(u)).getOrElse(Timestamp.Min)
     }
 
   implicit val arbDuration: Arbitrary[Duration] =
@@ -83,7 +83,7 @@ trait ArbTime {
   implicit val cogInstant: Cogen[Instant] =
     Cogen[(Long, Int)].contramap(t => (t.getEpochSecond, t.getNano))
 
-  implicit val cogInstantMicros: Cogen[InstantMicros] =
+  implicit val cogTimestamp: Cogen[Timestamp] =
     Cogen[Instant].contramap(_.toInstant)
 
   implicit val cogYear: Cogen[Year] =

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
@@ -10,7 +10,7 @@ import cats.Eq
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals", "org.wartremover.warts.OptionPartial"))
 final class EphemerisSpec extends CatsSuite {
   import ArbEphemeris._
   import ArbTime._
@@ -34,11 +34,14 @@ final class EphemerisSpec extends CatsSuite {
 
   test("Ephemeris.get.interpolated") {
     forAll { (t1: InstantMicros, c1: EphemerisCoordinates, c2: EphemerisCoordinates, n: Int) =>
-      val offset = (n % 100).abs
-      val (t2, t3) = (t1.plusSeconds(offset.toLong), t1.plusSeconds(100))
-      val e = Ephemeris(t1 -> c1, t3 -> c2)
-      val c3 = e.get(t2).getOrElse(sys.error("failed"))
-      val c4 = c1.interpolate(c2, offset.toDouble / 100.00)
+      val tEnd = t1.plusSeconds(100).getOrElse(InstantMicros.Max)
+      val tBeg = tEnd.plusSeconds(-100).get
+      val off  = (n % 100).abs
+      val tMid = tBeg.plusSeconds(off.toLong).get
+
+      val e  = Ephemeris(tBeg -> c1, tEnd -> c2)
+      val c3 = e.get(tMid).getOrElse(sys.error("failed"))
+      val c4 = c1.interpolate(c2, off.toDouble / 100.00)
       (c3.coord angularDistance c4.coord).toMicroarcseconds should be <= 15L
     }
   }

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
@@ -4,7 +4,7 @@
 package gem.math
 
 import gem.arb._
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.Eq
 import cats.kernel.laws.discipline._
@@ -33,8 +33,8 @@ final class EphemerisSpec extends CatsSuite {
   }
 
   test("Ephemeris.get.interpolated") {
-    forAll { (t1: InstantMicros, c1: EphemerisCoordinates, c2: EphemerisCoordinates, n: Int) =>
-      val tEnd = t1.plusSeconds(100).getOrElse(InstantMicros.Max)
+    forAll { (t1: Timestamp, c1: EphemerisCoordinates, c2: EphemerisCoordinates, n: Int) =>
+      val tEnd = t1.plusSeconds(100).getOrElse(Timestamp.Max)
       val tBeg = tEnd.plusSeconds(-100).get
       val off  = (n % 100).abs
       val tMid = tBeg.plusSeconds(off.toLong).get

--- a/modules/core/shared/src/test/scala/gem/util/TimestampSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/TimestampSpec.scala
@@ -9,6 +9,11 @@ import gem.arb.ArbTime._
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 
+import java.time.ZonedDateTime
+import java.time.ZoneOffset.UTC
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 
 @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
 final class TimestampSpec extends CatsSuite {
@@ -19,6 +24,21 @@ final class TimestampSpec extends CatsSuite {
   test("Construction should truncate Instant nanoseconds to microseconds") {
     forAll { (i: Timestamp) =>
       i.toInstant.getNano % 1000L == 0
+    }
+  }
+
+  test("Out of range dates are rejected") {
+    implicit val arbInt: Arbitrary[Int] =
+      Arbitrary {
+        Gen.frequency((1, Gen.choose(-999999999, 999999999)),
+                      (1, Gen.choose(     -4712,    294275)))
+      }
+
+    forAll { (y: Int) =>
+      val i = ZonedDateTime.of(y, 1, 1, 0, 0, 0, 0, UTC).toInstant
+      val t = Timestamp.fromInstant(i)
+
+      assert(t.isEmpty == (i.isBefore(Timestamp.Min.toInstant) || i.isAfter(Timestamp.Max.toInstant)))
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/util/TimestampSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/TimestampSpec.scala
@@ -11,13 +11,13 @@ import cats.tests.CatsSuite
 
 
 @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
-final class InstantMicrosSpec extends CatsSuite {
+final class TimestampSpec extends CatsSuite {
 
   // Laws
-  checkAll("InstantMicro", OrderTests[InstantMicros].order)
+  checkAll("Timestamp", OrderTests[Timestamp].order)
 
   test("Construction should truncate Instant nanoseconds to microseconds") {
-    forAll { (i: InstantMicros) =>
+    forAll { (i: Timestamp) =>
       i.toInstant.getNano % 1000L == 0
     }
   }

--- a/modules/db/src/main/scala/gem/dao/meta/Time.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Time.scala
@@ -10,7 +10,7 @@ import java.time.{ Instant, Duration }
 trait TimeMeta {
 
   implicit val InstantMicrosMeta: Meta[InstantMicros] =
-    Meta[Instant].xmap(InstantMicros.truncate, _.toInstant)
+    Meta[Instant].xmap(InstantMicros.unsafeClip, _.toInstant)
 
   implicit val DurationMeta: Meta[Duration] =
     Distinct.long("milliseconds").xmap(Duration.ofMillis, _.toMillis)

--- a/modules/db/src/main/scala/gem/dao/meta/Time.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Time.scala
@@ -4,13 +4,13 @@
 package gem.dao.meta
 
 import doobie._
-import gem.util.InstantMicros
+import gem.util.Timestamp
 import java.time.{ Instant, Duration }
 
 trait TimeMeta {
 
-  implicit val InstantMicrosMeta: Meta[InstantMicros] =
-    Meta[Instant].xmap(InstantMicros.unsafeClip, _.toInstant)
+  implicit val TimestampMeta: Meta[Timestamp] =
+    Meta[Instant].xmap(Timestamp.unsafeFromInstant, _.toInstant)
 
   implicit val DurationMeta: Meta[Duration] =
     Distinct.long("milliseconds").xmap(Duration.ofMillis, _.toMillis)

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -11,7 +11,7 @@ import gem.arb.ArbEphemerisMeta._
 import gem.arb.ArbTime._
 import gem.enum.Site
 import gem.math.Ephemeris
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.implicits._
 
@@ -55,7 +55,7 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("EphemerisDao should selectRange") {
-    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap, i0: InstantMicros, i1: InstantMicros) =>
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap, i0: Timestamp, i1: Timestamp) =>
       val List(start, end) = List(i0, i1).sorted
       val eʹ = execTest(m + (ks -> e), EphemerisDao.selectRange(ks.key, ks.site, start, end))
       e.toMap.range(start, end) shouldEqual eʹ.toMap
@@ -225,7 +225,7 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       val em = e.toMap
 
       val expected =
-        if (em.isEmpty) Option.empty[(InstantMicros, InstantMicros)]
+        if (em.isEmpty) Option.empty[(Timestamp, Timestamp)]
         else Some((em.firstKey, em.lastKey))
 
       expected shouldEqual execTest(m + (ks -> e), p)
@@ -233,7 +233,7 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("EphemerisDao bracketRange") {
-    import InstantMicros.{ Max, Min }
+    import Timestamp.{ Max, Min }
 
     forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
       val em = e.toMap
@@ -255,7 +255,7 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("EphemerisDao bracketRange exact") {
-    import InstantMicros.{ Max, Min }
+    import Timestamp.{ Max, Min }
 
     forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
       val em = e.toMap

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -11,7 +11,7 @@ import gem._
 import gem.enum._
 import gem.config._
 import gem.config.DynamicConfig.SmartGcalKey
-import gem.util.{ InstantMicros, Location }
+import gem.util.{ Timestamp, Location }
 import gem.math._
 import java.time.LocalDate
 import org.scalatest._
@@ -62,7 +62,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val stepType         = StepType.Science
     val ephemerisKey     = EphemerisKey.Comet("Lanrezac")
     val horizonsSolnRef  = HorizonsSolutionRef("JPL#K162/5")
-    val ephemerisMeta    = EphemerisMeta(InstantMicros.Min, InstantMicros.Min, Some(horizonsSolnRef))
+    val ephemerisMeta    = EphemerisMeta(Timestamp.Min, Timestamp.Min, Some(horizonsSolnRef))
 
     val gmosCustomRoiEntry =
       gem.config.GmosConfig.GmosCustomRoiEntry.unsafeFromDescription(1, 1, 1, 1)

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -4,7 +4,7 @@
 package gem.dao
 package check
 
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 class EphemerisCheck extends Check {
   import EphemerisDao.Statements._
@@ -12,7 +12,7 @@ class EphemerisCheck extends Check {
             "insert"      in check(insert)
   it should "delete"      in check(delete(Dummy.ephemerisKey, Dummy.site))
   it should "select"      in check(select(Dummy.ephemerisKey, Dummy.site))
-  it should "selectRange" in check(selectRange(Dummy.ephemerisKey, Dummy.site, InstantMicros.Min, InstantMicros.Max))
+  it should "selectRange" in check(selectRange(Dummy.ephemerisKey, Dummy.site, Timestamp.Min, Timestamp.Max))
 
   it should "selectNextUserSuppliedKey" in check(selectNextUserSuppliedKey)
 
@@ -22,8 +22,8 @@ class EphemerisCheck extends Check {
   it should "selectMeta"  in check(selectMeta(Dummy.ephemerisKey, Dummy.site))
 
   it should "selectTimes"  in check(selectTimes(Dummy.ephemerisKey, Dummy.site))
-  it should "selectTimeLE" in check(selectTimeLE(Dummy.ephemerisKey, Dummy.site, InstantMicros.Max))
-  it should "selectTimeGE" in check(selectTimeGE(Dummy.ephemerisKey, Dummy.site, InstantMicros.Min))
+  it should "selectTimeLE" in check(selectTimeLE(Dummy.ephemerisKey, Dummy.site, Timestamp.Max))
+  it should "selectTimeGE" in check(selectTimeGE(Dummy.ephemerisKey, Dummy.site, Timestamp.Min))
 
   it should "selectKeys"  in check(selectKeys(Dummy.site))
 }

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
@@ -54,7 +54,7 @@ object EphemerisParser {
       instantUTC(
         genYMD(monthMMM, hyphen) named "yyyy-MMM-dd",
         genLocalTime(colon)
-      ).map(InstantMicros.truncate)
+      ).flatMap(InstantMicros.clip(_).fold(err[InstantMicros]("date out of range"))(ok))
 
     val element: Parser[Ephemeris.Element] =
       for {

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
@@ -5,7 +5,7 @@ package gem
 package horizons
 
 import gem.math.{ Angle, Ephemeris, EphemerisCoordinates, Offset }
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import atto.ParseResult
 import atto.ParseResult.Done
@@ -50,11 +50,11 @@ object EphemerisParser {
       Angle.fromMicroarcseconds(µas)
     }
 
-    val utc: Parser[InstantMicros] =
+    val utc: Parser[Timestamp] =
       instantUTC(
         genYMD(monthMMM, hyphen) named "yyyy-MMM-dd",
         genLocalTime(colon)
-      ).flatMap(InstantMicros.clip(_).fold(err[InstantMicros]("date out of range"))(ok))
+      ).flatMap(Timestamp.fromInstant(_).fold(err[Timestamp]("date out of range"))(ok))
 
     val element: Parser[Ephemeris.Element] =
       for {

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -96,9 +96,9 @@ final case class HorizonsEphemerisUpdater(
 
 
   private def updateIfNecessary(
-                                 ctx:  Context,
-                                 time: Timestamp,
-                                 sem:  Semester
+    ctx:  Context,
+    time: Timestamp,
+    sem:  Semester
   ): ConnectionIO[Unit] =
 
     if (ctx.isUpToDateFor(sem)) recordUpdateCheck(ctx, time)
@@ -119,9 +119,9 @@ final case class HorizonsEphemerisUpdater(
 
 
   private def doUpdate(
-                        ctx:  Context,
-                        time: Timestamp,
-                        sem:  Semester
+    ctx:  Context,
+    time: Timestamp,
+    sem:  Semester
   ): ConnectionIO[Unit] = {
 
     // Need to update both meta and ephemeris.  First the new
@@ -170,11 +170,12 @@ object HorizonsEphemerisUpdater {
     * @param soln current horizons solution reference from JPL, if any
     */
   final case class Context(
-                            key:  EphemerisKey.Horizons,
-                            site: Site,
-                            meta: Option[EphemerisMeta],
-                            rnge: Option[(Timestamp, Timestamp)],
-                            soln: Option[HorizonsSolutionRef]) {
+    key:  EphemerisKey.Horizons,
+    site: Site,
+    meta: Option[EphemerisMeta],
+    rnge: Option[(Timestamp, Timestamp)],
+    soln: Option[HorizonsSolutionRef]
+  ) {
 
     /** Determines whether the existing ephemeris, if any, covers the given
       * semester.

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -8,7 +8,7 @@ package horizons
 import gem.dao.EphemerisDao
 import gem.enum.Site
 import gem.math.Ephemeris
-import gem.util.InstantMicros
+import gem.util.Timestamp
 import gem.horizons.EphemerisCompression._
 
 import cats._
@@ -63,7 +63,7 @@ final case class HorizonsEphemerisUpdater(
 
     for {
 
-      time <- InstantMicros.now
+      time <- Timestamp.now
       sem  <- Semester.current(site)
       ctx  <- context(key, site)
       _    <- updateIfNecessary(ctx, time, sem).transact(xa)
@@ -96,9 +96,9 @@ final case class HorizonsEphemerisUpdater(
 
 
   private def updateIfNecessary(
-    ctx:  Context,
-    time: InstantMicros,
-    sem:  Semester
+                                 ctx:  Context,
+                                 time: Timestamp,
+                                 sem:  Semester
   ): ConnectionIO[Unit] =
 
     if (ctx.isUpToDateFor(sem)) recordUpdateCheck(ctx, time)
@@ -107,7 +107,7 @@ final case class HorizonsEphemerisUpdater(
 
   private def recordUpdateCheck(
     ctx:  Context,
-    time: InstantMicros
+    time: Timestamp
   ): ConnectionIO[Unit] =
 
     for {
@@ -119,9 +119,9 @@ final case class HorizonsEphemerisUpdater(
 
 
   private def doUpdate(
-    ctx:  Context,
-    time: InstantMicros,
-    sem:  Semester
+                        ctx:  Context,
+                        time: Timestamp,
+                        sem:  Semester
   ): ConnectionIO[Unit] = {
 
     // Need to update both meta and ephemeris.  First the new
@@ -170,11 +170,11 @@ object HorizonsEphemerisUpdater {
     * @param soln current horizons solution reference from JPL, if any
     */
   final case class Context(
-    key:  EphemerisKey.Horizons,
-    site: Site,
-    meta: Option[EphemerisMeta],
-    rnge: Option[(InstantMicros, InstantMicros)],
-    soln: Option[HorizonsSolutionRef]) {
+                            key:  EphemerisKey.Horizons,
+                            site: Site,
+                            meta: Option[EphemerisMeta],
+                            rnge: Option[(Timestamp, Timestamp)],
+                            soln: Option[HorizonsSolutionRef]) {
 
     /** Determines whether the existing ephemeris, if any, covers the given
       * semester.

--- a/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
@@ -19,7 +19,6 @@ import fs2.io.file
 
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption.{ CREATE, TRUNCATE_EXISTING }
-import java.time.Instant
 
 /** Provides support for exporting ephemeris data to files that may be read by
   * the TCS.
@@ -47,13 +46,10 @@ final class TcsEphemerisExport[M[_]: Effect](xa: Transactor[M]) {
     *              exactly this time it will be the last element (otherwise,
     *              the element immediately following this time is included)
     */
-  def exportOne(path: Path, key: EphemerisKey, site: Site, start: Instant, end: Instant): M[Unit] = {
-    val s = InstantMicros.truncate(start)
-    val e = InstantMicros.truncate(end)
-
+  def exportOne(path: Path, key: EphemerisKey, site: Site, start: InstantMicros, end: InstantMicros): M[Unit] = {
     import EphemerisDao.{ bracketRange, streamRange }
 
-    Stream.eval(bracketRange(key, site, s, e))
+    Stream.eval(bracketRange(key, site, start, end))
       .flatMap { case (s, e) => streamRange(key, site, s, e) }
       .transact(xa)
       .take(RowLimit.toLong)
@@ -75,7 +71,7 @@ final class TcsEphemerisExport[M[_]: Effect](xa: Transactor[M]) {
     * @param start start time for the ephemeris data, inclusive
     * @param end   end time for the ephemeirs day, exclusive
     */
-  def exportAll(dir: Path, site: Site, start: Instant, end: Instant): M[Unit] = {
+  def exportAll(dir: Path, site: Site, start: InstantMicros, end: InstantMicros): M[Unit] = {
     def name(k: EphemerisKey): String =
       s"${k.format}.eph"
 

--- a/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
@@ -6,7 +6,7 @@ package gem.horizons.tcs
 import gem.EphemerisKey
 import gem.dao.EphemerisDao
 import gem.enum.Site
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.effect._
 import cats.implicits._
@@ -46,7 +46,7 @@ final class TcsEphemerisExport[M[_]: Effect](xa: Transactor[M]) {
     *              exactly this time it will be the last element (otherwise,
     *              the element immediately following this time is included)
     */
-  def exportOne(path: Path, key: EphemerisKey, site: Site, start: InstantMicros, end: InstantMicros): M[Unit] = {
+  def exportOne(path: Path, key: EphemerisKey, site: Site, start: Timestamp, end: Timestamp): M[Unit] = {
     import EphemerisDao.{ bracketRange, streamRange }
 
     Stream.eval(bracketRange(key, site, start, end))
@@ -71,7 +71,7 @@ final class TcsEphemerisExport[M[_]: Effect](xa: Transactor[M]) {
     * @param start start time for the ephemeris data, inclusive
     * @param end   end time for the ephemeirs day, exclusive
     */
-  def exportAll(dir: Path, site: Site, start: InstantMicros, end: InstantMicros): M[Unit] = {
+  def exportAll(dir: Path, site: Site, start: Timestamp, end: Timestamp): M[Unit] = {
     def name(k: EphemerisKey): String =
       s"${k.format}.eph"
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -37,9 +37,11 @@ final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
     checkParse("borrelly", head, tail)
   }
 
-  private def checkParse(name: String,
-                         head: TreeMap[Timestamp, EphemerisCoordinates],
-                         tail: TreeMap[Timestamp, EphemerisCoordinates]): org.scalatest.Assertion = {
+  private def checkParse(
+    name: String,
+    head: TreeMap[Timestamp, EphemerisCoordinates],
+    tail: TreeMap[Timestamp, EphemerisCoordinates]
+  ): org.scalatest.Assertion = {
 
     val e = EphemerisParser.parse(load(name)).option.getOrElse(Ephemeris.Empty)
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -66,7 +66,7 @@ final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
   }
 
   test("Must handle errors") {
-    val z = InstantMicros.ofEpochMilli(0L) -> EphemerisCoordinates.Zero
+    val z = InstantMicros.Min -> EphemerisCoordinates.Zero
     val s = stream("borrelly-error")
              .through(EphemerisParser.elements[IO])
              .handleErrorWith(_ => Stream(z))

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -4,7 +4,7 @@
 package gem.horizons
 
 import gem.math.{ Ephemeris, EphemerisCoordinates }
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.effect.IO
 import cats.tests.CatsSuite
@@ -38,8 +38,8 @@ final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
   }
 
   private def checkParse(name: String,
-               head: TreeMap[InstantMicros, EphemerisCoordinates],
-               tail: TreeMap[InstantMicros, EphemerisCoordinates]): org.scalatest.Assertion = {
+                         head: TreeMap[Timestamp, EphemerisCoordinates],
+                         tail: TreeMap[Timestamp, EphemerisCoordinates]): org.scalatest.Assertion = {
 
     val e = EphemerisParser.parse(load(name)).option.getOrElse(Ephemeris.Empty)
 
@@ -66,7 +66,7 @@ final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
   }
 
   test("Must handle errors") {
-    val z = InstantMicros.Min -> EphemerisCoordinates.Zero
+    val z = Timestamp.Min -> EphemerisCoordinates.Zero
     val s = stream("borrelly-error")
              .through(EphemerisParser.elements[IO])
              .handleErrorWith(_ => Stream(z))

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
@@ -4,7 +4,7 @@
 package gem.horizons
 
 import gem.math.{ Angle, Coordinates, EphemerisCoordinates, Offset }
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.effect.IO
 import fs2.Stream
@@ -21,8 +21,8 @@ trait EphemerisTestSupport {
   val TimeFormat: DateTimeFormatter =
     DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss.SSS")
 
-  def time(s: String): InstantMicros =
-    InstantMicros.unsafeClip(LocalDateTime.parse(s, TimeFormat).toInstant(ZoneOffset.UTC))
+  def time(s: String): Timestamp =
+    Timestamp.unsafeFromInstant(LocalDateTime.parse(s, TimeFormat).toInstant(ZoneOffset.UTC))
 
   def coords(s: String): Coordinates =
     Coordinates.Optics.fromHmsDms.getOption(s).getOrElse(Coordinates.Zero)
@@ -39,7 +39,7 @@ trait EphemerisTestSupport {
   def ephCoords(c: String, p: String, q: String): EphemerisCoordinates =
     EphemerisCoordinates(coords(c), Offset(offsetp(p), offsetq(q)))
 
-  def eph(elems: (String, (String, String, String))*): TreeMap[InstantMicros, EphemerisCoordinates] =
+  def eph(elems: (String, (String, String, String))*): TreeMap[Timestamp, EphemerisCoordinates] =
     TreeMap(elems.map { case (i, (c, p, q)) => time(i) -> ephCoords(c, p, q) }: _*)
 
   def inputStream(n: String): InputStream =

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
@@ -22,7 +22,7 @@ trait EphemerisTestSupport {
     DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss.SSS")
 
   def time(s: String): InstantMicros =
-    InstantMicros.truncate(LocalDateTime.parse(s, TimeFormat).toInstant(ZoneOffset.UTC))
+    InstantMicros.unsafeClip(LocalDateTime.parse(s, TimeFormat).toInstant(ZoneOffset.UTC))
 
   def coords(s: String): Coordinates =
     Coordinates.Optics.fromHmsDms.getOption(s).getOrElse(Coordinates.Zero)

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
@@ -9,7 +9,7 @@ import gem.math.Ephemeris
 import gem.syntax.time._
 import gem.test.RespectIncludeTags
 import gem.test.Tags._
-import gem.util.InstantMicros
+import gem.util.Timestamp
 
 import cats.implicits._
 import cats.tests.CatsSuite
@@ -161,8 +161,8 @@ object HorizonsEphemerisQuerySpec extends EphemerisTestSupport {
   private val start = LocalDateTime.of(2017, Month.AUGUST, 15, 1, 0).toInstant(UTC)
   private val end   = LocalDateTime.of(2017, Month.AUGUST, 15, 2, 0).toInstant(UTC)
 
-  private val startM      = InstantMicros.unsafeClip(start)
-  private val endM        = InstantMicros.unsafeClip(end)
+  private val startM      = Timestamp.unsafeFromInstant(start)
+  private val endM        = Timestamp.unsafeFromInstant(end)
 
   private val startCoords = ephCoords("17:21:29.110300 -21:55:46.509000", "-2.85225", "-1.61124")
   private val endCoords   = ephCoords("17:21:28.904000 -21:55:48.103000", "-2.87880", "-1.58756")

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
@@ -161,8 +161,8 @@ object HorizonsEphemerisQuerySpec extends EphemerisTestSupport {
   private val start = LocalDateTime.of(2017, Month.AUGUST, 15, 1, 0).toInstant(UTC)
   private val end   = LocalDateTime.of(2017, Month.AUGUST, 15, 2, 0).toInstant(UTC)
 
-  private val startM      = InstantMicros.truncate(start)
-  private val endM        = InstantMicros.truncate(end)
+  private val startM      = InstantMicros.unsafeClip(start)
+  private val endM        = InstantMicros.unsafeClip(end)
 
   private val startCoords = ephCoords("17:21:29.110300 -21:55:46.509000", "-2.85225", "-1.61124")
   private val endCoords   = ephCoords("17:21:28.904000 -21:55:48.103000", "-2.87880", "-1.58756")

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -8,7 +8,7 @@ import gem.enum.{ GcalArc, Site }
 import gem.config.GcalConfig.GcalArcs
 import gem.config.GmosConfig._
 import gem.math._
-import gem.util.{ Enumerated, InstantMicros }
+import gem.util.{ Enumerated, Timestamp }
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.auto._
@@ -83,9 +83,9 @@ package object json {
       ns <- c.downField("nanoseconds").as[Long]
     } yield Instant.ofEpochSecond(ss, ns)
 
-  // Instant micros
-  implicit val InstantMicrosEncoder: Encoder[InstantMicros] = Encoder[Instant].contramap(_.toInstant)
-  implicit val InstantMicrosDecoder: Decoder[InstantMicros] = Decoder[Instant].map(InstantMicros.truncate)
+  // Timestamp
+  implicit val TimestampEncoder: Encoder[Timestamp] = Encoder[Instant].contramap(_.toInstant)
+  implicit val TimestampDecoder: Decoder[Timestamp] = Decoder[Instant].map(Timestamp.unsafeFromInstant)
 
   // Enumerated as a tag
   implicit def enumeratedEncoder[A](implicit ev: Enumerated[A]): Encoder[A] = Encoder[String].contramap(ev.tag)


### PR DESCRIPTION
This PR implements issue #190.  Because `Instant` covers a range of dates that is much larger than those supported by the postgres timestamp,  we were able to create times that could not be written to the database or used in queries.   Here I limit the valid range of `Instant`s for creating timestamps to roughly those supported by the database and rename `InstantMicros` to `Timestamp` to reflect the fact that it more closely mirrors the postgres `timestamp` type.

The `Option`-returning API is a bit annoying.  Given that `Instant` is also limited in time range and can throw exceptions when adding milliseconds, etc. I also considered just having `Timestamp` behave like `Instant` with a smaller time range.  That felt wrong but I'm not sure and would welcome feedback.

Also, it occurs to me that the name `Timestamp` is used in a couple of other contexts including the JDBC `Timestamp` so perhaps a different name would be better?
