### PR TITLE
Update observation reference strategy

### DIFF
--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -25,18 +25,18 @@ object ObservationDao {
    */
   def insert(oid: Observation.Id, o: Observation[StaticConfig, Step[DynamicConfig]]): ConnectionIO[Unit] =
     for {
-      id <- StaticConfigDao.insert(o.staticConfig)
-      _  <- Statements.insert(oid, o, id).run
-      _  <- TargetEnvironmentDao.insert(oid, o.targets)
-      _  <- o.steps.zipWithIndex.traverse { case (s, i) =>
-              StepDao.insert(oid, Location.unsafeMiddle((i + 1) * 100), s)
-            }.void
+      _ <- Statements.insert(oid, o).run
+      _ <- StaticConfigDao.insert(oid, o.staticConfig)
+      _ <- TargetEnvironmentDao.insert(oid, o.targets)
+      _ <- o.steps.zipWithIndex.traverse { case (s, i) =>
+             StepDao.insert(oid, Location.unsafeMiddle((i + 1) * 100), s)
+           }.void
     } yield ()
 
   /** Construct a program to select the specified observation, with the instrument and no steps. */
   def selectFlat(id: Observation.Id): ConnectionIO[Observation[Instrument, Nothing]] =
     for {
-      o <- Statements.selectFlat(id).unique.map(_._1)
+      o <- Statements.selectFlat(id).unique
       t <- TargetEnvironmentDao.selectObs(id)
     } yield o.copy(targets = t)
 
@@ -44,8 +44,7 @@ object ObservationDao {
   def selectStatic(id: Observation.Id): ConnectionIO[Observation[StaticConfig, Nothing]] =
     for {
       obs <- selectFlat(id)
-      tup <- Statements.selectStaticId(id).unique
-      sc  <- StaticConfigDao.select(tup._1, tup._2)
+      sc  <- StaticConfigDao.select(id, obs.staticConfig)
     } yield obs.leftMap(_ => sc)
 
   /** Construct a program to select the specified observation, with static connfig and steps. */
@@ -73,7 +72,7 @@ object ObservationDao {
    */
   def selectAllFlat(pid: Program.Id): ConnectionIO[TreeMap[Observation.Index, Observation[Instrument, Nothing]]] =
     for {
-      m  <- Statements.selectAllFlat(pid).list.map(lst => TreeMap(lst.map { case (i,o,_) => (i,o) }: _*))
+      m  <- Statements.selectAllFlat(pid).list.map(lst => TreeMap(lst: _*))
       ts <- TargetEnvironmentDao.selectProg(pid)
     } yield merge(m, ts)
 
@@ -101,20 +100,17 @@ object ObservationDao {
 
   object Statements {
 
-
-    def insert(oid: Observation.Id, o: Observation[StaticConfig, _], staticId: Int): Update0 =
+    def insert(oid: Observation.Id, o: Observation[StaticConfig, _]): Update0 =
       sql"""
         INSERT INTO observation (observation_id,
                                 program_id,
                                 observation_index,
                                 title,
-                                static_id,
                                 instrument)
               VALUES (${oid},
                       ${oid.pid},
                       ${oid.index},
                       ${o.title},
-                      $staticId,
                       ${o.staticConfig.instrument: Instrument})
       """.update
 
@@ -125,32 +121,23 @@ object ObservationDao {
          WHERE program_id = $pid
       """.query[Observation.Id]
 
-    def selectStaticId(id: Observation.Id): Query0[(Instrument, Int)] =
+    def selectFlat(id: Observation.Id): Query0[Observation[Instrument, Nothing]] =
       sql"""
-        SELECT instrument, static_id
-          FROM observation
-         WHERE observation_id = $id
-      """.query[(Instrument, Int)]
-
-    def selectFlat(id: Observation.Id): Query0[(Observation[Instrument, Nothing], Int)] =
-      sql"""
-        SELECT title, instrument, static_id
+        SELECT title, instrument
           FROM observation
          WHERE observation_id = ${id}
-      """.query[(String, Instrument, Int)]
-        .map { case (t, i, s) =>
-          (Observation(t, TargetEnvironment.empty, i, Nil), s)
-        }
+      """.query[(String, Instrument)]
+        .map { case (t, i) => Observation(t, TargetEnvironment.empty, i, Nil) }
 
-    def selectAllFlat(pid: Program.Id): Query0[(Observation.Index, Observation[Instrument, Nothing], Int)] =
+    def selectAllFlat(pid: Program.Id): Query0[(Observation.Index, Observation[Instrument, Nothing])] =
       sql"""
-        SELECT observation_index, title, instrument, static_id
+        SELECT observation_index, title, instrument
           FROM observation
          WHERE program_id = ${pid}
       ORDER BY observation_index
-      """.query[(Short, String, Instrument, Int)]
-        .map { case (n, t, i, s) =>
-          (Observation.Index.unsafeFromShort(n), Observation(t, TargetEnvironment.empty, i, Nil), s)
+      """.query[(Short, String, Instrument)]
+        .map { case (n, t, i) =>
+          (Observation.Index.unsafeFromShort(n), Observation(t, TargetEnvironment.empty, i, Nil))
         }
 
   }

--- a/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
@@ -7,9 +7,8 @@ package check
 class ObservationCheck extends Check {
   import ObservationDao.Statements._
   "ObservationDao.Statements" should
-            "insert"         in check(insert(Dummy.observationId, Dummy.observation, 0))
+            "insert"         in check(insert(Dummy.observationId, Dummy.observation))
   it should "selectIds"      in check(selectIds(Dummy.programId))
-  it should "selectStaticId" in check(selectStaticId(Dummy.observationId))
   it should "selectFlat"     in check(selectFlat(Dummy.observationId))
   it should "selectAllFlat"  in check(selectAllFlat(Dummy.programId))
 }

--- a/modules/db/src/test/scala/gem/dao/check/StaticCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StaticCheck.scala
@@ -4,7 +4,7 @@
 package gem.dao
 package check
 
-import gem.enum.Instrument.{ Flamingos2, GmosN }
+import gem.enum.Instrument.GmosN
 import gem.config.StaticConfig
 import gem.config.GmosConfig.GmosNodAndShuffle
 
@@ -12,17 +12,15 @@ class StaticCheck extends Check {
   import StaticConfigDao.Statements._
 
   "StaticDao.Statements" should
-            "insertBaseSlice"           in check(insertBaseSlice(Flamingos2))
+            "F2.insert"                 in check(F2.insert(Dummy.observationId, StaticConfig.F2.Default))
+  it should "F2.select"                 in check(F2.select(Dummy.observationId))
 
-  it should "F2.insert"                 in check(F2.insert(0, StaticConfig.F2.Default))
-  it should "F2.select"                 in check(F2.select(0))
-
-  it should "Gmos.insertNorth"          in check(Gmos.insertNorth(0, StaticConfig.GmosNorth.Default))
-  it should "Gmos.insertSouth"          in check(Gmos.insertSouth(0, StaticConfig.GmosSouth.Default))
-  it should "Gmos.insertCustomRoiEntry" in check(Gmos.insertCustomRoiEntry(0, GmosN, Dummy.gmosCustomRoiEntry))
-  it should "Gmos.insertNodAndShuffle"  in check(Gmos.insertNodAndShuffle(0, GmosN, GmosNodAndShuffle.Default))
-  it should "Gmos.selectNorth"          in check(Gmos.selectNorth(0))
-  it should "Gmos.selectSouth"          in check(Gmos.selectSouth(0))
-  it should "Gmos.selectCustomRoiEntry" in check(Gmos.selectCustomRoiEntry(0, GmosN))
-  it should "Gmos.selectNodAndShuffle"  in check(Gmos.selectNodAndShuffle(0, GmosN))
+  it should "Gmos.insertNorth"          in check(Gmos.insertNorth(Dummy.observationId, StaticConfig.GmosNorth.Default))
+  it should "Gmos.insertSouth"          in check(Gmos.insertSouth(Dummy.observationId, StaticConfig.GmosSouth.Default))
+  it should "Gmos.insertCustomRoiEntry" in check(Gmos.insertCustomRoiEntry(Dummy.observationId, GmosN, Dummy.gmosCustomRoiEntry))
+  it should "Gmos.insertNodAndShuffle"  in check(Gmos.insertNodAndShuffle(Dummy.observationId, GmosN, GmosNodAndShuffle.Default))
+  it should "Gmos.selectNorth"          in check(Gmos.selectNorth(Dummy.observationId))
+  it should "Gmos.selectSouth"          in check(Gmos.selectSouth(Dummy.observationId))
+  it should "Gmos.selectCustomRoiEntry" in check(Gmos.selectCustomRoiEntry(Dummy.observationId, GmosN))
+  it should "Gmos.selectNodAndShuffle"  in check(Gmos.selectNodAndShuffle(Dummy.observationId, GmosN))
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -10,7 +10,7 @@ import doobie.postgres.implicits._
 import java.util.logging.{ Level, Logger }
 
 /** Shared support for import applications using Doobie. */
-trait DoobieClient extends ProgramIdMeta with ObservationIdMeta {
+trait DoobieClient extends ProgramIdMeta with ObservationIndexMeta {
 
   val Url  = "jdbc:postgresql:gem"
   val User = "postgres"

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -20,7 +20,7 @@ object Importer extends DoobieClient {
 
   object datasets {
     def lookupStepIds(oid: Observation.Id): ConnectionIO[List[Int]] =
-      sql"SELECT step_id FROM step WHERE observation_id = $oid ORDER BY location".query[Int].list
+      sql"SELECT step_id FROM step WHERE program_id = ${oid.pid} AND observation_index = ${oid.index} ORDER BY location".query[Int].list
 
     def tuples(sids: List[Int], ds: List[Dataset]): List[(Int, Dataset)] = {
       val sidMap = sids.zipWithIndex.map(_.swap).toMap
@@ -37,7 +37,7 @@ object Importer extends DoobieClient {
   def writeObservation(oid: Observation.Id, o: Observation[StaticConfig, Step[DynamicConfig]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
 
     val rmObservation: ConnectionIO[Unit] =
-      sql"DELETE FROM observation WHERE observation_id = ${oid}".update.run.void
+      sql"DELETE FROM observation WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}".update.run.void
 
     (u: User[_], l: Log[ConnectionIO]) =>
       for {

--- a/modules/sql/src/main/resources/db/migration/V043__Observation_Keys.sql
+++ b/modules/sql/src/main/resources/db/migration/V043__Observation_Keys.sql
@@ -1,0 +1,100 @@
+
+-------------------------------------------------------------------------------
+-- Observation Updates
+--
+-- * Establish (program_id, observation_index, instrument) as primary key.
+--   This (a) provides an index that will work for bulk queries on program_id,
+--   and (b) serves as a foreign key referent from various other tables
+--   guaranteeing that they use the same instrument as the observation.
+--
+-- * Keep observation_id column and constraint as before:
+--     program_id + "-" + observation_index
+--
+-- * Keep a unique constraint on observation_id to prevent two different
+--   instruments for the same observation and gain an index on observation_id.
+--
+-- * Drop the static_ic column, since we are dropping the static_config table
+--   and replacing the static_id with the observation reference triple
+--   (program_id, observation_index, instrument)
+-------------------------------------------------------------------------------
+
+DROP INDEX ix_observation_instrument;
+
+DROP INDEX ix_observation_program_id;
+
+ALTER TABLE observation
+  DROP CONSTRAINT  observation_static_id_fkey,
+  DROP COLUMN      static_id,
+  DROP CONSTRAINT  observation_pkey CASCADE,
+  DROP CONSTRAINT  observation_instrument_observation_id_key,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  unique_observation_id UNIQUE (observation_id);
+
+
+-------------------------------------------------------------------------------
+-- Static Configuration Updates
+--
+-- * Removes the static_config table altogether, flattening the hierarchy.
+--   We are then left with individual instrument static configuration tables
+--   like static_f2, static_gmos_north and their subtables like gmos_custom_roi.
+--   These will refer directly to their corresponding observation.
+--
+-- * Uses the triple (program_id, observation_index, instrument) as a FK into
+--   observation.  This gurantees that he instrument matches and facilitates
+--   bulk load queries for the program as a whole.
+-------------------------------------------------------------------------------
+
+ALTER TABLE gmos_custom_roi
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+ALTER TABLE gmos_nod_and_shuffle
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+ALTER TABLE static_f2
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+ALTER TABLE static_gmos_north
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+  
+ALTER TABLE static_gmos_south
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+ 
+DROP TABLE static_config;
+
+
+-------------------------------------------------------------------------------
+-- Dynamic Configuration Updates
+-- 
+-- Here we just switch from observation_id to (program_id, observation_index).
+-------------------------------------------------------------------------------
+
+ALTER TABLE step
+  ADD  COLUMN     program_id        text     NOT NULL,
+  ADD  COLUMN     observation_index id_index NOT NULL,
+  ADD  CONSTRAINT observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE,
+  DROP COLUMN     observation_id,
+  ADD  CONSTRAINT unique_location UNIQUE (program_id, observation_index, location);
+
+
+ 
+
+


### PR DESCRIPTION
This is a proposal for reworking observation references from tables, particularly for static configurations.  This is motivated by asterisms, which conceptually overlap with static configurations.  In particular, there is one per observation and they have instrument-specific features.  The asterism instrument has to match the observation instrument just as the static configuration instrument must match.

Looking back at static configurations, it occurred to me that we could do away with the `static_config` table altogether, and therefore the `static_id` column in `observation`.  Since asterisms will likely work the same way, I wanted to see whether this would work first.

See the `V043__Observation_Keys.sql` migration at the end for a description of the changes.