### PR TITLE
Put User Targets in Observation

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -19,6 +19,7 @@ import cats.implicits._
  */
 final case class Observation[+S, +D](
   title: String,
+  targets: TargetEnvironment,
   staticConfig: S,
   steps: List[D])
 

--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -5,20 +5,15 @@ package gem
 
 import cats.Eq
 
-import gem.enum.Site
-import gem.math.Ephemeris
+import gem.math.ProperMotion
 
-import monocle.Optional
 import monocle.macros.Lenses
 
 /** A target of observation. */
-@Lenses final case class Target(name: String, track: Track)
+@Lenses final case class Target(name: String, track: Either[EphemerisKey, ProperMotion])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Target {
-
-  val ephemerides: Optional[Target, Map[Site, Ephemeris]] =
-    track composeOptional Track.ephemerides
 
   implicit val EqTarget: Eq[Target] =
     Eq.fromUniversalEquals

--- a/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
+++ b/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
@@ -17,6 +17,9 @@ import monocle.macros.Lenses
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object TargetEnvironment {
 
+  val empty: TargetEnvironment =
+    TargetEnvironment(Set.empty)
+
   implicit val EqTargetEnvironment: Eq[TargetEnvironment] =
     Eq.fromUniversalEquals
 

--- a/modules/core/shared/src/main/scala/gem/UserTarget.scala
+++ b/modules/core/shared/src/main/scala/gem/UserTarget.scala
@@ -5,10 +5,8 @@ package gem
 
 import cats.Eq
 
-import gem.enum.{ Site, UserTargetType }
-import gem.math.Ephemeris
+import gem.enum.UserTargetType
 
-import monocle.Optional
 import monocle.macros.Lenses
 
 
@@ -18,9 +16,6 @@ import monocle.macros.Lenses
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object UserTarget {
-
-  val ephemerides: Optional[UserTarget, Map[Site, Ephemeris]] =
-    target composeOptional Target.ephemerides
 
   implicit val EqUserTarget: Eq[UserTarget] =
     Eq.fromUniversalEquals

--- a/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
@@ -54,7 +54,7 @@ object Ephemeris {
   type Element = (Timestamp, EphemerisCoordinates)
 
   /** The empty ephemeris. */
-  val Empty: Ephemeris = apply()
+  val empty: Ephemeris = apply()
 
   /** Construct an ephemeris from a sequence of literal elements. */
   def apply(es: Element*): Ephemeris =
@@ -67,7 +67,7 @@ object Ephemeris {
   /** Ephemerides form a monoid, using `++` as the combining operation. */
   implicit val MonoidEphemeris: Monoid[Ephemeris] =
     new Monoid[Ephemeris] {
-      val empty: Ephemeris = Empty
+      val empty: Ephemeris = Ephemeris.empty
       def combine(a: Ephemeris, b: Ephemeris) = a ++ b
     }
 

--- a/modules/core/shared/src/main/scala/gem/util/Timestamp.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Timestamp.scala
@@ -115,7 +115,7 @@ object Timestamp {
       unsafeFromInstant(Instant.now())
     }
 
-  /** Creates an InstantMicro representing the current time using milliseconds
+  /** Creates a Timestamp representing the current time using milliseconds
     * from the Java time epoch.
     *
     * @group Constructors

--- a/modules/core/shared/src/test/scala/gem/arb/ArbEphemeris.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbEphemeris.scala
@@ -36,7 +36,7 @@ trait ArbEphemeris {
   implicit val arbEphemeris: Arbitrary[Ephemeris] =
     Arbitrary {
       for {
-        len <- choose(0, 100)
+        len <- choose(0, 10)
         es  <- listOfN(len, arbitrary[Element])
       } yield Ephemeris(es: _*)
     }

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTarget.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTarget.scala
@@ -4,24 +4,27 @@
 package gem
 package arb
 
+import gem.math.ProperMotion
+
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen._
 
 trait ArbTarget {
 
-  import ArbTrack._
+  import ArbEphemerisKey._
+  import ArbProperMotion._
 
   implicit val arbTarget: Arbitrary[Target] =
     Arbitrary {
       for {
         n <- Gen.alphaStr.map(_.take(64))
-        t <- arbitrary[Track]
+        t <- arbitrary[Either[EphemerisKey, ProperMotion]]
       } yield Target(n, t)
     }
 
   implicit val cogTarget: Cogen[Target] =
-    Cogen[(String, Track)].contramap { t =>
+    Cogen[(String, Either[EphemerisKey, ProperMotion])].contramap { t =>
       (t.name, t.track)
     }
 }

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTrack.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTrack.scala
@@ -16,7 +16,6 @@ trait ArbTrack {
   import ArbProperMotion._
   import ArbEnumerated._
   import ArbEphemeris._
-  import ArbEphemerisKey._
 
   implicit val arbSidereal: Arbitrary[Track.Sidereal] =
     Arbitrary {
@@ -29,16 +28,13 @@ trait ArbTrack {
   implicit val arbNonsidereal: Arbitrary[Track.Nonsidereal] =
     Arbitrary {
       for {
-        key  <- arbitrary[EphemerisKey]
         eph  <- arbitrary[Ephemeris]
         site <- arbitrary[Site]
-      } yield Nonsidereal(key, Map(site -> eph))
+      } yield Nonsidereal(Map(site -> eph))
     }
 
   implicit val cogNonsidereal: Cogen[Track.Nonsidereal] =
-    Cogen[(EphemerisKey, Map[Site, Ephemeris])].contramap { n =>
-      (n.ephemerisKey, n.ephemerides)
-    }
+    Cogen[Map[Site, Ephemeris]].contramap(_.ephemerides)
 
   implicit val arbTrack: Arbitrary[Track] =
     Arbitrary {

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+// At the moment, TargetEnvironment just wraps user targets but it will grow to
+// encompass the science asterism and guide targets as well.
+
+object TargetEnvironmentDao {
+
+  def insert(oid: Observation.Id, e: TargetEnvironment): ConnectionIO[Unit] =
+    e.userTargets.toList.traverse(UserTargetDao.insert(_, oid)).void
+
+  def select(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
+    UserTargetDao.selectAll(oid: Observation.Id).map { lst =>
+      TargetEnvironment(lst.unzip._2.toSet)
+    }
+
+}

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -15,7 +15,7 @@ import doobie.implicits._
 object TargetEnvironmentDao {
 
   def insert(oid: Observation.Id, e: TargetEnvironment): ConnectionIO[Unit] =
-    e.userTargets.toList.traverse(UserTargetDao.insert(_, oid)).void
+    e.userTargets.toList.traverse(UserTargetDao.insert(oid, _)).void
 
   def select(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
     UserTargetDao.selectAll(oid: Observation.Id).map { lst =>

--- a/modules/db/src/main/scala/gem/dao/TrackDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TrackDao.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+
+import gem.enum.Site
+import gem.math.ProperMotion
+import gem.util.Timestamp
+
+
+object TrackDao {
+
+  /** Obtains, loading from the database if necessary, target tracking data.
+    * Enables coordinate queries for a target for the given site and time range.
+    */
+  def select(t: Target, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[Track] =
+    t.track.fold(nonsidereal(_, s, start, end), sidereal)
+
+  private def sidereal(p: ProperMotion): ConnectionIO[Track] =
+    Track.Sidereal(p).pure[ConnectionIO].widen[Track]
+
+  private def nonsidereal(k: EphemerisKey, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[Track] =
+    for {
+      range <- EphemerisDao.bracketRange(k, s, start, end)
+      eph   <- EphemerisDao.selectRange(k, s, range._1, range._2)
+    } yield Track.Nonsidereal(Map(s -> eph))
+
+}

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -24,7 +24,7 @@ object UserTargetDao {
   import EnumeratedMeta._
   import ObservationIdMeta._
 
-  def insert(userTarget: UserTarget, oid: Observation.Id): ConnectionIO[Int] =
+  def insert( oid: Observation.Id, userTarget: UserTarget): ConnectionIO[Int] =
     for {
       tid <- TargetDao.insert(userTarget.target)
       uid <- Statements.insert(tid, userTarget.targetType, oid).withUniqueGeneratedKeys[Int]("id")

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -24,7 +24,7 @@ object UserTargetDao {
   import EnumeratedMeta._
   import ObservationIdMeta._
 
-  def insert( oid: Observation.Id, userTarget: UserTarget): ConnectionIO[Int] =
+  def insert(oid: Observation.Id, userTarget: UserTarget): ConnectionIO[Int] =
     for {
       tid <- TargetDao.insert(userTarget.target)
       uid <- Statements.insert(tid, userTarget.targetType, oid).withUniqueGeneratedKeys[Int]("id")

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -43,7 +43,7 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("EphemerisDao should return empty ephmeris if the key is not found") {
     forAll { (ks: KS, m: EphemerisMap) =>
       val e = execTest(m - ks, EphemerisDao.selectAll(ks.key, ks.site))
-      e shouldEqual Ephemeris.Empty
+      e shouldEqual Ephemeris.empty
     }
   }
 
@@ -65,7 +65,7 @@ class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("EphemerisDao should delete by key") {
     forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
       val eʹ = execTest(m + (ks -> e), EphemerisDao.delete(ks.key, ks.site) *> EphemerisDao.selectAll(ks.key, ks.site))
-      eʹ shouldEqual Ephemeris.Empty
+      eʹ shouldEqual Ephemeris.empty
     }
   }
 

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -5,7 +5,8 @@ package gem.dao
 
 import cats.implicits._
 import doobie.implicits._
-import gem.Observation
+import gem.{ Observation, Step }
+import gem.config.{ DynamicConfig, StaticConfig }
 import org.scalatest._
 import org.scalatest.prop._
 import org.scalatest.Matchers._
@@ -31,7 +32,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("ObservationDao should select flat observations") {
     val oid = Observation.Id(pid, One)
 
-    forAll(genObservation) { obsIn =>
+    forAll { (obsIn: Observation[StaticConfig, Step[DynamicConfig]]) =>
       val obsOut = withProgram {
         for {
           _ <- ObservationDao.insert(oid, obsIn)
@@ -46,7 +47,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("ObservationDao should select static observations") {
     val oid = Observation.Id(pid, One)
 
-    forAll(genObservation) { obsIn =>
+    forAll { (obsIn: Observation[StaticConfig, Step[DynamicConfig]]) =>
       val obsOut = withProgram {
         for {
           _ <- ObservationDao.insert(oid, obsIn)
@@ -61,7 +62,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("ObservationDao should roundtrip complete observations") {
     val oid = Observation.Id(pid, One)
 
-    forAll(genObservation) { obsIn =>
+    forAll { (obsIn: Observation[StaticConfig, Step[DynamicConfig]]) =>
       val obsOut = withProgram {
         for {
           _ <- ObservationDao.insert(oid, obsIn)

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -95,7 +95,7 @@ class SmartGcalSpec extends FlatSpec with Matchers with DaoTest {
   private def doTest[A](test: ConnectionIO[A]): A =
     withProgram {
       for {
-        _ <- ObservationDao.insert(oid, Observation("SmartGcalSpec Obs", StaticConfig.F2.Default, List.empty[Step[DynamicConfig]]))
+        _ <- ObservationDao.insert(oid, Observation("SmartGcalSpec Obs", TargetEnvironment.empty, StaticConfig.F2.Default, List.empty[Step[DynamicConfig]]))
         a <- test
       } yield a
     }

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -29,6 +29,7 @@ class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
       TreeMap(idx ->
         Observation(
           "Untitled Obs",
+          TargetEnvironment.empty,
           StaticConfig.F2(MosPreImaging.IsNotMosPreImaging),
           List(
             Step.Science(

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -22,24 +22,19 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       genObservation
     }
 
-  // TODO: We will need to figure out what to do about ephemeris.  It isn't
-  // stored when you write a Target with TargetDao, or loaded when you read one.
-  def stripEphemeris(ut: UserTarget): UserTarget =
-    UserTarget.ephemerides.set(Map.empty)(ut)
-
-  property("UserTargetDao should roundtrip-ish") {
+  property("UserTargetDao should roundtrip") {
     forAll { (obs: Observation[StaticConfig, Step[DynamicConfig]], ut: UserTarget) =>
       val oid = Observation.Id(pid, Observation.Index.unsafeFromInt(1))
 
       val utʹ = withProgram {
         for {
           _  <- ObservationDao.insert(oid, obs)
-          id <- UserTargetDao.insert(stripEphemeris(ut), oid)
+          id <- UserTargetDao.insert(ut, oid)
           uʹ <- UserTargetDao.select(id)
         } yield uʹ
       }
 
-      Some(stripEphemeris(ut)) shouldEqual utʹ
+      Some(ut) shouldEqual utʹ
     }
   }
 }

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -21,7 +21,7 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
       val utʹ = withProgram {
         for {
           _  <- ObservationDao.insert(oid, obs)
-          id <- UserTargetDao.insert(ut, oid)
+          id <- UserTargetDao.insert(oid, ut)
           uʹ <- UserTargetDao.select(id)
         } yield uʹ
       }

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -10,17 +10,9 @@ import org.scalatest._
 import org.scalatest.prop._
 import org.scalatest.Matchers._
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary._
-
 
 class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   import gem.arb.ArbUserTarget._
-
-  implicit val arbObservation: Arbitrary[Observation[StaticConfig, Step[DynamicConfig]]] =
-    Arbitrary {
-      genObservation
-    }
 
   property("UserTargetDao should roundtrip") {
     forAll { (obs: Observation[StaticConfig, Step[DynamicConfig]], ut: UserTarget) =>

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -49,7 +49,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val gcalShutter      = GcalShutter.Open
     val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, 0)
     val user             = User[Nothing]("", "", "", "", false, Map.empty)
-    val observation      = Observation[StaticConfig, Nothing]("", StaticConfig.F2.Default, Nil)
+    val observation      = Observation[StaticConfig, Nothing]("", TargetEnvironment.empty, StaticConfig.F2.Default, Nil)
     val program          = Program(programId, "", TreeMap.empty)
     val f2SmartGcalKey   = DynamicConfig.F2.Default.key
     val gcalLampType     = GcalLampType.Arc

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -90,7 +90,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     }
 
     val target: Target =
-      Target("untitled", Track.Sidereal(ProperMotion.const(Coordinates.Zero)))
+      Target("untitled", Right(ProperMotion.const(Coordinates.Zero)))
 
   }
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -43,7 +43,7 @@ final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
     tail: TreeMap[Timestamp, EphemerisCoordinates]
   ): org.scalatest.Assertion = {
 
-    val e = EphemerisParser.parse(load(name)).option.getOrElse(Ephemeris.Empty)
+    val e = EphemerisParser.parse(load(name)).option.getOrElse(Ephemeris.empty)
 
     // This works but the error message isn't helpful when it fails.  There
     // should be a way to combine shouldEqual assertions ...

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -4,7 +4,7 @@
 package gem
 
 import cats.data.OneAnd
-import gem.enum.{ GcalArc, Site }
+import gem.enum.GcalArc
 import gem.config.GcalConfig.GcalArcs
 import gem.config.GmosConfig._
 import gem.math._
@@ -145,18 +145,18 @@ package object json {
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   implicit val EphemerisDecoder: Decoder[Ephemeris] = Decoder[List[Ephemeris.Element]].map(ls => Ephemeris(ls: _*))
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val NonsiderealEncoder: Encoder[Track.Nonsidereal] = n =>
-    Json.obj(
-      "key"         -> n.ephemerisKey.asJson,
-      "ephemerides" -> n.ephemerides.toList.asJson
-    )
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val NonsiderealDecoder: Decoder[Track.Nonsidereal] = c =>
-    for {
-      k <- c.downField("key").as[EphemerisKey]
-      e <- c.downField("ephemerides").as[List[(Site, Ephemeris)]].map(_.toMap)
-    } yield Track.Nonsidereal(k, e)
+//  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+//  implicit val NonsiderealEncoder: Encoder[Track.Nonsidereal] = n =>
+//    Json.obj(
+//      "key"         -> n.ephemerisKey.asJson,
+//      "ephemerides" -> n.ephemerides.toList.asJson
+//    )
+//  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+//  implicit val NonsiderealDecoder: Decoder[Track.Nonsidereal] = c =>
+//    for {
+//      k <- c.downField("key").as[EphemerisKey]
+//      e <- c.downField("ephemerides").as[List[(Site, Ephemeris)]].map(_.toMap)
+//    } yield Track.Nonsidereal(k, e)
 
   // Offset.P maps to a signed angle in arcseconds
   implicit val OffsetPEncoder: Encoder[Offset.P] = AngleAsSignedArcsecondsEncoder.contramap(_.toAngle)

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -139,25 +139,6 @@ package object json {
       px <- c.downField("parallax")       .as[Option[Angle]](Decoder.decodeOption(AngleAsSignedMilliarcsecondsDecoder))
     } yield ProperMotion(bc, ep, pv, rv, px)
 
-  // Ephemeris as a List[Ephemeris.Element]
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val EphemerisEncoder: Encoder[Ephemeris] = Encoder[List[Ephemeris.Element]].contramap(_.toMap.toList)
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val EphemerisDecoder: Decoder[Ephemeris] = Decoder[List[Ephemeris.Element]].map(ls => Ephemeris(ls: _*))
-
-//  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-//  implicit val NonsiderealEncoder: Encoder[Track.Nonsidereal] = n =>
-//    Json.obj(
-//      "key"         -> n.ephemerisKey.asJson,
-//      "ephemerides" -> n.ephemerides.toList.asJson
-//    )
-//  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-//  implicit val NonsiderealDecoder: Decoder[Track.Nonsidereal] = c =>
-//    for {
-//      k <- c.downField("key").as[EphemerisKey]
-//      e <- c.downField("ephemerides").as[List[(Site, Ephemeris)]].map(_.toMap)
-//    } yield Track.Nonsidereal(k, e)
-
   // Offset.P maps to a signed angle in arcseconds
   implicit val OffsetPEncoder: Encoder[Offset.P] = AngleAsSignedArcsecondsEncoder.contramap(_.toAngle)
   implicit val OffsetPDecoder: Decoder[Offset.P] = AngleAsSignedArcsecondsDecoder.map(Offset.P.apply)

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package gem.ocs2
+package gem
+package ocs2
 
 import cats.implicits._
 import gem.{ Dataset, EphemerisKey, Observation, Program, Step, Target }
@@ -157,7 +158,7 @@ object Decoders {
         t  <- (n \! "data" \? "#title").decodeOrZero[String]
         st <- (n \! "sequence"        ).decode[StaticConfig](StaticDecoder)
         sq <- (n \! "sequence"        ).decode[List[Step[DynamicConfig]]](SequenceDecoder)
-      } yield Observation(t, st, sq)
+      } yield Observation(t, TargetEnvironment.empty, st, sq)
     }
 
   implicit val ProgramDecoder: PioDecoder[Program[Observation[StaticConfig, Step[DynamicConfig]]]] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -7,7 +7,7 @@ import Decoders._
 
 import cats.effect.IO, cats.implicits._
 
-import gem.{ Dataset, Observation, Program, Step, Target }
+import gem.{ Dataset, Observation, Program, Step }
 import gem.config.{ StaticConfig, DynamicConfig }
 import gem.ocs2.pio.{ PioDecoder, PioError }
 import gem.ocs2.pio.PioError._
@@ -46,10 +46,10 @@ final class ImportServer(ocsHost: String) {
   private def badRequest(id: String, idType: String): IO[Response[IO]] =
     BadRequest(s"Could not parse $idType id '$id'")
 
-  private def fetchDecodeAndStore[A](id: String, f: (A, List[Dataset], List[Target]) => IO[Unit])(implicit ev: PioDecoder[A]): IO[Response[IO]] = {
+  private def fetchDecodeAndStore[A](id: String, f: (A, List[Dataset]) => IO[Unit])(implicit ev: PioDecoder[A]): IO[Response[IO]] = {
     def decodeAndStore(xml: Node): IO[Response[IO]] =
-      PioDecoder[(A, List[Dataset], List[Target])].decode(xml).leftMap(_.toResponse(id)).traverse { case (a, ds, ts) =>
-        f(a, ds, ts).as(Ok(s"Imported $id"))
+      PioDecoder[(A, List[Dataset])].decode(xml).leftMap(_.toResponse(id)).traverse { case (a, ds) =>
+        f(a, ds).as(Ok(s"Imported $id"))
       }.flatMap(_.merge)
 
     // TODO: add timeout
@@ -71,7 +71,7 @@ final class ImportServer(ocsHost: String) {
 
   def importObservation(obsIdStr: String): IO[Response[IO]] = {
     val checkId = Observation.Id.fromString(obsIdStr) toRight badRequest(obsIdStr, "observation")
-    checkId.map { oid => fetchDecodeAndStore[Obs](obsIdStr, (a, ds, _) => Importer.importObservation(oid, a, ds)) }.merge
+    checkId.map { oid => fetchDecodeAndStore[Obs](obsIdStr, (a, ds) => Importer.importObservation(oid, a, ds)) }.merge
   }
 
   def importProgram(pidStr: String): IO[Response[IO]] = {

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -4,7 +4,7 @@
 package gem.ocs2
 
 import gem.dao._
-import gem.{ Dataset, Log, Observation, Program, Step, Target, User }
+import gem.{ Dataset, Log, Observation, Program, Step, User }
 import gem.config.{ StaticConfig, DynamicConfig }
 
 import cats.effect.IO
@@ -46,7 +46,7 @@ object Importer extends DoobieClient {
       } yield ()
   }
 
-  def writeProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset], ts: List[Target]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
+  def writeProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
     val rmProgram: ConnectionIO[Unit] =
       sql"DELETE FROM program WHERE program_id = ${p.id}".update.run.void
 
@@ -59,9 +59,6 @@ object Importer extends DoobieClient {
         _ <- p.observations.toList.traverse { case (i,o) =>
                val oid = Observation.Id(p.id, i)
                writeObservation(oid, o, dsMap(oid))(u, l)
-             }
-        _ <- l.log(u, s"insert targets from ${p.id}") {
-               ts.traverse_(TargetDao.insert)
              }
       } yield ()
   }
@@ -78,6 +75,6 @@ object Importer extends DoobieClient {
   def importObservation(oid: Observation.Id, o: Observation[StaticConfig, Step[DynamicConfig]], ds: List[Dataset]): IO[Unit] =
     doImport(writeObservation(oid, o, ds))
 
-  def importProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset], ts: List[Target]): IO[Unit] =
-    doImport(writeProgram(p, ds, ts))
+  def importProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset]): IO[Unit] =
+    doImport(writeProgram(p, ds))
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -117,6 +117,13 @@ object Parsers {
   val offsetQ: PioParse[Offset.Q] =
     arcsec.map(Offset.Q.apply)
 
+  val userTargetType: PioParse[UserTargetType] = enum(
+    "blindOffset" -> UserTargetType.BlindOffset,
+    "offAxis"     -> UserTargetType.OffAxis,
+    "tuningStar"  -> UserTargetType.TuningStar,
+    "other"       -> UserTargetType.Other
+  )
+
   object Calibration {
 
     val lamp: PioParse[GcalLamp] = {

--- a/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
+++ b/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
@@ -3,7 +3,7 @@
 
 package gem.ocs2
 
-import gem.{ EphemerisKey, Target, Track }
+import gem.{ EphemerisKey, Target }
 import gem.math._
 import gem.ocs2.Decoders._
 import gem.ocs2.pio._
@@ -119,7 +119,7 @@ object TargetDecodersTest {
   }
 
   val SiderealTarget: Target =
-    Target("Example", Track.Sidereal(SiderealProperMotion))
+    Target("Example", Right(SiderealProperMotion))
 
   val NonsiderealNode: Elem =
     <paramset name="target">
@@ -132,7 +132,7 @@ object TargetDecodersTest {
     </paramset>
 
   val NonsiderealTarget: Target =
-    Target("Oumuamua", Track.Nonsidereal(EphemerisKey.Comet("C/1937 P1"), Map.empty))
+    Target("Oumuamua", Left(EphemerisKey.Comet("C/1937 P1")))
 
   // Deletes all instances of params and paramsets that have the given name.
   private def delete(name: String, e: Elem): Elem = {

--- a/modules/sql/src/main/resources/db/migration/V041__UserTarget_Trigger.sql
+++ b/modules/sql/src/main/resources/db/migration/V041__UserTarget_Trigger.sql
@@ -1,0 +1,19 @@
+--
+-- This migration adds a trigger to cleanup the corresponding target when a
+-- user target is deleted.
+--
+
+-- User targets are automatically deleted when the observation in which they
+-- are contained is deleted.  There is no reference from target back to
+-- user target though, so a deleted user target would leave garbage in the
+-- target table were it not for this trigger.
+
+CREATE FUNCTION delete_user_target_reference() RETURNS trigger AS $delete_user_target_reference$
+  BEGIN
+    DELETE FROM target where id = OLD.target_id;
+    RETURN OLD;
+  END;
+$delete_user_target_reference$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_user_target_reference AFTER DELETE ON user_target
+  FOR EACH ROW EXECUTE PROCEDURE delete_user_target_reference();


### PR DESCRIPTION
This is the first step in associating targets with observations.  It adds a `targets` field in `Observation` that references a `TargetEnvironment` which at this point contains only `user_targets`.  Corresponding updates to the `ObservationDao` and OCS2 import are included.  As discussed in #195 and #176, `Target` loses a direct reference to a `Track` but keeps all the information necessary to create a `Track` for determining its location at a given time.  Unlinking targets and tracking information simplifies test cases considerably and makes logical comparisons of targets (and the observations that contain them) possible.

Subsequent phases will add the asterism and guide targets.