### PR TITLE
TreeMap.fromList

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Program.scala
+++ b/modules/core/shared/src/main/scala/gem/Program.scala
@@ -6,6 +6,8 @@ package gem
 import cats.{ Applicative, Eval, Traverse }
 import cats.implicits._
 
+import gem.syntax.treemapcompanion._
+
 import scala.collection.immutable.TreeMap
 
 /**
@@ -30,7 +32,7 @@ object Program {
         fa.observations.values.toList.foldRight(lb)(f)
       def traverse[G[_]: Applicative, A, B](fa: Program[A])(f: A => G[B]): G[Program[B]] =
         fa.observations.values.toList.traverse(f).map { bs =>
-          fa.copy(observations = TreeMap(fa.observations.keys.toList.zip(bs): _*))
+          fa.copy(observations = TreeMap.fromList(fa.observations.keys.toList.zip(bs)))
         }
     }
 

--- a/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
@@ -3,6 +3,7 @@
 
 package gem.math
 
+import gem.syntax.treemapcompanion._
 import gem.util.Timestamp
 
 import cats.{ Eq, Foldable, Monoid }
@@ -58,11 +59,15 @@ object Ephemeris {
 
   /** Construct an ephemeris from a sequence of literal elements. */
   def apply(es: Element*): Ephemeris =
-    new Ephemeris(TreeMap(es: _*)) {}
+    fromList(es.toList)
+
+  /** Construct an ephemeris from a `List` of elements. */
+  def fromList(es: List[Element]): Ephemeris =
+    new Ephemeris(TreeMap.fromList(es)) {}
 
   /** Construct an ephemeris from a foldable of elements. */
   def fromFoldable[F[_]: Foldable](fa: F[Element]): Ephemeris =
-    apply(fa.toList: _*)
+    fromList(fa.toList)
 
   /** Ephemerides form a monoid, using `++` as the combining operation. */
   implicit val MonoidEphemeris: Monoid[Ephemeris] =

--- a/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import cats.Foldable
+
+import scala.collection.immutable.TreeMap
+
+final class TreeMapCompanionOps(val self: TreeMap.type) extends AnyVal {
+
+  /** Creates a `TreeMap` from a `List[(A, B)]`, provided an `Ordering[A]`
+    * is available.
+    */
+  def fromList[A: Ordering, B](lst: List[(A, B)]): TreeMap[A, B] =
+    TreeMap(lst: _*)
+
+  /** Creates a `TreeMap` from a `Foldable[(A, B)]`, provided an `Ordering[A]`
+    * is available.
+    */
+  def fromFoldable[F[_], A, B](fab: F[(A, B)])(implicit F: Foldable[F], A: Ordering[A]): TreeMap[A, B] =
+    fromList(F.toList(fab))
+}
+
+trait ToTreeMapCompanionOps {
+  implicit def ToTreeMapCompanionOps(c: TreeMap.type): TreeMapCompanionOps =
+    new TreeMapCompanionOps(c)
+}
+
+object treemapcompanion extends ToTreeMapCompanionOps

--- a/modules/core/shared/src/main/scala/gem/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/package.scala
@@ -14,5 +14,6 @@ package object syntax {
                 with ToStringOps
                 with ToInstantOps
                 with ToDurationOps
+                with ToTreeMapCompanionOps
                 with ToTreeSetCompanionOps
 }

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -8,6 +8,7 @@ import gem.arb._
 import gem.config.{DynamicConfig, GcalConfig, StaticConfig, TelescopeConfig}
 import gem.enum.{Instrument, SmartGcalType}
 import gem.math.Offset
+import gem.syntax.treemapcompanion._
 import gem.util.Location
 import org.scalacheck._
 import org.scalacheck.Gen._
@@ -111,5 +112,5 @@ trait Arbitraries extends gem.config.Arbitraries  {
       count   <- Gen.choose(0, limit)
       obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Observation.Index.unsafeFromShort))
       obsList <- obsIdxs.traverse(_ => arbitrary[Observation[StaticConfig, Step[DynamicConfig]]])
-    } yield TreeMap(obsIdxs.zip(obsList): _*)
+    } yield TreeMap.fromList(obsIdxs.zip(obsList))
 }

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -9,6 +9,7 @@ import doobie._, doobie.implicits._
 import gem.config.{DynamicConfig, StaticConfig}
 import gem.dao.meta._
 import gem.enum.Instrument
+import gem.syntax.treemapcompanion._
 import gem.util.Location
 
 import scala.collection.immutable.TreeMap
@@ -72,7 +73,7 @@ object ObservationDao {
    */
   def selectAllFlat(pid: Program.Id): ConnectionIO[TreeMap[Observation.Index, Observation[Instrument, Nothing]]] =
     for {
-      m  <- Statements.selectAllFlat(pid).list.map(lst => TreeMap(lst: _*))
+      m  <- Statements.selectAllFlat(pid).list.map(lst => TreeMap.fromList(lst))
       ts <- TargetEnvironmentDao.selectProg(pid)
     } yield merge(m, ts)
 
@@ -85,7 +86,7 @@ object ObservationDao {
       ids <- selectIds(pid)
       oss <- ids.traverse(selectStatic)
       ts  <- TargetEnvironmentDao.selectProg(pid)
-    } yield merge(TreeMap(ids.map(_.index).zip(oss): _*), ts)
+    } yield merge(TreeMap.fromList(ids.map(_.index).zip(oss)), ts)
 
   /**
    * Construct a program to select all observations for the specified science program, with the
@@ -96,7 +97,7 @@ object ObservationDao {
       ids <- selectIds(pid)
       oss <- ids.traverse(select)
       ts  <- TargetEnvironmentDao.selectProg(pid)
-    } yield merge(TreeMap(ids.map(_.index).zip(oss): _*), ts)
+    } yield merge(TreeMap.fromList(ids.map(_.index).zip(oss)), ts)
 
   object Statements {
 

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -12,6 +12,7 @@ import gem.config.GcalConfig.GcalLamp
 import gem.dao.meta._
 import gem.enum._
 import gem.math.Offset
+import gem.syntax.treemapcompanion._
 import java.time.Duration
 import scala.collection.immutable.TreeMap
 
@@ -28,7 +29,7 @@ object StepDao {
 
   private implicit class ToMap[A](q: Query0[(Loc, A)]) {
     def toMap[B >: A]: ConnectionIO[TreeMap[Loc, B]] =
-      q.list.map(ps => TreeMap(ps.widen[(Loc, B)]: _*))
+      q.list.map(ps => TreeMap.fromList(ps.widen[(Loc, B)]))
   }
 
   import Statements._
@@ -62,7 +63,7 @@ object StepDao {
     * @param oid observation whose steps should be selected
     */
   def selectAllEmpty(oid: Observation.Id): ConnectionIO[TreeMap[Loc, Step[Instrument]]] =
-    Statements.selectAllEmpty(oid).list.map(ps => TreeMap(ps: _*))
+    Statements.selectAllEmpty(oid).list.map(ps => TreeMap.fromList(ps))
 
   /** Selects the step at the indicated location in the sequence associated with
     * the indicated observation.

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -4,6 +4,7 @@
 package gem.horizons
 
 import gem.math.{ Ephemeris, EphemerisCoordinates }
+import gem.syntax.treemapcompanion._
 import gem.util.Timestamp
 
 import cats.effect.IO
@@ -62,7 +63,7 @@ final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
     )
 
     val s = stream("borrelly").through(EphemerisParser.elements[IO])
-    val m = TreeMap(s.take(head.size.toLong).compile.toVector.unsafeRunSync: _*)
+    val m = TreeMap.fromFoldable(s.take(head.size.toLong).compile.toVector.unsafeRunSync)
 
     assert(m == head)
   }
@@ -96,7 +97,7 @@ final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
     )
 
     val s = stream("borrelly-error").through(EphemerisParser.validElements[IO])
-    val m = TreeMap(s.take(head.size.toLong).compile.toVector.unsafeRunSync: _*)
+    val m = TreeMap.fromFoldable(s.take(head.size.toLong).compile.toVector.unsafeRunSync)
 
     assert(m == head)
   }

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
@@ -4,6 +4,7 @@
 package gem.horizons
 
 import gem.math.{ Angle, Coordinates, EphemerisCoordinates, Offset }
+import gem.syntax.treemapcompanion._
 import gem.util.Timestamp
 
 import cats.effect.IO
@@ -40,7 +41,7 @@ trait EphemerisTestSupport {
     EphemerisCoordinates(coords(c), Offset(offsetp(p), offsetq(q)))
 
   def eph(elems: (String, (String, String, String))*): TreeMap[Timestamp, EphemerisCoordinates] =
-    TreeMap(elems.map { case (i, (c, p, q)) => time(i) -> ephCoords(c, p, q) }: _*)
+    TreeMap.fromList(elems.toList.map { case (i, (c, p, q)) => time(i) -> ephCoords(c, p, q) })
 
   def inputStream(n: String): InputStream =
     getClass.getResourceAsStream(s"$n.eph")

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -13,8 +13,7 @@ import gem.ocs2.pio.PioPath._
 import gem.ocs2.pio.{ PioDecoder, PioError, PioPath }
 import gem.ocs2.pio.PioError.ParseError
 import gem.ocs2.pio.PioDecoder.fromParse
-import gem.syntax.string._
-import gem.syntax.treesetcompanion._
+import gem.syntax.all._
 
 import java.time.Instant
 
@@ -218,7 +217,7 @@ object Decoders {
         t  <- (n \!  "data" \? "#title").decodeOrZero[String]
         is <- (n \\* "observation"     ).decode[Observation.Index]
         os <- (n \\* "observation"     ).decode[Observation[StaticConfig, Step[DynamicConfig]]]
-      } yield Program(id, t, TreeMap(is.zip(os): _*))
+      } yield Program(id, t, TreeMap.fromList(is.zip(os)))
     }
 
 }


### PR DESCRIPTION
Simply adds a `fromList` method to `TreeMap` to avoid the `: _*` syntax.