### PR TITLE
many version updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,18 +5,18 @@ lazy val attoVersion         = "0.6.2-M1"
 lazy val catsEffectVersion   = "0.8"
 lazy val catsVersion         = "1.0.1"
 lazy val declineVersion      = "0.4.1"
-lazy val doobieVersion       = "0.5.0-M13"
-lazy val flywayVersion       = "5.0.6"
-lazy val fs2Version          = "0.10.0-M11"
-lazy val http4sVersion       = "0.18.0-M8"
+lazy val doobieVersion       = "0.5.0-RC1"
+lazy val flywayVersion       = "5.0.7"
+lazy val fs2Version          = "0.10.0"
+lazy val http4sVersion       = "0.18.0"
 lazy val jwtVersion          = "0.14.1"
 lazy val kpVersion           = "0.9.5"
 lazy val monocleVersion      = "1.5.0-cats"
 lazy val mouseVersion        = "0.16"
 lazy val paradiseVersion     = "2.1.1"
 lazy val scalaCheckVersion   = "1.13.5"
-lazy val scalaParsersVersion = "1.0.6"
-lazy val scalaTestVersion    = "3.0.4"
+lazy val scalaParsersVersion = "1.1.0"
+lazy val scalaTestVersion    = "3.0.5"
 lazy val scalaXmlVerson      = "1.0.6"
 lazy val shapelessVersion    = "2.3.3"
 lazy val slf4jVersion        = "1.7.25"
@@ -76,7 +76,7 @@ lazy val gemWarts =
 lazy val commonSettings = Seq(
 
   // These sbt-header settings can't be set in ThisBuild for some reason
-  headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment),
+  headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
   headerLicense  := Some(HeaderLicense.Custom(
     """|Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
        |For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -24,6 +24,7 @@ import java.net.URLEncoder
 import java.util.logging.Logger
 
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 import scala.language.postfixOps
 import scala.xml.{Elem, Node}
 
@@ -125,7 +126,7 @@ object ImportServer extends StreamApp[IO] {
     BlazeBuilder[IO]
       .bindHttp(8989, "localhost")
       .mountService(service, "/import")
-      .serve
+      .serve(implicitly, ExecutionContext.global)
 
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,18 +4,20 @@ resolvers  ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.postgresql" % "postgresql"  % "42.1.1", // needed by flyway
-  "org.slf4j"      % "slf4j-nop"   % "1.7.21", // to silence some log messages
-  "org.typelevel" %% "cats-core"   % "1.0.0-MF",
-  "org.typelevel" %% "cats-effect" % "0.4"
+  "org.postgresql" % "postgresql"  % "42.2.1", // needed by flyway
+  "org.slf4j"      % "slf4j-nop"   % "1.7.25", // to silence some log messages
+  "org.typelevel" %% "cats-core"   % "1.0.1",
+  "org.typelevel" %% "cats-effect" % "0.8"
 )
 
 addSbtPlugin("org.flywaydb"      % "flyway-sbt"            % "4.2.0")
 addSbtPlugin("org.scalastyle"   %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"   % "1.2.2")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"   % "1.3.2")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"               % "0.9.3")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"            % "3.0.2")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"            % "4.1.0")
 addSbtPlugin("org.wartremover"   % "sbt-wartremover"       % "2.2.1")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"           % "0.6.22")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph"  % "0.9.0")
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"           % "0.3.4-2+gd4c4ec6")
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"           % "0.3.4")
+
+onLoad in Global := { s => "dependencyUpdates" :: s }

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,2 +1,2 @@
 // So the build build will use it
-// addSbtPlugin("io.get-coursier"  % "sbt-coursier" % "1.0.0-RC4")
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates" % "0.3.4")


### PR DESCRIPTION
This updates some library dependences:

- doobie 0.5.0-RC1
- Flyway 5.0.7
- fs2 0.10.0
- http4s 0.18.0
- scala-parser-combinators 1.1.0
- ScalaTest 3.0.5
- postgres-jdbc 42.2.1

and some build dependencies

- postgre-jdbc  42.2.1
- slf4j-nop 1.7.25
- cats-core 1.0.1
- cats-effect 0.8

and build plugins

- sbt-native-packager 1.3.2
- sbt-header 4.1.0
- sbt-updates 0.3.4

It also adds sbt-updates to the build build, so you can say `reload plugins` to see if there are any newer plugins or build dependencies. Do `reload return` to get back to the main build.