### PR TITLE
Target Id

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -16,6 +16,15 @@ import monocle.macros.Lenses
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Target {
 
+  /** Target identifier. */
+  final case class Id(toInt: Int) extends AnyVal
+
+  object Id {
+    /** Ids ordered by wrapped integer value. */
+    implicit val IdOrder: Order[Id] =
+      Order.by(_.toInt)
+  }
+
   /** A target order based on tracking information.  For sidereal targets this
     * roughly means by base coordinate without applying proper motion.  For
     * non-sidereal this means by `EphemerisKey`.

--- a/modules/db/src/main/scala/gem/dao/AsterismDao.scala
+++ b/modules/db/src/main/scala/gem/dao/AsterismDao.scala
@@ -71,7 +71,7 @@ object AsterismDao {
     as.traverse(f).map { lst => TreeMap(lst.flatMap(_.toList): _*) }
 
   def selectAllSingleTarget(pid: Program.Id): AsterismMap = {
-    def toEntry(idx: Observation.Index, tid: Int, inst: Instrument): OptMapEntry =
+    def toEntry(idx: Observation.Index, tid: Target.Id, inst: Instrument): OptMapEntry =
       TargetDao.select(tid).map {
         _.map(idx -> Asterism.SingleTarget(_, inst))
       }
@@ -83,7 +83,7 @@ object AsterismDao {
   }
 
   def selectAllGhostDualTarget(pid: Program.Id): AsterismMap = {
-    def toEntry(idx: Observation.Index, tid0: Int, tid1: Int): OptMapEntry =
+    def toEntry(idx: Observation.Index, tid0: Target.Id, tid1: Target.Id): OptMapEntry =
       for {
         t0 <- TargetDao.select(tid0)
         t1 <- TargetDao.select(tid1)
@@ -104,7 +104,7 @@ object AsterismDao {
 
     object SingleTarget {
 
-      def insert(oid: Observation.Id, t: Int, i: Instrument): Update0 =
+      def insert(oid: Observation.Id, t: Target.Id, i: Instrument): Update0 =
         sql"""
           INSERT INTO single_target_asterism (
                         program_id,
@@ -121,28 +121,28 @@ object AsterismDao {
                       )
         """.update
 
-      def select(oid: Observation.Id): Query0[(Int, Instrument)] =
+      def select(oid: Observation.Id): Query0[(Target.Id, Instrument)] =
         sql"""
           SELECT target_id,
                  instrument
             FROM single_target_asterism
            WHERE program_id        = ${oid.pid}
              AND observation_index = ${oid.index}
-        """.query[(Int, Instrument)]
+        """.query[(Target.Id, Instrument)]
 
-      def selectAll(pid: Program.Id): Query0[(Observation.Index, Int, Instrument)] =
+      def selectAll(pid: Program.Id): Query0[(Observation.Index, Target.Id, Instrument)] =
         sql"""
           SELECT observation_index,
                  target_id,
                  instrument
             FROM single_target_asterism
            WHERE program_id = $pid
-        """.query[(Observation.Index, Int, Instrument)]
+        """.query[(Observation.Index, Target.Id, Instrument)]
     }
 
     object GhostDualTarget {
 
-      def insert(oid: Observation.Id, t0: Int, t1: Int): Update0 =
+      def insert(oid: Observation.Id, t0: Target.Id, t1: Target.Id): Update0 =
         sql"""
           INSERT INTO ghost_dual_target_asterism (
                         program_id,
@@ -161,23 +161,23 @@ object AsterismDao {
                       )
         """.update
 
-      def select(oid: Observation.Id): Query0[(Int, Int)] =
+      def select(oid: Observation.Id): Query0[(Target.Id, Target.Id)] =
         sql"""
           SELECT target1_id,
                  target2_id
             FROM ghost_dual_target_asterism
            WHERE program_id        = ${oid.pid}
              AND observation_index = ${oid.index}
-        """.query[(Int, Int)]
+        """.query[(Target.Id, Target.Id)]
 
-      def selectAll(pid: Program.Id): Query0[(Observation.Index, Int, Int)] =
+      def selectAll(pid: Program.Id): Query0[(Observation.Index, Target.Id, Target.Id)] =
         sql"""
           SELECT observation_index,
                  target1_id,
                  target2_id
             FROM ghost_dual_target_asterism
            WHERE program_id = $pid
-        """.query[(Observation.Index, Int, Int)]
+        """.query[(Observation.Index, Target.Id, Target.Id)]
 
     }
 

--- a/modules/db/src/main/scala/gem/dao/TargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetDao.scala
@@ -21,16 +21,18 @@ object TargetDao extends EnumeratedMeta /* extend EnumeratedMeta to lower the pr
   implicit val MetaTrackType: Meta[TrackType] =
     pgEnumString("e_track_type", TrackType.unsafeFromTag, _.tag)
 
-  def select(id: Int): ConnectionIO[Option[Target]] =
+  def select(id: Target.Id): ConnectionIO[Option[Target]] =
     Statements.select(id).option
 
-  def insert(target: Target): ConnectionIO[Int] =
-    Statements.insert(target).withUniqueGeneratedKeys[Int]("id")
+  def insert(target: Target): ConnectionIO[Target.Id] =
+    Statements.insert(target)
+              .withUniqueGeneratedKeys[Int]("id")
+              .map(Target.Id(_))
 
-  def update(id: Int, target: Target): ConnectionIO[Int] =
+  def update(id: Target.Id, target: Target): ConnectionIO[Int] =
     Statements.update(id, target).run
 
-  def delete(id: Int): ConnectionIO[Int] =
+  def delete(id: Target.Id): ConnectionIO[Int] =
     Statements.delete(id).run
 
   object Statements {
@@ -63,7 +65,7 @@ object TargetDao extends EnumeratedMeta /* extend EnumeratedMeta to lower the pr
          Declination.fromStringSignedDMS.reverseGet(cs.dec))
       }
 
-    def select(id: Int): Query0[Target] =
+    def select(id: Target.Id): Query0[Target] =
       sql"""
         SELECT name, track_type,
                e_key_type, e_key,                     -- ephemeris key
@@ -87,7 +89,7 @@ object TargetDao extends EnumeratedMeta /* extend EnumeratedMeta to lower the pr
            )
       ).update
 
-    def update(id: Int, target: Target): Update0 =
+    def update(id: Target.Id, target: Target): Update0 =
       (fr"""UPDATE target
             SET (name, track_type,
                  e_key_type, e_key,                     -- ephemeris key
@@ -102,7 +104,7 @@ object TargetDao extends EnumeratedMeta /* extend EnumeratedMeta to lower the pr
       ) ++
        fr"WHERE id = $id").update
 
-    def delete(id: Int): Update0 =
+    def delete(id: Target.Id): Update0 =
       sql"DELETE FROM target WHERE id=$id".update
 
   }

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -17,7 +17,7 @@ object UserTargetDao {
 
   // A target ID and the corresponding user target type.  We use the id to
   // get the actual target.
-  final case class ProtoUserTarget(targetId: Int, targetType: UserTargetType, oi: Observation.Index) {
+  final case class ProtoUserTarget(targetId: Target.Id, targetType: UserTargetType, oi: Observation.Index) {
 
     val toUserTarget: ConnectionIO[Option[UserTarget]] =
       TargetDao.select(targetId).map { _.map(UserTarget(_, targetType)) }
@@ -82,7 +82,7 @@ object UserTargetDao {
     import gem.dao.meta.ProgramIdMeta._
     import gem.dao.meta.ObservationIndexMeta._
 
-    def insert(targetId: Int, targetType: UserTargetType, oid: Observation.Id): Update0 =
+    def insert(targetId: Target.Id, targetType: UserTargetType, oid: Observation.Id): Update0 =
       sql"""
         INSERT INTO user_target (
           target_id,

--- a/modules/db/src/test/scala/gem/dao/check/AsterismCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/AsterismCheck.scala
@@ -4,6 +4,7 @@
 package gem.dao
 package check
 
+import gem.Target
 import gem.enum.Instrument
 
 class AsterismCheck extends Check {
@@ -11,11 +12,11 @@ class AsterismCheck extends Check {
   import AsterismDao.Statements._
 
   "AsterismDao.Statements" should
-            "SingleTarget.insert"    in check(SingleTarget.insert(Dummy.observationId, 0, Instrument.GmosS))
+            "SingleTarget.insert"    in check(SingleTarget.insert(Dummy.observationId, Target.Id(0), Instrument.GmosS))
   it should "SingleTarget.select"    in check(SingleTarget.select(Dummy.observationId))
   it should "SingleTarget.selectAll" in check(SingleTarget.selectAll(Dummy.programId))
 
-  it should "GhostDualTarget.insert"    in check(GhostDualTarget.insert(Dummy.observationId, 0, 0))
+  it should "GhostDualTarget.insert"    in check(GhostDualTarget.insert(Dummy.observationId, Target.Id(0), Target.Id(0)))
   it should "GhostDualTarget.select"    in check(GhostDualTarget.select(Dummy.observationId))
   it should "GhostDualTarget.selectAll" in check(GhostDualTarget.selectAll(Dummy.programId))
 }

--- a/modules/db/src/test/scala/gem/dao/check/TargetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/TargetCheck.scala
@@ -4,11 +4,13 @@
 package gem.dao
 package check
 
+import gem.Target
+
 class TargetCheck extends Check {
   import TargetDao.Statements._
   "TargetDao.Statements" should
-            "select" in check(select(0))
+            "select" in check(select(Target.Id(0)))
   it should "insert" in check(insert(Dummy.target))
-  it should "update" in check(update(0, Dummy.target))
-  it should "delete" in check(delete(0))
+  it should "update" in check(update(Target.Id(0), Dummy.target))
+  it should "delete" in check(delete(Target.Id(0)))
 }

--- a/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
@@ -4,13 +4,14 @@
 package gem.dao
 package check
 
+import gem.Target
 import gem.enum.UserTargetType.Other
 
 class UserTargetCheck extends Check {
   import UserTargetDao.Statements._
 
   "UserTargetDao.Statements" should
-            "insert"           in check(insert(0, Other, Dummy.observationId))
+            "insert"           in check(insert(Target.Id(0), Other, Dummy.observationId))
   it should "select"           in check(select(0))
   it should "selectAllForObs"  in check(selectObs(Dummy.observationId))
   it should "selectAllForProg" in check(selectProg(Dummy.programId))


### PR DESCRIPTION
There are a number of `Int` database ids that pop up in the codebase.  Working with guide stars, I came across the need for a guide target id, a guide group id, and of course the target id.  I think the time has come to have types for the various ids beyond the primitive `Int`s.  I'm not sure if this is the way we want to do it though, so I offer `Target.Id` for discussion first.