### PR TITLE
remove Dataset.Label.Optics module

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Dataset.scala
+++ b/modules/core/shared/src/main/scala/gem/Dataset.scala
@@ -28,9 +28,10 @@ object Dataset {
    */
   final case class Label(observationId: Observation.Id, index: Int) {
     override def toString =
-      Label.Optics.fromString.productToString(this)
+      Label.fromString.productToString(this)
   }
-  object Label {
+
+  object Label extends LabelOptics {
 
     /**
      * Labels are ordered by observation and index.
@@ -43,22 +44,22 @@ object Dataset {
     implicit val LabelShow: Show[Label] =
       Show.fromToString
 
-    object Optics {
+  }
 
-      /** Format from Strings into Label and back. */
-      val fromString: Format[String, Label] =
-        Format(s =>
-          s.lastIndexOf('-') match {
-            case -1 => None
-            case  n =>
-              val (a, b) = s.splitAt(n)
-              b.drop(1).parseIntOption.filter(_ > 0).flatMap { n =>
-                Observation.Id.fromString(a).map(oid => Dataset.Label(oid, n))
-              }
-          }, l => f"${l.observationId.format}-${l.index}%03d"
-        )
+  trait LabelOptics { this: Label.type =>
 
-    }
+    /** Format from Strings into Label and back. */
+    val fromString: Format[String, Label] =
+      Format(s =>
+        s.lastIndexOf('-') match {
+          case -1 => None
+          case  n =>
+            val (a, b) = s.splitAt(n)
+            b.drop(1).parseIntOption.filter(_ > 0).flatMap { n =>
+              Observation.Id.fromString(a).map(oid => Dataset.Label(oid, n))
+            }
+        }, l => f"${l.observationId.format}-${l.index}%03d"
+      )
 
   }
 

--- a/modules/core/shared/src/test/scala/gem/DatasetLabelSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/DatasetLabelSpec.scala
@@ -15,7 +15,7 @@ final class DatasetLabelSpec extends CatsSuite {
 
   // Laws
   checkAll("DatasetLabel", OrderTests[Dataset.Label].order)
-  checkAll("Optics.fromString", FormatTests(Dataset.Label.Optics.fromString).formatWith(strings))
+  checkAll("Optics.fromString", FormatTests(Dataset.Label.fromString).formatWith(strings))
 
   test("Equality must be natural") {
     forAll { (a: Dataset.Label, b: Dataset.Label) =>

--- a/modules/core/shared/src/test/scala/gem/arb/ArbDataset.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbDataset.scala
@@ -38,7 +38,7 @@ trait ArbDataset {
 
   // Strings that are often parsable as Labels
   val strings: Gen[String] =
-    arbitrary[Dataset.Label].map(Dataset.Label.Optics.fromString.reverseGet).flatMapOneOf(
+    arbitrary[Dataset.Label].map(Dataset.Label.fromString.reverseGet).flatMapOneOf(
       Gen.const,                            // Do nothing, or
       s => arbitrary[String],               // Replace with an arbitrary String, or
       s => Gen.const(s.replace("-0", "-")), // remove a leading zero.

--- a/modules/db/src/main/scala/gem/dao/meta/DatasetLabel.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/DatasetLabel.scala
@@ -11,7 +11,7 @@ trait DatasetLabelMeta {
 
   // Dataset.Label as string
   implicit val DatasetLabelMeta: Meta[Dataset.Label] =
-    Dataset.Label.Optics.fromString.asMeta
+    Dataset.Label.fromString.asMeta
 
 }
 object DatasetLabelMeta extends DatasetLabelMeta

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -109,7 +109,7 @@ object Parsers {
     PioParse(Observation.Id.fromString)
 
   val datasetLabel: PioParse[Dataset.Label] =
-    PioParse(Dataset.Label.Optics.fromString.getOption)
+    PioParse(Dataset.Label.fromString.getOption)
 
   val offsetP: PioParse[Offset.P] =
     arcsec.map(Offset.P.apply)


### PR DESCRIPTION
This removes the nested module in `Dataset.Label` to make it consistent with other code.