### PR TITLE
Bulk TargetEnvironment Load

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -26,26 +26,29 @@ final case class Observation[+S, +D](
 object Observation {
 
   /** A positive, non-zero integer for use in ids. */
-  sealed abstract case class Index(toInt: Int) {
+  sealed abstract case class Index(toShort: Short) {
     def format: String =
-      s"$toInt"
+      s"$toShort"
   }
 
   object Index {
-    def fromInt(i: Int): Option[Index] =
+    val One: Index =
+      unsafeFromShort(1)
+
+    def fromShort(i: Short): Option[Index] =
       (i > 0) option new Index(i) {}
 
-    def unsafeFromInt(i: Int): Index =
-      fromInt(i).getOrElse(sys.error(s"Negative index: $i"))
+    def unsafeFromShort(i: Short): Index =
+      fromShort(i).getOrElse(sys.error(s"Negative index: $i"))
 
     def fromString(s: String): Option[Index] =
-      s.parseIntOption.filter(_ > 0).map(new Index(_) {})
+      s.parseShortOption.filter(_ > 0).map(new Index(_) {})
 
     def unsafeFromString(s: String): Index =
       fromString(s).getOrElse(sys.error(s"Malformed observation index: '$s'"))
 
     implicit val OrderIndex: Order[Index] =
-      Order.by(_.toInt)
+      Order.by(_.toShort)
 
     implicit val OrderingIndex: scala.math.Ordering[Index] =
       OrderIndex.toOrdering

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -109,7 +109,7 @@ trait Arbitraries extends gem.config.Arbitraries  {
   def genObservationMap(limit: Int): Gen[TreeMap[Observation.Index, Observation[StaticConfig, Step[DynamicConfig]]]] =
     for {
       count   <- Gen.choose(0, limit)
-      obsIdxs <- Gen.listOfN(count, Gen.posNum[Int]).map(_.distinct.map(Observation.Index.unsafeFromInt))
+      obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Observation.Index.unsafeFromShort))
       obsList <- obsIdxs.traverse(_ => arbitrary[Observation[StaticConfig, Step[DynamicConfig]]])
     } yield TreeMap(obsIdxs.zip(obsList): _*)
 }

--- a/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
@@ -16,12 +16,12 @@ trait ArbObservation {
     Arbitrary {
       for {
         pid <- arbitrary[ProgramId]
-        num <- choose(1, 100)
-      } yield Observation.Id(pid, Observation.Index.unsafeFromInt(num))
+        num <- choose[Short](1, 100)
+      } yield Observation.Id(pid, Observation.Index.unsafeFromShort(num))
     }
 
   implicit val cogObservationIdex: Cogen[Observation.Index] =
-    Cogen[Int].contramap(_.toInt)
+    Cogen[Short].contramap(_.toShort)
 
   implicit val cogObservationId: Cogen[Observation.Id] =
     Cogen[(ProgramId, Observation.Index)].contramap(oid => (oid.pid, oid.index))

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -4,13 +4,10 @@
 package gem
 package dao
 
-import gem.syntax.treesetcompanion._
 import cats.implicits._
 
 import doobie._
 import doobie.implicits._
-
-import scala.collection.immutable.TreeSet
 
 
 // At the moment, TargetEnvironment just wraps user targets but it will grow to
@@ -21,12 +18,9 @@ object TargetEnvironmentDao {
   def insert(oid: Observation.Id, e: TargetEnvironment): ConnectionIO[Unit] =
     e.userTargets.toList.traverse(UserTargetDao.insert(oid, _)).void
 
-  private def toTargetEnvironment(lst: List[(Int, UserTarget)]): TargetEnvironment =
-    TargetEnvironment(TreeSet.fromList(lst.unzip._2))
-
   def selectObs(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
-    UserTargetDao.selectObs(oid).map(toTargetEnvironment)
+    UserTargetDao.selectObs(oid).map(TargetEnvironment(_))
 
   def selectProg(pid: Program.Id): ConnectionIO[Map[Observation.Id, TargetEnvironment]] =
-    UserTargetDao.selectProg(pid).map(_.mapValues(toTargetEnvironment))
+    UserTargetDao.selectProg(pid).map(_.mapValues(TargetEnvironment(_)))
 }

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -21,9 +21,12 @@ object TargetEnvironmentDao {
   def insert(oid: Observation.Id, e: TargetEnvironment): ConnectionIO[Unit] =
     e.userTargets.toList.traverse(UserTargetDao.insert(oid, _)).void
 
-  def select(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
-    UserTargetDao.selectAll(oid: Observation.Id).map { lst =>
-      TargetEnvironment(TreeSet.fromList(lst.unzip._2))
-    }
+  private def toTargetEnvironment(lst: List[(Int, UserTarget)]): TargetEnvironment =
+    TargetEnvironment(TreeSet.fromList(lst.unzip._2))
 
+  def selectObs(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
+    UserTargetDao.selectObs(oid).map(toTargetEnvironment)
+
+  def selectProg(pid: Program.Id): ConnectionIO[Map[Observation.Id, TargetEnvironment]] =
+    UserTargetDao.selectProg(pid).map(_.mapValues(toTargetEnvironment))
 }

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -21,6 +21,6 @@ object TargetEnvironmentDao {
   def selectObs(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
     UserTargetDao.selectObs(oid).map(TargetEnvironment(_))
 
-  def selectProg(pid: Program.Id): ConnectionIO[Map[Observation.Id, TargetEnvironment]] =
+  def selectProg(pid: Program.Id): ConnectionIO[Map[Observation.Index, TargetEnvironment]] =
     UserTargetDao.selectProg(pid).map(_.mapValues(TargetEnvironment(_)))
 }

--- a/modules/db/src/main/scala/gem/dao/meta/ObservationIndexMeta.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ObservationIndexMeta.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.Observation
+
+trait ObservationIndexMeta {
+
+  // Observation.Index has a DISTINCT type due to its check constraint so we
+  // need a fine-grained mapping here to satisfy the query checker.
+  implicit val ObservationIndexMeta: Meta[Observation.Index] =
+    Distinct.short("id_index").xmap(Observation.Index.unsafeFromShort, _.toShort)
+
+}
+object ObservationIndexMeta extends ObservationIndexMeta
+

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -26,11 +26,8 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
     }
   }
 
-  val One: Observation.Index =
-    Observation.Index.unsafeFromInt(1)
-
   property("ObservationDao should select flat observations") {
-    val oid = Observation.Id(pid, One)
+    val oid = Observation.Id(pid, Observation.Index.One)
 
     forAll { (obsIn: Observation[StaticConfig, Step[DynamicConfig]]) =>
       val obsOut = withProgram {
@@ -45,7 +42,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should select static observations") {
-    val oid = Observation.Id(pid, One)
+    val oid = Observation.Id(pid, Observation.Index.One)
 
     forAll { (obsIn: Observation[StaticConfig, Step[DynamicConfig]]) =>
       val obsOut = withProgram {
@@ -60,7 +57,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should roundtrip complete observations") {
-    val oid = Observation.Id(pid, One)
+    val oid = Observation.Id(pid, Observation.Index.One)
 
     forAll { (obsIn: Observation[StaticConfig, Step[DynamicConfig]]) =>
       val obsOut = withProgram {

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -90,7 +90,7 @@ class SmartGcalSpec extends FlatSpec with Matchers with DaoTest {
     ss.values.toList shouldEqual lookup(m).map(Step.Gcal(f2, _))
   }
 
-  private val oid = Observation.Id(pid, Observation.Index.unsafeFromInt(1))
+  private val oid = Observation.Id(pid, Observation.Index.One)
 
   private def doTest[A](test: ConnectionIO[A]): A =
     withProgram {

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -19,7 +19,7 @@ class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
 
   "StepDao" should "serialize telescope configurations properly" in {
 
-    val idx  = Observation.Index.unsafeFromInt(1)
+    val idx  = Observation.Index.One
 
     // We specifically want to test round-tripping of telescope offsets.
     val pid  = Program.Id.unsafeFromString("GS-1234A-Q-1")

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -16,7 +16,7 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
 
   property("UserTargetDao should roundtrip") {
     forAll { (obs: Observation[StaticConfig, Step[DynamicConfig]], ut: UserTarget) =>
-      val oid = Observation.Id(pid, Observation.Index.unsafeFromInt(1))
+      val oid = Observation.Id(pid, Observation.Index.One)
 
       val utʹ = withProgram {
         for {

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -51,17 +51,15 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   property("UserTargetDao should bulk select program") {
     forAll(genObservationMap(10)) { m =>
 
-      val obsList = m.toList.map { case (i, o) =>
-        (Observation.Id(pid, i), o)
-      }
+      val obsList = m.toList
 
-      val expected = obsList.map { case (oid, obs) =>
-        oid -> obs.targets.userTargets
+      val expected = obsList.map { case (oi, obs) =>
+        oi -> obs.targets.userTargets
       }.filter(_._2.nonEmpty).toMap
 
       val actual = withProgram {
         for {
-          _   <- obsList.traverse_((ObservationDao.insert _).tupled)
+          _   <- obsList.traverse_ { case (oi, obs) => ObservationDao.insert(Observation.Id(pid, oi), obs) }
           uts <- UserTargetDao.selectProg(pid)
         } yield uts
       }

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -39,7 +39,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val programType      = ProgramType.C
     val dailyProgramId   = Program.Id.Daily(site, DailyProgramType.ENG, LocalDate.now())
     val scienceProgramId = Program.Id.Science(site, semester, programType, 0)
-    val observationId    = Observation.Id(programId, Observation.Index.unsafeFromInt(1))
+    val observationId    = Observation.Id(programId, Observation.Index.One)
     val datasetLabel     = Dataset.Label(observationId, 0)
     val dataset          = Dataset(datasetLabel, "", instant)
     val eventType        = EventType.Abort

--- a/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
@@ -10,8 +10,9 @@ class UserTargetCheck extends Check {
   import UserTargetDao.Statements._
 
   "UserTargetDao.Statements" should
-            "insert"    in check(insert(0, Other, Dummy.observationId))
-  it should "select"    in check(select(0))
-  it should "selectAll" in check(selectAll(Dummy.observationId))
+            "insert"           in check(insert(0, Other, Dummy.observationId))
+  it should "select"           in check(select(0))
+  it should "selectAllForObs"  in check(selectObs(Dummy.observationId))
+  it should "selectAllForProg" in check(selectProg(Dummy.programId))
 
 }

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -61,8 +61,8 @@ package object json {
   val AngleAsSignedMilliarcsecondsDecoder: Decoder[Angle] = Decoder[BigDecimal].map(Angle.fromSignedMilliarcseconds)
 
   // Observation.Index to Integer.
-  implicit val ObservationIndexEncoder: Encoder[Observation.Index] = Encoder[Int].contramap(_.toInt)
-  implicit val ObservationIndexDecoder: Decoder[Observation.Index] = Decoder[Int].map(Observation.Index.unsafeFromInt)
+  implicit val ObservationIndexEncoder: Encoder[Observation.Index] = Encoder[Short].contramap(_.toShort)
+  implicit val ObservationIndexDecoder: Decoder[Observation.Index] = Decoder[Short].map(Observation.Index.unsafeFromShort)
 
   // Wavelength mapping to integral Angstroms.
   implicit val (
@@ -159,9 +159,9 @@ package object json {
 
   // Codec for maps keyed by Observation.Index
   implicit def observationIndexMapEncoder[A: Encoder]: Encoder[TreeMap[Observation.Index, A]] =
-    Encoder[TreeMap[Int, A]].contramap(_.map { case (k, v) => (k.toInt, v) })
+    Encoder[TreeMap[Short, A]].contramap(_.map { case (k, v) => (k.toShort, v) })
   implicit def observationIndexMapDecoder[A: Decoder]: Decoder[TreeMap[Observation.Index, A]] =
-    Decoder[TreeMap[Int, A]].map(_.map { case (k, v) => (Observation.Index.unsafeFromInt(k), v) })
+    Decoder[TreeMap[Short, A]].map(_.map { case (k, v) => (Observation.Index.unsafeFromShort(k), v) })
 
   // GmosCustomRoiEntry as a quad of shorts
   implicit val GmosCustomRoiEntryEncoder: Encoder[GmosCustomRoiEntry] =

--- a/modules/sql/src/main/resources/db/migration/V042__UserTarget_ProgId.sql
+++ b/modules/sql/src/main/resources/db/migration/V042__UserTarget_ProgId.sql
@@ -1,0 +1,11 @@
+--
+-- Adds program_id to user_target to facilitate bulk loading for program.
+--
+
+ALTER TABLE user_target
+  ADD COLUMN program_id        text     NOT NULL REFERENCES program ON DELETE CASCADE,
+  ADD COLUMN observation_index id_index NOT NULL,
+  ADD CONSTRAINT observation_id_check CHECK (((observation_id)::text = (((program_id)::text || '-'::text) || observation_index)));
+
+CREATE INDEX user_target_observation_index ON user_target (program_id, observation_index)
+


### PR DESCRIPTION
This PR addresses a comment from #204:

> I'm a little concerned about the complexity here. Could `TargetEnvironmentDao` have a bulk load method that loads all the environments for a program?

Along the way, I had to make a couple of other changes:

1. `Observation.Index` wrapped an `Int` and yet the corresponding database type was `CREATE DOMAIN id_index AS smallint`.  I'm not sure which is better but they needed to be aligned so I changed the wrapped Scala type to `Short`.

2. The `user_target` table had an `observation_id` but no `program_id`, which would make the query for all matching a `program_id` difficult.  I added redundant columns for this.

