### PR TITLE
Order UserTarget

### DIFF
--- a/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
@@ -8,7 +8,8 @@ import gem.parser.EphemerisKeyParsers
 import gem.syntax.parser._
 import gem.syntax.string._
 
-import cats.{ Eq, Show }
+import cats.{ Order, Show }
+import cats.implicits._
 import monocle.macros.Lenses
 
 /** Ephemeris data lookup key which uniquely identifies a non-sidreal object in
@@ -132,6 +133,6 @@ object EphemerisKey {
   implicit val ShowEphemerisKey: Show[EphemerisKey] =
     Show.fromToString
 
-  implicit val EqualEphemerisKey: Eq[EphemerisKey] =
-    Eq.fromUniversalEquals
+  implicit val OrderEphemerisKey: Order[EphemerisKey] =
+    Order.by(_.format)
 }

--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -17,7 +17,7 @@ import monocle.macros.Lenses
 object Target {
 
   /** A target order based on tracking information.  For sidereal targets this
-    * roughly means by base coordinate without applying propermotion.  For
+    * roughly means by base coordinate without applying proper motion.  For
     * non-sidereal this means by `EphemerisKey`.
     */
   implicit val TargetTrackOrder: Order[Target] =

--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -16,8 +16,14 @@ import monocle.macros.Lenses
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Target {
 
-  /** Targets ordered by name first and then tracking information. */
-  implicit val TargetOrder: Order[Target] =
+  implicit val EqTarget: Eq[Target] =
+    Eq.fromUniversalEquals
+
+  /** Targets ordered by name first and then tracking information.
+    *
+    * Not implicit.
+    */
+  val TargetNameOrder: Order[Target] =
     Order.by(t => (t.name, t.track))
 
   /** A target order based on tracking information.  For sidereal targets this

--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -3,7 +3,8 @@
 
 package gem
 
-import cats.Eq
+import cats._
+import cats.implicits._
 
 import gem.math.ProperMotion
 
@@ -15,6 +16,16 @@ import monocle.macros.Lenses
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Target {
 
-  implicit val EqTarget: Eq[Target] =
-    Eq.fromUniversalEquals
+  /** Targets ordered by name first and then tracking information. */
+  implicit val TargetOrder: Order[Target] =
+    Order.by(t => (t.name, t.track))
+
+  /** A target order based on tracking information.  For sidereal targets this
+    * roughly means by base coordinate without applying propermotion.  For
+    * non-sidereal this means by `EphemerisKey`.
+    *
+    * Not implicit.
+    */
+  val TargetTrackOrder: Order[Target] =
+    Order.by(t => (t.track, t.name))
 }

--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -16,22 +16,18 @@ import monocle.macros.Lenses
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Target {
 
-  implicit val EqTarget: Eq[Target] =
-    Eq.fromUniversalEquals
+  /** A target order based on tracking information.  For sidereal targets this
+    * roughly means by base coordinate without applying propermotion.  For
+    * non-sidereal this means by `EphemerisKey`.
+    */
+  implicit val TargetTrackOrder: Order[Target] =
+    Order.by(t => (t.track, t.name))
 
   /** Targets ordered by name first and then tracking information.
     *
-    * Not implicit.
+    * Not implicit. The implicit target order is track then name.
     */
   val TargetNameOrder: Order[Target] =
     Order.by(t => (t.name, t.track))
 
-  /** A target order based on tracking information.  For sidereal targets this
-    * roughly means by base coordinate without applying propermotion.  For
-    * non-sidereal this means by `EphemerisKey`.
-    *
-    * Not implicit.
-    */
-  val TargetTrackOrder: Order[Target] =
-    Order.by(t => (t.track, t.name))
 }

--- a/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
+++ b/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
@@ -6,19 +6,21 @@ package gem
 import cats.Eq
 import monocle.macros.Lenses
 
+import scala.collection.immutable.TreeSet
+
 /** Collection of targets associated with an observation.
   */
 @Lenses final case class TargetEnvironment(
   /* asterism, */
   /* guide stars, */
-  userTargets: Set[UserTarget]
+  userTargets: TreeSet[UserTarget]
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object TargetEnvironment {
 
   val empty: TargetEnvironment =
-    TargetEnvironment(Set.empty)
+    TargetEnvironment(TreeSet.empty)
 
   implicit val EqTargetEnvironment: Eq[TargetEnvironment] =
     Eq.fromUniversalEquals

--- a/modules/core/shared/src/main/scala/gem/UserTarget.scala
+++ b/modules/core/shared/src/main/scala/gem/UserTarget.scala
@@ -3,7 +3,8 @@
 
 package gem
 
-import cats.Eq
+import cats._
+import cats.implicits._
 
 import gem.enum.UserTargetType
 
@@ -17,6 +18,9 @@ import monocle.macros.Lenses
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object UserTarget {
 
-  implicit val EqUserTarget: Eq[UserTarget] =
-    Eq.fromUniversalEquals
+  implicit val OrderUserTarget: Order[UserTarget] =
+    Order.by(u => (u.target, u.targetType))
+
+  implicit val OrderingUserTarget: Ordering[UserTarget] =
+    OrderUserTarget.toOrdering
 }

--- a/modules/core/shared/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Angle.scala
@@ -194,7 +194,7 @@ object Angle {
   val AngleOrder: Order[Angle] =
     Order.by(_.toMicroarcseconds)
 
-  /** Sorts Angle by signed microarcseconds, so [-180, 180).  Not implicit. */
+  /** Sorts Angle by signed angle, so [-180, 180).  Not implicit. */
   val SignedAngleOrder: Order[Angle] =
     Order.by(_.toSignedMicroarcseconds)
 

--- a/modules/core/shared/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Angle.scala
@@ -4,7 +4,7 @@
 package gem
 package math
 
-import cats.{ Eq, Show }
+import cats.{ Eq, Order, Show }
 import cats.kernel.CommutativeGroup
 import cats.instances.long._
 import cats.syntax.eq._
@@ -189,6 +189,14 @@ object Angle {
   /** Angles are equal if their magnitudes are equal. */
   implicit val AngleEqual: Eq[Angle] =
     Eq.fromUniversalEquals
+
+  /** Sorts Angle by magnitude [0, 360) degrees. Not implicit. */
+  val AngleOrder: Order[Angle] =
+    Order.by(_.toMicroarcseconds)
+
+  /** Sorts Angle by signed microarcseconds, so [-180, 180).  Not implicit. */
+  val SignedAngleOrder: Order[Angle] =
+    Order.by(_.toSignedMicroarcseconds)
 
   // This works for both DMS and HMS so let's just do it once.
   protected[math] def toMicrosexigesimal(micros: Long): (Int, Int, Int, Int, Int) = {

--- a/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
@@ -104,8 +104,8 @@ object Coordinates {
     Coordinates(RA.fromRadians(ra), Declination.unsafeFromRadians(dec))
 
   /** @group Typeclass Instances */
-  implicit val CoordinatesEqual: Eq[Coordinates] =
-    Eq.fromUniversalEquals
+  implicit val CoordinatesOrder: Order[Coordinates] =
+    Order.by(c => (c.ra, c.dec))
 
   /** @group Typeclass Instances. */
   implicit val ShowCoordinates: Show[Coordinates] =

--- a/modules/core/shared/src/main/scala/gem/math/Epoch.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Epoch.scala
@@ -4,7 +4,7 @@
 package gem
 package math
 
-import cats.{ Eq, Show }
+import cats.{ Order, Show }
 import cats.implicits._
 import gem.parser.EpochParsers
 import gem.syntax.parser._
@@ -112,8 +112,8 @@ object Epoch {
     def toJulianDay(dt: LocalDateTime): Double =
       JulianDate.ofLocalDateTime(dt).dayNumber.toDouble
 
-    implicit val SchemeEq: Eq[Scheme] =
-      Eq.fromUniversalEquals
+    implicit val SchemeOrder: Order[Scheme] =
+      Order.by(s => (s.prefix, s.yearBasis, s.julianBasis, s.lengthOfYear))
 
     implicit val SchemeShow: Show[Scheme] =
       Show.fromToString
@@ -146,8 +146,8 @@ object Epoch {
   def unsafeFromString(s: String): Epoch =
     parse(s).getOrElse(sys.error(s"invalid epoch: $s"))
 
-  implicit val EpochEq: Eq[Epoch] =
-    Eq.fromUniversalEquals
+  implicit val EpochOrder: Order[Epoch] =
+    Order.by(e => (e.scheme, e.toMilliyears))
 
   implicit val EpochShow: Show[Epoch] =
     Show.fromToString

--- a/modules/core/shared/src/main/scala/gem/math/Offset.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Offset.scala
@@ -4,7 +4,7 @@
 package gem
 package math
 
-import cats.{ Eq, Show }
+import cats.{ Order, Show }
 import cats.kernel.CommutativeGroup
 import cats.implicits._
 
@@ -42,9 +42,9 @@ object Offset {
   implicit val ShowOffset: Show[Offset] =
     Show.fromToString
 
-  /** Offsets are equal if their components are pairwise equal. */
-  implicit val EqualOffset: Eq[Offset] =
-    Eq.by(o => (o.p, o.q))
+  /** Offsets are ordered by p, then q. */
+  implicit val OrderOffset: Order[Offset] =
+    Order.by(o => (o.p, o.q))
 
   /** P component of an angular offset.. */
   final case class P(toAngle: Angle) {
@@ -79,9 +79,9 @@ object Offset {
     implicit val ShowP: Show[P] =
       Show.fromToString
 
-    /** P components are equal if their angles are equal. */
-    implicit val EqualP: Eq[P] =
-      Eq.by(_.toAngle)
+    /** P components are by signed microarcseconds. */
+    implicit val OrderP: Order[P] =
+      Order.by(_.toAngle.toSignedMicroarcseconds)
 
   }
 
@@ -118,9 +118,9 @@ object Offset {
     implicit val ShowQ: Show[Q] =
       Show.fromToString
 
-    /** Q components are equal if their angles are equal. */
-    implicit val EqualQ: Eq[Q] =
-      Eq.by(_.toAngle)
+    /** Q components are ordered by signed microarcseconds. */
+    implicit val OrderQ: Order[Q] =
+      Order.by(_.toAngle.toSignedMicroarcseconds)
 
   }
 

--- a/modules/core/shared/src/main/scala/gem/math/Offset.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Offset.scala
@@ -81,7 +81,7 @@ object Offset {
 
     /** P components are by signed angle. */
     implicit val OrderP: Order[P] =
-      Order.by(_.toAngle.toSignedMicroarcseconds)
+      Angle.SignedAngleOrder.contramap(_.toAngle)
 
   }
 
@@ -120,7 +120,7 @@ object Offset {
 
     /** Q components are ordered by signed angle. */
     implicit val OrderQ: Order[Q] =
-      Order.by(_.toAngle.toSignedMicroarcseconds)
+      Angle.SignedAngleOrder.contramap(_.toAngle)
 
   }
 

--- a/modules/core/shared/src/main/scala/gem/math/Offset.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Offset.scala
@@ -79,7 +79,7 @@ object Offset {
     implicit val ShowP: Show[P] =
       Show.fromToString
 
-    /** P components are by signed microarcseconds. */
+    /** P components are by signed angle. */
     implicit val OrderP: Order[P] =
       Order.by(_.toAngle.toSignedMicroarcseconds)
 
@@ -118,7 +118,7 @@ object Offset {
     implicit val ShowQ: Show[Q] =
       Show.fromToString
 
-    /** Q components are ordered by signed microarcseconds. */
+    /** Q components are ordered by signed angle. */
     implicit val OrderQ: Order[Q] =
       Order.by(_.toAngle.toSignedMicroarcseconds)
 

--- a/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
@@ -175,14 +175,27 @@ object ProperMotion {
     implicit val MonoidOrder: Monoid[Order[ProperMotion]] =
       Order.whenEqualMonoid[ProperMotion]
 
+    implicit val AngleOrder: Order[Angle] =
+      Angle.SignedAngleOrder
+
     def order[A: Order](f: ProperMotion => A): Order[ProperMotion] =
       Order.by(f)
+
+    // This could be done with:
+    //
+    //   Order.by(p => (p.baseCoordinates, p.epoch, ...))
+    //
+    // but that would always perform comparisons for all the fields (and all
+    // their contained fields down to the leaves of the tree) all of the time.
+    // The Monoid approach on the other hand will stop at the first difference.
+    // This is premature optimization perhaps but it seems like it might make a
+    // difference when sorting a long list of targets.
 
     order(_.baseCoordinates)  |+|
       order(_.epoch)          |+|
       order(_.properVelocity) |+|
       order(_.radialVelocity) |+|
-      order(_.parallax)(catsKernelStdOrderForOption(Angle.SignedAngleOrder))
+      order(_.parallax)
 
   }
 }

--- a/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
@@ -3,7 +3,7 @@
 
 package gem.math
 
-import cats.Eq
+import cats._
 import cats.implicits._
 import java.time.Instant
 import scala.math.{ sin, cos, hypot, atan2 }
@@ -170,9 +170,21 @@ object ProperMotion {
   }
   // scalastyle:on method.length
 
-  implicit val EqProperMotion: Eq[ProperMotion] =
-    Eq.fromUniversalEquals
+  implicit val OrderProperMotion: Order[ProperMotion] = {
 
+    implicit val MonoidOrder: Monoid[Order[ProperMotion]] =
+      Order.whenEqualMonoid[ProperMotion]
+
+    def order[A: Order](f: ProperMotion => A): Order[ProperMotion] =
+      Order.by(f)
+
+    order(_.baseCoordinates)  |+|
+      order(_.epoch)          |+|
+      order(_.properVelocity) |+|
+      order(_.radialVelocity) |+|
+      order(_.parallax)(catsKernelStdOrderForOption(Angle.SignedAngleOrder))
+
+  }
 }
 
 

--- a/modules/core/shared/src/main/scala/gem/syntax/TreeSet.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/TreeSet.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import scala.collection.immutable.TreeSet
+
+final class TreeSetCompanionOps(val self: TreeSet.type) extends AnyVal {
+
+  def fromList[A: Ordering](lst: List[A]): TreeSet[A] =
+    TreeSet(lst: _*)
+
+}
+
+trait ToTreeSetCompanionOps {
+  implicit def ToTreeSetCompanionOps(c: TreeSet.type): TreeSetCompanionOps =
+    new TreeSetCompanionOps(c)
+}
+
+object treesetcompanion extends ToTreeSetCompanionOps

--- a/modules/core/shared/src/main/scala/gem/syntax/TreeSet.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/TreeSet.scala
@@ -7,6 +7,7 @@ import scala.collection.immutable.TreeSet
 
 final class TreeSetCompanionOps(val self: TreeSet.type) extends AnyVal {
 
+  /** Creates a `TreeSet` from a `List`, provided an `Ordering` is available. */
   def fromList[A: Ordering](lst: List[A]): TreeSet[A] =
     TreeSet(lst: _*)
 

--- a/modules/core/shared/src/main/scala/gem/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/package.scala
@@ -14,4 +14,5 @@ package object syntax {
                 with ToStringOps
                 with ToInstantOps
                 with ToDurationOps
+                with ToTreeSetCompanionOps
 }

--- a/modules/core/shared/src/test/scala/gem/EphemerisKeySpec.scala
+++ b/modules/core/shared/src/test/scala/gem/EphemerisKeySpec.scala
@@ -13,7 +13,7 @@ import cats.tests.CatsSuite
 final class EphemerisKeySpec extends CatsSuite {
 
   // Laws
-  checkAll("EphemerisKey", EqTests[EphemerisKey].eqv)
+  checkAll("EphemerisKey", OrderTests[EphemerisKey].order)
 
   test("Equality must be natural") {
     forAll { (a: EphemerisKey, b: EphemerisKey) =>

--- a/modules/core/shared/src/test/scala/gem/TargetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/TargetSpec.scala
@@ -13,5 +13,6 @@ final class TargetSpec extends CatsSuite {
   import ArbTarget._
 
   // Laws
-  checkAll("Target", EqTests[Target].eqv)
+  checkAll("Target", OrderTests[Target].order)
+  checkAll("TargetTrack", OrderTests[Target](Target.TargetTrackOrder).order)
 }

--- a/modules/core/shared/src/test/scala/gem/TargetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/TargetSpec.scala
@@ -13,6 +13,7 @@ final class TargetSpec extends CatsSuite {
   import ArbTarget._
 
   // Laws
-  checkAll("Target", OrderTests[Target].order)
+  checkAll("Target", EqTests[Target].eqv)
+  checkAll("TargetName", OrderTests[Target](Target.TargetNameOrder).order)
   checkAll("TargetTrack", OrderTests[Target](Target.TargetTrackOrder).order)
 }

--- a/modules/core/shared/src/test/scala/gem/TargetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/TargetSpec.scala
@@ -13,7 +13,6 @@ final class TargetSpec extends CatsSuite {
   import ArbTarget._
 
   // Laws
-  checkAll("Target", EqTests[Target].eqv)
+  checkAll("Target",     OrderTests[Target].order)
   checkAll("TargetName", OrderTests[Target](Target.TargetNameOrder).order)
-  checkAll("TargetTrack", OrderTests[Target](Target.TargetTrackOrder).order)
 }

--- a/modules/core/shared/src/test/scala/gem/UserTargetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/UserTargetSpec.scala
@@ -13,5 +13,5 @@ final class UserTargetSpec extends CatsSuite {
   import ArbUserTarget._
 
   // Laws
-  checkAll("UserTarget", EqTests[UserTarget].eqv)
+  checkAll("UserTarget", OrderTests[UserTarget].order)
 }

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTargetEnvironment.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTargetEnvironment.scala
@@ -4,10 +4,15 @@
 package gem
 package arb
 
+import gem.syntax.treesetcompanion._
+
 import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen._
+
+import scala.collection.immutable.TreeSet
+
 
 trait ArbTargetEnvironment {
 
@@ -18,7 +23,7 @@ trait ArbTargetEnvironment {
       for {
         len <- choose(0, 10)
         uts <- listOfN(len, arbitrary[UserTarget])
-      } yield TargetEnvironment(uts.toSet)
+      } yield TargetEnvironment(TreeSet.fromList(uts))
     }
 
   implicit val cogTargetEnvironment: Cogen[TargetEnvironment] =

--- a/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
@@ -15,6 +15,8 @@ final class AngleSpec extends CatsSuite {
   // Laws
   checkAll("Angle", CommutativeGroupTests[Angle].commutativeGroup)
   checkAll("Angle", EqTests[Angle].eqv)
+  checkAll("Angle", OrderTests[Angle](Angle.AngleOrder).order)
+  checkAll("SignedAngle", OrderTests[Angle](Angle.SignedAngleOrder).order)
 
   test("Equality must be natural") {
     forAll { (a: Angle, b: Angle) =>

--- a/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
@@ -17,7 +17,7 @@ final class CoordinatesSpec extends CatsSuite {
   import ArbAngle._
 
   // Laws
-  checkAll("Coordinates", EqTests[Coordinates].eqv)
+  checkAll("Coordinates", OrderTests[Coordinates].order)
   checkAll("Formats.HmsDms", FormatTests(Coordinates.Optics.fromHmsDms).formatWith(ArbCoordinates.strings))
 
   test("Equality must be natural") {

--- a/modules/core/shared/src/test/scala/gem/math/EpochSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EpochSpec.scala
@@ -15,7 +15,7 @@ final class EpochSpec extends CatsSuite {
   import ArbTime._
 
   // Laws
-  checkAll("Epoch", EqTests[Epoch].eqv)
+  checkAll("Epoch", OrderTests[Epoch].order)
 
   test("Epoch.eq.natural") {
     forAll { (a: Epoch, b: Epoch) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
@@ -14,7 +14,7 @@ final class OffsetPSpec extends CatsSuite {
 
   // Laws
   checkAll("Offset.P", CommutativeGroupTests[Offset.P].commutativeGroup)
-  checkAll("Offset.P", EqTests[Offset.P].eqv)
+  checkAll("Offset.P", OrderTests[Offset.P].order)
 
   test("Equality must be natural") {
     forAll { (a: Offset.P, b: Offset.P) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
@@ -14,7 +14,7 @@ final class OffsetQSpec extends CatsSuite {
 
   // Laws
   checkAll("Offset.Q", CommutativeGroupTests[Offset.Q].commutativeGroup)
-  checkAll("Offset.Q", EqTests[Offset.Q].eqv)
+  checkAll("Offset.Q", OrderTests[Offset.Q].order)
 
   test("Equality must be natural") {
     forAll { (a: Offset.Q, b: Offset.Q) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
@@ -14,7 +14,7 @@ final class OffsetSpec extends CatsSuite {
 
   // Laws
   checkAll("Offset", CommutativeGroupTests[Offset].commutativeGroup)
-  checkAll("Offset", EqTests[Offset].eqv)
+  checkAll("Offset", OrderTests[Offset].order)
 
   test("Equality must be natural") {
     forAll { (a: Offset, b: Offset) =>

--- a/modules/core/shared/src/test/scala/gem/math/ProperMotionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/ProperMotionSpec.scala
@@ -13,7 +13,7 @@ final class ProperMotionSpec extends CatsSuite {
   import ArbProperMotion._
 
   // Laws
-  checkAll("ProperMotion", EqTests[ProperMotion].eqv)
+  checkAll("ProperMotion", OrderTests[ProperMotion].order)
 
   test("ProperMotion.identity") {
     forAll { (pm: ProperMotion) =>

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -4,10 +4,14 @@
 package gem
 package dao
 
+import gem.syntax.treesetcompanion._
 import cats.implicits._
 
 import doobie._
 import doobie.implicits._
+
+import scala.collection.immutable.TreeSet
+
 
 // At the moment, TargetEnvironment just wraps user targets but it will grow to
 // encompass the science asterism and guide targets as well.
@@ -19,7 +23,7 @@ object TargetEnvironmentDao {
 
   def select(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
     UserTargetDao.selectAll(oid: Observation.Id).map { lst =>
-      TargetEnvironment(lst.unzip._2.toSet)
+      TargetEnvironment(TreeSet.fromList(lst.unzip._2))
     }
 
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -14,10 +14,11 @@ import gem.ocs2.pio.{ PioDecoder, PioError, PioPath }
 import gem.ocs2.pio.PioError.ParseError
 import gem.ocs2.pio.PioDecoder.fromParse
 import gem.syntax.string._
+import gem.syntax.treesetcompanion._
 
 import java.time.Instant
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.{ TreeMap, TreeSet }
 
 
 /** `PioDecoder` instances for our model types.
@@ -196,7 +197,7 @@ object Decoders {
         // a <- asterism
         // g <- guideEnvironment
         uts <- validTargets(n \? "&userTargets" \* "&userTarget").decode[UserTarget]
-      } yield TargetEnvironment(uts.toSet)
+      } yield TargetEnvironment(TreeSet.fromList(uts))
     }
   }
 


### PR DESCRIPTION
This PR addresses a comment from @tpolecat in #194:

> If we can define `Order[Target]` we can use `TreeSet` in the `TargetEnvironment` which is a bit more sane. It would also give us a deterministic ordering which might be good. 

To define an `Order[Target]` requires making a few choices.  I'm not sure whether I came down on the right side in every case. 