### PR TITLE
Section

### DIFF
--- a/modules/core/shared/src/main/scala/gem/util/Section.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Section.scala
@@ -1,0 +1,83 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.util
+
+import cats.arrow.Category
+import monocle.Iso
+
+/**
+ * A normalizing optic, isomorphic to Iso but with different laws, specifically `get`
+ * need not be injective; i.e., distinct inputs may have the same `get` result, which combined
+ * with a subsequent `reverseGet` yield a normalized form for A.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+final case class Section[A, B](get: A => B, reverseGet: B => A) {
+
+  /** Compose with another Section. */
+  def composeSection[C](f: Section[B, C]): Section[A, C] =
+    Section(a => f.get(get(a)), reverseGet compose f.reverseGet)
+
+  /** Compose with an Iso. */
+  def composeIso[C](f: Iso[B, C]): Section[A, C] =
+    Section(a => f.get(get(a)), reverseGet compose f.reverseGet)
+
+  /** Alias to composeSection. */
+  def ^<-![C](f: Section[B, C]): Section[A, C] =
+    composeSection(f)
+
+  /** Alias to composeIso. */
+  def ^<->[C](f: Iso[B, C]): Section[A, C] =
+    composeIso(f)
+
+  /** Section is an invariant functor over A. */
+  def imapA[C](f: C => B, g: B => C): Section[A, C] =
+    Section(get andThen g, f andThen reverseGet)
+
+  /** Section is an invariant functor over B. */
+  def imapB[C](f: A => C, g: C => A): Section[C, B] =
+    Section(g andThen get, reverseGet andThen f)
+
+  /**
+   * get and reverseGet, yielding a normalized formatted value. Subsequent get/reverseGet cycles are
+   * idempotent.
+   */
+  def normalize(b: A): A =
+    reverseGet(get(b))
+
+  /** If we can reverseGet a Product as a String we can implement a tagged toString like "Foo(stuff)". */
+  def productToString(b: B)(
+    implicit as: A =:= String,
+             bp: B <:< Product
+  ): String =
+    taggedToString(b.productPrefix, b)
+
+  /**
+   * If we provide a tag like "Foo" and reverseGet as a String we can implement a nice toString like
+   * "Foo(stuff)".
+   */
+  def taggedToString(tag: String, b: B)(
+    implicit as: A =:= String
+  ): String =
+    new StringBuilder(tag)
+      .append('(')
+      .append(as(reverseGet(b)))
+      .append(')')
+      .toString
+
+}
+
+object Section {
+
+  /** An Iso is trivially a Section. */
+  def fromIso[A, B](p: Iso[A, B]): Section[A, B] =
+    Section(p.get, p.reverseGet)
+
+  /** Section forms a category. */
+  implicit def SectionCategory: Category[Section] =
+    new Category[Section] {
+      def id[A] = Section(identity, identity)
+      def compose[A, B, C](f: Section[B, C], g: Section[A, B]): Section[A, C] = g ^<-! f
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/util/Section.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Section.scala
@@ -16,11 +16,11 @@ final case class Section[A, B](get: A => B, reverseGet: B => A) {
 
   /** Compose with another Section. */
   def composeSection[C](f: Section[B, C]): Section[A, C] =
-    Section(a => f.get(get(a)), reverseGet compose f.reverseGet)
+    Section(get andThen f.get, reverseGet compose f.reverseGet)
 
   /** Compose with an Iso. */
   def composeIso[C](f: Iso[B, C]): Section[A, C] =
-    Section(a => f.get(get(a)), reverseGet compose f.reverseGet)
+    Section(get andThen f.get, reverseGet compose f.reverseGet)
 
   /** Alias to composeSection. */
   def ^<-![C](f: Section[B, C]): Section[A, C] =

--- a/modules/core/shared/src/test/scala/gem/laws/SectionLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/SectionLaws.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.Eq
+import cats.implicits._
+import gem.util.Section
+
+final case class SectionLaws[A, B](fab: Section[A, B]) {
+
+  def normalize(a: A): IsEq[B] =
+    fab.get(fab.normalize(a)) <-> fab.get(a)
+
+  def normalizedGetRoundTrip(a: A): IsEq[A] = {
+    val aʹ = fab.normalize(a)
+    (fab.get andThen fab.reverseGet)(aʹ) <-> aʹ
+  }
+
+  def reverseGetRoundTrip(b: B): IsEq[B] =
+    (fab.reverseGet andThen fab.get)(b) <-> b
+
+  // True if `a` is parsable but not in normal form. The existence of such a value in our test data
+  // will show that `normalize` and `parseRoundTrup` are actually testing something.
+  def demonstratesNormalization(a: A)(implicit ev: Eq[A]): Boolean =
+    (fab.get andThen fab.reverseGet)(a) =!= a
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/SectionTests.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/SectionTests.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+package discipline
+
+import cats.Eq
+import gem.util.Section
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait SectionTests[A, B] extends Laws {
+  val laws: SectionLaws[A, B]
+
+  def section(
+    implicit aa: Arbitrary[A], ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    new SimpleRuleSet("Section",
+      "normalize"                -> forAll((a: A) => laws.normalize(a)),
+      "normalized get roundtrip" -> forAll((a: A) => laws.normalizedGetRoundTrip(a)),
+      "reverseGet roundtrip"     -> forAll((b: B) => laws.reverseGetRoundTrip(b)),
+      "coverage"                 -> exists((a: A) => laws.demonstratesNormalization(a))
+    )
+
+  /** Convenience constructor that allows passing an explicit generator for input values. */
+  def sectionWith(ga: Gen[A])(
+    implicit ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    section(Arbitrary(ga), ea, ab, eb)
+
+}
+
+object SectionTests extends Laws {
+
+  def apply[A, B](fab: Section[A, B]): SectionTests[A, B] =
+    new SectionTests[A, B] {
+      val laws = new SectionLaws(fab)
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/util/SectionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/SectionSpec.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package util
+
+import cats.tests.CatsSuite
+import gem.laws.discipline._
+
+final class SectionSpec extends CatsSuite {
+
+  // Our example Section injects Int into Byte
+  val example: Section[Int, Byte] =
+    Section(_.toByte, _.toInt)
+
+  // Ensure it's lawful
+  checkAll("Sections.HmsDms", SectionTests(example).section)
+
+}

--- a/modules/core/shared/src/test/scala/gem/util/SectionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/SectionSpec.scala
@@ -14,6 +14,6 @@ final class SectionSpec extends CatsSuite {
     Section(_.toByte, _.toInt)
 
   // Ensure it's lawful
-  checkAll("Sections.HmsDms", SectionTests(example).section)
+  checkAll("IntByte", SectionTests(example).section)
 
 }


### PR DESCRIPTION
A **section** arises when you have a pair of arrows `f: A => B` and `s: B => A` such that `f compose s = id`. This means you can go `B => A => B` without losing information, but not necessarily the other way. We can see this as a normalizing isomorphism, where `f` might not be injective; i.e., it might squeeze a bunch of `A`s into the same `B`, but once you're "in" you can go back and forth. Consider `f: Int => Byte = _.toByte` and `s: Byte => Int = _.toInt`. Anyway in this situation we say that `s` is a **section** for `f`.

The encoding here looks like `Iso` where `f = get` and `s = reverseGet`. This is useful for things like `Angle.fromMicroarcseconds` ↔︎ `a.toMicroarcseconds` which normalizes its values to `[0°, 360°)`.
