### PR TITLE
Target Update Proposal

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -5,20 +5,15 @@ package gem
 
 import cats.Eq
 
-import gem.enum.Site
-import gem.math.Ephemeris
+import gem.math.ProperMotion
 
-import monocle.Optional
 import monocle.macros.Lenses
 
 /** A target of observation. */
-@Lenses final case class Target(name: String, track: Track)
+@Lenses final case class Target(name: String, track: Either[EphemerisKey, ProperMotion])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Target {
-
-  val ephemerides: Optional[Target, Map[Site, Ephemeris]] =
-    track composeOptional Track.ephemerides
 
   implicit val EqTarget: Eq[Target] =
     Eq.fromUniversalEquals

--- a/modules/core/shared/src/main/scala/gem/UserTarget.scala
+++ b/modules/core/shared/src/main/scala/gem/UserTarget.scala
@@ -5,10 +5,8 @@ package gem
 
 import cats.Eq
 
-import gem.enum.{ Site, UserTargetType }
-import gem.math.Ephemeris
+import gem.enum.UserTargetType
 
-import monocle.Optional
 import monocle.macros.Lenses
 
 
@@ -18,9 +16,6 @@ import monocle.macros.Lenses
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object UserTarget {
-
-  val ephemerides: Optional[UserTarget, Map[Site, Ephemeris]] =
-    target composeOptional Target.ephemerides
 
   implicit val EqUserTarget: Eq[UserTarget] =
     Eq.fromUniversalEquals

--- a/modules/core/shared/src/test/scala/gem/arb/Target.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Target.scala
@@ -4,24 +4,27 @@
 package gem
 package arb
 
+import gem.math.ProperMotion
+
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen._
 
 trait ArbTarget {
 
-  import ArbTrack._
+  import ArbEphemerisKey._
+  import ArbProperMotion._
 
   implicit val arbTarget: Arbitrary[Target] =
     Arbitrary {
       for {
         n <- Gen.alphaStr.map(_.take(64))
-        t <- arbitrary[Track]
+        t <- arbitrary[Either[EphemerisKey, ProperMotion]]
       } yield Target(n, t)
     }
 
   implicit val cogTarget: Cogen[Target] =
-    Cogen[(String, Track)].contramap { t =>
+    Cogen[(String, Either[EphemerisKey, ProperMotion])].contramap { t =>
       (t.name, t.track)
     }
 }

--- a/modules/core/shared/src/test/scala/gem/arb/Track.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/Track.scala
@@ -16,7 +16,6 @@ trait ArbTrack {
   import ArbProperMotion._
   import ArbEnumerated._
   import ArbEphemeris._
-  import ArbEphemerisKey._
 
   implicit val arbSidereal: Arbitrary[Track.Sidereal] =
     Arbitrary {
@@ -29,16 +28,13 @@ trait ArbTrack {
   implicit val arbNonsidereal: Arbitrary[Track.Nonsidereal] =
     Arbitrary {
       for {
-        key  <- arbitrary[EphemerisKey]
         eph  <- arbitrary[Ephemeris]
         site <- arbitrary[Site]
-      } yield Nonsidereal(key, Map(site -> eph))
+      } yield Nonsidereal(Map(site -> eph))
     }
 
   implicit val cogNonsidereal: Cogen[Track.Nonsidereal] =
-    Cogen[(EphemerisKey, Map[Site, Ephemeris])].contramap { n =>
-      (n.ephemerisKey, n.ephemerides)
-    }
+    Cogen[Map[Site, Ephemeris]].contramap(_.ephemerides)
 
   implicit val arbTrack: Arbitrary[Track] =
     Arbitrary {

--- a/modules/db/src/main/scala/gem/dao/TrackDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TrackDao.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+
+import gem.enum.Site
+import gem.math.ProperMotion
+import gem.util.Timestamp
+
+
+object TrackDao {
+
+  /** Obtains, loading from the database if necessary, target tracking data.
+    * Enables coordinate queries for a target for the given site and time range.
+    */
+  def select(t: Target, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[Track] =
+    t.track.fold(nonsidereal(_, s, start, end), sidereal)
+
+  private def sidereal(p: ProperMotion): ConnectionIO[Track] =
+    Track.Sidereal(p).pure[ConnectionIO].widen[Track]
+
+  private def nonsidereal(k: EphemerisKey, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[Track] =
+    for {
+      range <- EphemerisDao.bracketRange(k, s, start, end)
+      eph   <- EphemerisDao.selectRange(k, s, range._1, range._2)
+    } yield Track.Nonsidereal(Map(s -> eph))
+
+}

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -22,24 +22,19 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       genObservation
     }
 
-  // TODO: We will need to figure out what to do about ephemeris.  It isn't
-  // stored when you write a Target with TargetDao, or loaded when you read one.
-  def stripEphemeris(ut: UserTarget): UserTarget =
-    UserTarget.ephemerides.set(Map.empty)(ut)
-
-  property("UserTargetDao should roundtrip-ish") {
+  property("UserTargetDao should roundtrip") {
     forAll { (obs: Observation[StaticConfig, Step[DynamicConfig]], ut: UserTarget) =>
       val oid = Observation.Id(pid, Observation.Index.unsafeFromInt(1))
 
       val utʹ = withProgram {
         for {
           _  <- ObservationDao.insert(oid, obs)
-          id <- UserTargetDao.insert(stripEphemeris(ut), oid)
+          id <- UserTargetDao.insert(ut, oid)
           uʹ <- UserTargetDao.select(id)
         } yield uʹ
       }
 
-      Some(stripEphemeris(ut)) shouldEqual utʹ
+      Some(ut) shouldEqual utʹ
     }
   }
 }

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -90,7 +90,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     }
 
     val target: Target =
-      Target("untitled", Track.Sidereal(ProperMotion.const(Coordinates.Zero)))
+      Target("untitled", Right(ProperMotion.const(Coordinates.Zero)))
 
   }
 

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -4,7 +4,7 @@
 package gem
 
 import cats.data.OneAnd
-import gem.enum.{ GcalArc, Site }
+import gem.enum.GcalArc
 import gem.config.GcalConfig.GcalArcs
 import gem.config.GmosConfig._
 import gem.math._
@@ -133,18 +133,18 @@ package object json {
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   implicit val EphemerisDecoder: Decoder[Ephemeris] = Decoder[List[Ephemeris.Element]].map(ls => Ephemeris(ls: _*))
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val NonsiderealEncoder: Encoder[Track.Nonsidereal] = n =>
-    Json.obj(
-      "key"         -> n.ephemerisKey.asJson,
-      "ephemerides" -> n.ephemerides.toList.asJson
-    )
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val NonsiderealDecoder: Decoder[Track.Nonsidereal] = c =>
-    for {
-      k <- c.downField("key").as[EphemerisKey]
-      e <- c.downField("ephemerides").as[List[(Site, Ephemeris)]].map(_.toMap)
-    } yield Track.Nonsidereal(k, e)
+//  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+//  implicit val NonsiderealEncoder: Encoder[Track.Nonsidereal] = n =>
+//    Json.obj(
+//      "key"         -> n.ephemerisKey.asJson,
+//      "ephemerides" -> n.ephemerides.toList.asJson
+//    )
+//  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+//  implicit val NonsiderealDecoder: Decoder[Track.Nonsidereal] = c =>
+//    for {
+//      k <- c.downField("key").as[EphemerisKey]
+//      e <- c.downField("ephemerides").as[List[(Site, Ephemeris)]].map(_.toMap)
+//    } yield Track.Nonsidereal(k, e)
 
   // Offset.P maps to a signed angle in arcseconds
   implicit val OffsetPEncoder: Encoder[Offset.P] = AngleAsSignedArcsecondsEncoder.contramap(_.toAngle)

--- a/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
+++ b/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
@@ -3,7 +3,7 @@
 
 package gem.ocs2
 
-import gem.{ EphemerisKey, Target, Track }
+import gem.{ EphemerisKey, Target }
 import gem.math._
 import gem.ocs2.Decoders._
 import gem.ocs2.pio._
@@ -119,7 +119,7 @@ object TargetDecodersTest {
   }
 
   val SiderealTarget: Target =
-    Target("Example", Track.Sidereal(SiderealProperMotion))
+    Target("Example", Right(SiderealProperMotion))
 
   val NonsiderealNode: Elem =
     <paramset name="target">
@@ -132,7 +132,7 @@ object TargetDecodersTest {
     </paramset>
 
   val NonsiderealTarget: Target =
-    Target("Oumuamua", Track.Nonsidereal(EphemerisKey.Comet("C/1937 P1"), Map.empty))
+    Target("Oumuamua", Left(EphemerisKey.Comet("C/1937 P1")))
 
   // Deletes all instances of params and paramsets that have the given name.
   private def delete(name: String, e: Elem): Elem = {


### PR DESCRIPTION
This PR isn't ready to be merged (👎) so I'm not looking for approval in that sense.  It fleshes out the latest idea in #176 a bit though and I thought it would be good to get some feedback before continuing.

Highlights (?):

* Changes `Target` to replace `Track` with an `Either[EphemerisKey, ProperMotion]`.  I'm not sure about this idea but at this point having an additional layer wrapping the key or proper motion didn't seem right either.

* In doing so, it mangles the `TargetDao` a bit.  I feel bad about that.  It can probably be done correctly with the `TaggedCoproduct` idea that was there?

* Adds `TrackDao` to have a single API for getting a `Track` for coordinate lookups.  The sidereal case is trivial there of course and the nonsidereal case just delegates to `EphemerisDao`.