### PR TITLE
Add targets type parameter to Observation

### DIFF
--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -5,7 +5,7 @@ package gem
 
 import cats.implicits._
 import gem.arb._
-import gem.config.{DynamicConfig, GcalConfig, StaticConfig, TelescopeConfig}
+import gem.config.{ DynamicConfig, GcalConfig, TelescopeConfig }
 import gem.enum.{Instrument, SmartGcalType}
 import gem.math.Offset
 import gem.syntax.treemapcompanion._
@@ -87,7 +87,7 @@ trait Arbitraries extends gem.config.Arbitraries  {
 
   // Observation
 
-  def genObservationOf(i: Instrument): Gen[Observation[StaticConfig, Step[DynamicConfig]]] =
+  def genObservationOf(i: Instrument): Gen[Observation.Full] =
     for {
       t <- genTitle
       e <- arbitrary[TargetEnvironment]
@@ -95,7 +95,7 @@ trait Arbitraries extends gem.config.Arbitraries  {
       d <- genSequenceOf(i)
     } yield Observation(t, e, s, d)
 
-  implicit val arbObservation: Arbitrary[Observation[StaticConfig, Step[DynamicConfig]]] =
+  implicit val arbObservation: Arbitrary[Observation.Full] =
     Arbitrary {
       for {
         i <- Gen.oneOf(
@@ -107,10 +107,10 @@ trait Arbitraries extends gem.config.Arbitraries  {
       } yield o
     }
 
-  def genObservationMap(limit: Int): Gen[TreeMap[Observation.Index, Observation[StaticConfig, Step[DynamicConfig]]]] =
+  def genObservationMap(limit: Int): Gen[TreeMap[Observation.Index, Observation.Full]] =
     for {
       count   <- Gen.choose(0, limit)
       obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Observation.Index.unsafeFromShort))
-      obsList <- obsIdxs.traverse(_ => arbitrary[Observation[StaticConfig, Step[DynamicConfig]]])
+      obsList <- obsIdxs.traverse(_ => arbitrary[Observation.Full])
     } yield TreeMap.fromList(obsIdxs.zip(obsList))
 }

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -4,7 +4,6 @@
 package gem
 package dao
 
-import gem.config.{DynamicConfig, StaticConfig}
 import gem.dao.meta._
 
 import cats.implicits._
@@ -22,7 +21,7 @@ object ProgramDao {
     Statements.insert(p).run.as(p.id)
 
   /** Insert a complete program. */
-  def insert(p: Program[Observation[StaticConfig, Step[DynamicConfig]]]): ConnectionIO[Program.Id] =
+  def insert(p: Program[Observation.Full]): ConnectionIO[Program.Id] =
     insertFlat(p) <* p.observations.toList.traverse { case (i,o) =>
       ObservationDao.insert(Observation.Id(p.id, i), o)
     }
@@ -53,7 +52,7 @@ object ProgramDao {
     Statements.selectFlat(pid).option
 
   /** Select a program by id, with full Observation information. */
-  def selectFull(pid: Program.Id): ConnectionIO[Option[Program[Observation[StaticConfig, Step[DynamicConfig]]]]] =
+  def selectFull(pid: Program.Id): ConnectionIO[Option[Program[Observation.Full]]] =
     for {
       opn <- selectFlat(pid)
       os  <- ObservationDao.selectAll(pid)

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -7,8 +7,6 @@ package dao
 import cats.implicits._
 import doobie.implicits._
 
-import gem.config.{ DynamicConfig, StaticConfig }
-
 import org.scalatest._
 import org.scalatest.prop._
 import org.scalatest.Matchers._
@@ -18,7 +16,7 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   import gem.arb.ArbUserTarget._
 
   property("UserTargetDao should roundtrip") {
-    forAll { (obs: Observation[StaticConfig, Step[DynamicConfig]], ut: UserTarget) =>
+    forAll { (obs: Observation.Full, ut: UserTarget) =>
       val oid = Observation.Id(pid, Observation.Index.One)
 
       val utʹ = withProgram {
@@ -34,7 +32,7 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("UserTargetDao should bulk select observation") {
-    forAll { (obs: Observation[StaticConfig, Step[DynamicConfig]]) =>
+    forAll { (obs: Observation.Full) =>
       val oid = Observation.Id(pid, Observation.Index.One)
 
       val actual = withProgram {

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -49,7 +49,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val gcalShutter      = GcalShutter.Open
     val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, 0)
     val user             = User[Nothing]("", "", "", "", false, Map.empty)
-    val observation      = Observation[StaticConfig, Nothing]("", TargetEnvironment.empty, StaticConfig.F2.Default, Nil)
+    val observation      = Observation[TargetEnvironment, StaticConfig, Nothing]("", TargetEnvironment.empty, StaticConfig.F2.Default, Nil)
     val program          = Program(programId, "", TreeMap.empty)
     val f2SmartGcalKey   = DynamicConfig.F2.Default.key
     val gcalLampType     = GcalLampType.Arc

--- a/modules/json/src/test/scala/gem/json/CompilationTest.scala
+++ b/modules/json/src/test/scala/gem/json/CompilationTest.scala
@@ -28,7 +28,7 @@ import gem.util.Enumerated
   def enumerated[E: Enumerated] = assertCodec[E]
   def programA[A: Encoder: Decoder] = assertCodec[Program[A]]
   def stepA[A: Encoder: Decoder] = assertCodec[Step[A]]
-  def observationAB[A: Encoder: Decoder, B: Encoder: Decoder] = assertCodec[Observation[A, B]]
+  def observationABC[A: Encoder: Decoder, B: Encoder: Decoder, C: Encoder: Decoder] = assertCodec[Observation[A, B, C]]
 
   // Sanity checks
   assertCodec[User[ProgramRole]]

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -200,7 +200,7 @@ object Decoders {
     }
   }
 
-  implicit val ObservationDecoder: PioDecoder[Observation[StaticConfig, Step[DynamicConfig]]] =
+  implicit val ObservationDecoder: PioDecoder[Observation.Full] =
     PioDecoder { n =>
       for {
         t  <- (n \! "data" \? "#title"                   ).decodeOrZero[String]
@@ -210,13 +210,13 @@ object Decoders {
       } yield Observation(t, e, st, sq)
     }
 
-  implicit val ProgramDecoder: PioDecoder[Program[Observation[StaticConfig, Step[DynamicConfig]]]] =
+  implicit val ProgramDecoder: PioDecoder[Program[Observation.Full]] =
     PioDecoder { n =>
       for {
         id <- (n \!  "@name"           ).decode[Program.Id]
         t  <- (n \!  "data" \? "#title").decodeOrZero[String]
         is <- (n \\* "observation"     ).decode[Observation.Index]
-        os <- (n \\* "observation"     ).decode[Observation[StaticConfig, Step[DynamicConfig]]]
+        os <- (n \\* "observation"     ).decode[Observation.Full]
       } yield Program(id, t, TreeMap.fromList(is.zip(os)))
     }
 

--- a/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
@@ -5,8 +5,7 @@ package gem.ocs2
 
 import cats.effect.IO, cats.implicits._
 import doobie._, doobie.implicits._
-import gem.{ Dataset, Log, Observation, Program, Step, User }
-import gem.config.{ StaticConfig, DynamicConfig }
+import gem.{ Dataset, Log, Observation, Program, User }
 import gem.dao.UserDao
 import gem.ocs2.Decoders._
 import gem.ocs2.pio.PioDecoder
@@ -21,8 +20,7 @@ import scala.xml.{XML, Elem}
   */
 object FileImporter extends DoobieClient {
 
-  type Obs  = Observation[StaticConfig, Step[DynamicConfig]]
-  type Prog = Program[Obs]
+  type Prog = Program[Observation.Full]
 
   val dir: File = new File("archive")
 
@@ -46,7 +44,7 @@ object FileImporter extends DoobieClient {
   def read(f: File): IO[Elem] =
     IO(XML.loadFile(f))
 
-  def insert(u: User[_], p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset], log: Log[ConnectionIO]): ConnectionIO[Unit] =
+  def insert(u: User[_], p: Program[Observation.Full], ds: List[Dataset], log: Log[ConnectionIO]): ConnectionIO[Unit] =
     Importer.writeProgram(p, ds)(u, log)
 
   def readAndInsert(u: User[_], f: File, log: Log[ConnectionIO]): IO[Unit] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -4,8 +4,7 @@
 package gem.ocs2
 
 import gem.dao._
-import gem.{ Dataset, Log, Observation, Program, Step, User }
-import gem.config.{ StaticConfig, DynamicConfig }
+import gem.{ Dataset, Log, Observation, Program, User }
 
 import cats.effect.IO
 import cats.implicits._
@@ -34,7 +33,7 @@ object Importer extends DoobieClient {
       } yield ()
   }
 
-  def writeObservation(oid: Observation.Id, o: Observation[StaticConfig, Step[DynamicConfig]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
+  def writeObservation(oid: Observation.Id, o: Observation.Full, ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
 
     val rmObservation: ConnectionIO[Unit] =
       sql"DELETE FROM observation WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}".update.run.void
@@ -48,7 +47,7 @@ object Importer extends DoobieClient {
       } yield ()
   }
 
-  def writeProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
+  def writeProgram(p: Program[Observation.Full], ds: List[Dataset]): (User[_], Log[ConnectionIO]) => ConnectionIO[Unit] = {
     val rmProgram: ConnectionIO[Unit] =
       sql"DELETE FROM program WHERE program_id = ${p.id}".update.run.void
 
@@ -74,9 +73,9 @@ object Importer extends DoobieClient {
       _ <- l.shutdown(5 * 1000).transact(lxa) // if we're not done soon something is wrong
     } yield ()
 
-  def importObservation(oid: Observation.Id, o: Observation[StaticConfig, Step[DynamicConfig]], ds: List[Dataset]): IO[Unit] =
+  def importObservation(oid: Observation.Id, o: Observation.Full, ds: List[Dataset]): IO[Unit] =
     doImport(writeObservation(oid, o, ds))
 
-  def importProgram(p: Program[Observation[StaticConfig, Step[DynamicConfig]]], ds: List[Dataset]): IO[Unit] =
+  def importProgram(p: Program[Observation.Full], ds: List[Dataset]): IO[Unit] =
     doImport(writeProgram(p, ds))
 }

--- a/modules/ui/src/main/scala/gem/ui/Main.scala
+++ b/modules/ui/src/main/scala/gem/ui/Main.scala
@@ -39,7 +39,7 @@ object TestProgram {
       1
     )
 
-  val f2: Observation[StaticConfig, Step[DynamicConfig]] =
+  val f2: Observation.Full =
     Observation(
       "F2 Observation",
       TargetEnvironment(TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
@@ -47,7 +47,7 @@ object TestProgram {
       List(Step.Gcal(DynamicConfig.F2.Default, gcal))
     )
 
-  val gmosS: Observation[StaticConfig, Step[DynamicConfig]] =
+  val gmosS: Observation.Full =
     Observation(
       "GMOS-S Observation",
       TargetEnvironment(TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
@@ -55,7 +55,7 @@ object TestProgram {
       List(Step.SmartGcal(DynamicConfig.GmosSouth.Default, SmartGcalType.Arc))
     )
 
-  val gmosN: Observation[StaticConfig, Step[DynamicConfig]] =
+  val gmosN: Observation.Full =
     Observation(
       "GMOS-N Observation",
       TargetEnvironment(TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
@@ -63,7 +63,7 @@ object TestProgram {
       List(Step.Bias(DynamicConfig.GmosNorth.Default))
     )
 
-  val p: Program[Observation[StaticConfig, Step[DynamicConfig]]] =
+  val p: Program[Observation.Full] =
     Program(
       pid,
       "Test Program",


### PR DESCRIPTION
While working on adding asterisms and seeing the `TargetEnvironment` grow more complex, I realized we probably should allow loading `Observation`s without their targets as @tpolecat suggested.  This PR adds a `T` type parameter for targets along the lines of the parameter for the static and dynamic configuration.

One question I have is whether there is a better way to deal with the three `Observation` functors that result from this.  See `Observation.targetsFunctor` etc.