### PR TITLE
angle optics

### DIFF
--- a/modules/core/shared/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Angle.scala
@@ -10,14 +10,17 @@ import cats.instances.long._
 import cats.syntax.eq._
 import gem.parser.AngleParsers
 import gem.syntax.parser._
-import gem.optics.Format
-import monocle.Prism
+import gem.optics._
+import monocle.{ Iso, Prism }
 
 /**
  * Exact angles represented as integral microarcseconds. These values form a commutative group over
  * addition, where the inverse is reflection around the 0-180° axis. The subgroup of angles where
  * integral microarcseconds correspond with clock microseconds (i.e., where they are evenly
  * divisible by 15 microarcseconds) is represented by the HourAgle subtype.
+ *
+ * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+ * object. Floating-point conversions are provided directly
  * @param toMicroarcseconds This angle in microarcseconds. Exact.
  */
 sealed class Angle protected (val toMicroarcseconds: Long) {
@@ -28,11 +31,15 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
 
   /**
    * Flip this angle 180°. Equivalent to `mirrorBy(this + Angle90)`. Exact, invertible.
+   * @group Transformations
    */
   def flip: Angle =
     this + Angle.Angle180
 
-  /** Additive inverse of this angle, equvalent to `mirrorBy Angle0`. Exact, invertible. */
+  /**
+   * Additive inverse of this angle, equvalent to `mirrorBy Angle0`. Exact, invertible.
+   * @group Transformations
+   */
   def unary_- : Angle =
     Angle.fromMicroarcseconds(-toMicroarcseconds.toLong)
 
@@ -41,67 +48,58 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
    * circle and flipping it over, around a line drawn from the center going off in direction `a`.
    * So `(88° mirrorBy 90°) = 92°` for instance, as is `88° mirrorBy 270°` since it's the same
    * line. This operation is specified completely by the identity `b - a = (a mirrorBy b) - b`.
+   * @group Transformations
    */
   def mirrorBy(a: Angle): Angle = {
     val Δ = a.toMicroarcseconds - toMicroarcseconds
     Angle.fromMicroarcseconds(toMicroarcseconds + Δ * 2L)
   }
 
-  /** Signed microarcseconds, in [-180°, 180°). */
-  def toSignedMicroarcseconds: Long = {
-    val µas360 = Angle.Angle180.toMicroarcseconds * 2L
-    if (toMicroarcseconds >= Angle.Angle180.toMicroarcseconds) toMicroarcseconds - µas360
-    else toMicroarcseconds
-  }
-
-  /** This angle in decimal degrees. Approximate, non-invertible */
+  /**
+   * This angle in decimal degrees. Approximate, non-invertible.
+   * @group Conversions
+   */
   def toDoubleDegrees: Double =
     toMicroarcseconds.toDouble / (60.0 * 60.0 * 1000.0 * 1000.0)
 
-  /** This angle in signed decimal degrees. Approximate, non-invertible */
+  /**
+   * This angle in signed decimal degrees. Approximate, non-invertible
+   * @group Conversions
+   */
   def toSignedDoubleDegrees: Double =
-    toSignedMicroarcseconds.toDouble / (60.0 * 60.0 * 1000.0 * 1000.0)
+    Angle.signedMicroarcseconds.get(this).toDouble / (60.0 * 60.0 * 1000.0 * 1000.0)
 
-  /** This angle in decimal radian, [0 .. 2π) Approximate, non-invertible */
+  /**
+   * This angle in decimal radian, [0 .. 2π) Approximate, non-invertible
+   * @group Conversions
+   */
   def toDoubleRadians: Double =
     toDoubleDegrees.toRadians
 
-  /** This angle in signed decimal radians, [-π .. π) Approximate, non-invertible */
+  /**
+   * This angle in signed decimal radians, [-π .. π) Approximate, non-invertible
+   * @group Conversions
+   */
   def toSignedDoubleRadians: Double =
     toSignedDoubleDegrees.toRadians
 
   /**
-   * Convert to the closest hour angle by rounding down to the closest 15 milliarcseconds.
-   * Exact, non-invertible.
+   * Sum of this angle and `a`. Exact, commutative, invertible.
+   * @group Operations
    */
-  def toHourAngle: HourAngle =
-    HourAngle.fromMicroseconds(toMicroarcseconds.toLong / 15L)
-
-  /**
-   * Convert to the closest hour angle iff its magnitude is an even multiple of 15 milliarcseconds.
-   * Exact and invertible where defined.
-   */
-  def toHourAngleExact: Option[HourAngle] =
-    if (toMicroarcseconds % 15L === 0L) Some(toHourAngle) else None
-
-  /**
-   * Destructure this value into a sum of degrees, arcminutes, arcseconds, milliarcseconds, and
-   * microseconds. Exact, invertible via `Angle.fromDMS`.
-   */
-  def toDMS: Angle.DMS =
-    Angle.DMS(this)
-
-  /** Sum of this angle and `a`. Exact, commutative, invertible. */
   def +(a: Angle): Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds + a.toMicroarcseconds)
 
-  /** Difference of this angle and `a`. Exact, invertible. */
+  /**
+   * Difference of this angle and `a`. Exact, invertible.
+   * @group Operations
+   */
   def -(a: Angle): Angle =
     Angle.fromMicroarcseconds(toMicroarcseconds - a.toMicroarcseconds)
 
   /** String representation of this Angle, for debugging purposes only. */
   override def toString =
-    f"Angle($toDMS, $toDoubleDegrees%1.10f°)"
+    f"Angle(${Angle.dms.get(this)}, $toDoubleDegrees%1.10f°)"
 
   /** Angles are equal if their magnitudes are equal. Exact. */
   override final def equals(a: Any) =
@@ -117,47 +115,46 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
 
 object Angle extends AngleOptics {
 
-  val Angle0:   Angle = fromDegrees(0)
-  val Angle90:  Angle = fromDegrees(90)
-  val Angle180: Angle = fromDegrees(180)
-  val Angle270: Angle = fromDegrees(270)
+  /** @group Constants */ lazy val Angle0:   Angle = degrees.reverseGet(0)
+  /** @group Constants */ lazy val Angle90:  Angle = degrees.reverseGet(90)
+  /** @group Constants */ lazy val Angle180: Angle = degrees.reverseGet(180)
+  /** @group Constants */ lazy val Angle270: Angle = degrees.reverseGet(270)
 
-  /** Construct a new Angle of the given magnitude in integral microarcseconds, modulo 360°. Exact. */
+  /**
+   * Construct a new Angle of the given magnitude in integral microarcseconds, modulo 360°. Exact.
+   * @group Constructors
+   */
   def fromMicroarcseconds(µas: Long): Angle = {
     val µasPer360 = 360L * 60L * 60L * 1000L * 1000L
     val µasʹ = (((µas % µasPer360) + µasPer360) % µasPer360)
     new Angle(µasʹ)
   }
 
-  /** Construct a new Angle of the given magnitude in integral milliarcseconds, modulo 360°. Exact. */
-  def fromMilliarcseconds(as: Int): Angle =
-    fromMicroarcseconds(as.toLong * 1000L)
-
-  /** Construct a new Angle of the given magnitude in integral arcseconds, modulo 360°. Exact. */
-  def fromArcseconds(as: Int): Angle =
-    fromMilliarcseconds(as * 1000)
-
-  /** Construct a new Angle of the given magnitude in integral arcminutes, modulo 360°. Exact. */
-  def fromArcminutes(ms: Int): Angle =
-    fromArcseconds(ms * 60)
-
-  /** Construct a new Angle of the given magnitude in integral degrees, modulo 360°. Exact. */
-  def fromDegrees(ms: Int): Angle =
-    fromArcminutes(ms * 60)
-
-  /** Construct a new Angle of the given magnitude in double degrees, modulo 360°. Approximate. */
+  /**
+   * Construct a new Angle of the given magnitude in double degrees, modulo 360°. Approximate.
+   * @group Constructors
+   */
   def fromDoubleDegrees(ds: Double): Angle =
     fromMicroarcseconds((ds * 60 * 60 * 1000 * 1000).toLong)
 
-  /** Construct a new Angle of the given magnitude in double arcseconds, modulo 360°. Approximate. */
+  /**
+   * Construct a new Angle of the given magnitude in double arcseconds, modulo 360°. Approximate.
+   * @group Constructors
+   */
   def fromDoubleArcseconds(as: Double): Angle =
     fromMicroarcseconds((as * 1000 * 1000).toLong)
 
-  /** Construct a new Angle of the given magnitude in radians, modulo 2π. Approximate. */
+  /**
+   * Construct a new Angle of the given magnitude in radians, modulo 2π. Approximate.
+   * @group Constructors
+   */
   def fromDoubleRadians(rad: Double): Angle =
     fromDoubleDegrees(rad.toDegrees)
 
-  /** Angle forms a commutative group. */
+  /**
+   * Angle forms a commutative group.
+   * @group Typeclass Instances
+   */
   implicit val AngleCommutativeGroup: CommutativeGroup[Angle] =
     new CommutativeGroup[Angle] {
       val empty: Angle = Angle0
@@ -165,20 +162,30 @@ object Angle extends AngleOptics {
       def inverse(a: Angle) = -a
     }
 
+  /** @group Typeclass Instances */
   implicit val AngleShow: Show[Angle] =
     Show.fromToString
 
-  /** Angles are equal if their magnitudes are equal. */
+  /**
+   * Angles are equal if their magnitudes are equal.
+   * @group Typeclass Instances
+   */
   implicit val AngleEqual: Eq[Angle] =
     Eq.fromUniversalEquals
 
-  /** Sorts Angle by magnitude [0, 360) degrees. Not implicit. */
+  /**
+   * Sorts Angle by magnitude [0, 360) degrees. Not implicit.
+   * @group Typeclass Instances
+   */
   val AngleOrder: Order[Angle] =
     Order.by(_.toMicroarcseconds)
 
-  /** Sorts Angle by signed angle, so [-180, 180).  Not implicit. */
+  /**
+   * Sorts Angle by signed angle, so [-180, 180).  Not implicit.
+   * @group Typeclass Instances
+   */
   val SignedAngleOrder: Order[Angle] =
-    Order.by(_.toSignedMicroarcseconds)
+    Order.by(signedMicroarcseconds.get)
 
   // This works for both DMS and HMS so let's just do it once.
   protected[math] def toMicrosexigesimal(micros: Long): (Int, Int, Int, Int, Int) = {
@@ -205,10 +212,15 @@ object Angle extends AngleOptics {
     def format: String = f"$degrees%02d:$arcminutes%02d:$arcseconds%02d.$milliarcseconds%03d$microarcseconds%03d"
     override final def toString = s"DMS($format)"
   }
+  object DMS {
+    implicit val eqDMS: Eq[DMS] =
+      Eq.by(_.toAngle)
+  }
 
   /**
    * Construct a new Angle of the given magnitude as a sum of degrees, arcminutes, arcseconds,
    * milliarcseconds, and microarcseconds. Exact modulo 360°.
+   * @group Constructors
    */
   def fromDMS(
     degrees:         Int,
@@ -227,17 +239,91 @@ object Angle extends AngleOptics {
 
 }
 
-trait AngleOptics { this: Angle.type =>
+trait AngleOptics extends OpticsHelpers { this: Angle.type =>
 
-  val hourAngle: Prism[Angle, HourAngle] =
-    Prism((_: Angle).toHourAngleExact)(_.toAngle)
+  /**
+   * Microarcseconds, in [0, 360°).
+   * @group Optics
+   */
+  lazy val microarcseconds: SplitMono[Angle, Long] =
+    SplitMono(_.toMicroarcseconds, Angle.fromMicroarcseconds)
 
-  val fromStringDMS: Format[String, Angle] =
-    Format(AngleParsers.dms.parseExact, _.toDMS.format)
+  /**
+   * Signed microarcseconds, in [-180°, 180°).
+   * @group Optics
+   */
+  lazy val signedMicroarcseconds: SplitMono[Angle, Long] = {
+    lazy val µas360 = Angle.Angle180.toMicroarcseconds * 2L
+    microarcseconds.imapB[Long](
+      identity,
+      µas => if (µas >= Angle.Angle180.toMicroarcseconds) µas - µas360  else µas
+    )
+  }
 
-  val fromStringSignedDMS: Format[String, Angle] =
+  /**
+   * Milliarcseconds, in [0, 360°).
+   * @group Optics
+   */
+  lazy val milliarcseconds: Wedge[Angle, Int] =
+    microarcseconds.scaled(1000L)
+
+  /**
+   * Arcseconds, in [0, 360°).
+   * @group Optics
+   */
+  lazy val arcseconds: Wedge[Angle, Int] =
+    microarcseconds.scaled(1000L * 1000L)
+
+  /**
+   * Arcminutes, in [0, 360°).
+   * @group Optics
+   */
+  lazy val arcminutes: Wedge[Angle, Int] =
+      microarcseconds.scaled(1000L * 1000L * 60L)
+
+  /**
+   * Degrees, in [0, 360).
+   * @group Optics
+   */
+  lazy val degrees: Wedge[Angle, Int] = microarcseconds.scaled(1000L * 1000L * 60L * 60L)
+
+  /**
+   * This angle, rounded down to the nearest HourAngle.
+   * @group Optics
+   */
+  lazy val hourAngle: SplitEpi[Angle, HourAngle] =
+    SplitEpi(a => HourAngle.microseconds.reverseGet(a.toMicroarcseconds.toLong / 15L), identity)
+
+  /**
+   * This angle as an HourAngle, where defined.
+   * @group Optics
+   */
+  lazy val hourAngleExact: Prism[Angle, HourAngle] =
+    Prism((a: Angle) => if (a.toMicroarcseconds % 15L === 0L) Some(hourAngle.get(a)) else None)(identity)
+
+  /**
+   * This angle as an DMS.
+   * @group Optics
+   */
+  lazy val dms: Iso[Angle, DMS] =
+    Iso(DMS(_))(_.toAngle)
+
+  /**
+   * String parsed as unsigned DMS.
+   * @see [[gem.parser.AngleParsers]]
+   * @group Optics
+   */
+  lazy val fromStringDMS: Format[String, Angle] =
+    Format(AngleParsers.dms.parseExact, dms.get(_).format)
+
+  /**
+   * String parsed as signed DMS.
+   * @see [[gem.parser.AngleParsers]]
+   * @group Optics
+   */
+  lazy val fromStringSignedDMS: Format[String, Angle] =
     Format(fromStringDMS.getOption, { a =>
-      if (a.toSignedMicroarcseconds < 0) "-" + fromStringDMS.reverseGet(-a)
+      if (signedMicroarcseconds.get(a) < 0) "-" + fromStringDMS.reverseGet(-a)
       else "+" + fromStringDMS.reverseGet(a)
     })
 
@@ -248,6 +334,9 @@ trait AngleOptics { this: Angle.type =>
  * Exact hour angles represented as integral microseconds. These values form a commutative group
  * over addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
  * integral Angles where microarcseconds are evenly divisible by 15.
+ *
+ * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+ * object. Floating-point conversions are provided directly
  * @see The helpful [[https://en.wikipedia.org/wiki/Hour_angle Wikipedia]] article.
  */
 final class HourAngle private (µas: Long) extends Angle(µas) {
@@ -255,13 +344,10 @@ final class HourAngle private (µas: Long) extends Angle(µas) {
   // Sanity checks … should be correct via the companion constructor.
   assert(toMicroarcseconds %  15 === 0, s"Invariant violated. $µas isn't divisible by 15.")
 
-  /** Forget this is an HourAngle. */
-  def toAngle: Angle =
-    this
-
   /**
    * Flip this HourAngle by 12h. This is logically identical to the superclass implementation
    * and serves only to refine the return type. Exact, invertible.
+   * @group Transformations
    */
   override def flip: HourAngle =
     this + HourAngle.HourAngle12
@@ -270,27 +356,30 @@ final class HourAngle private (µas: Long) extends Angle(µas) {
    * Additive inverse of this HourAngle (by mirroring around the 0-12h axis). This is logically
    * identical to the superclass implementation and serves only to refine the return type. Exact,
    * invertible.
+   * @group Transformations
    */
   override def unary_- : HourAngle =
     HourAngle.fromMicroseconds(-toMicroseconds.toLong)
 
-  // Overridden for efficiency
-  override def toHourAngle = this
-  override def toHourAngleExact = Some(this)
-
-  // Define in terms of toMicroarcseconds to avoid a second member
+  /**
+   * This `HourAngle` in microseconds. Exact.
+   * @group Conversions
+   */
   def toMicroseconds: Long =
     toMicroarcseconds / 15
 
-  def toHMS: HourAngle.HMS =
-    HourAngle.HMS(this)
-
-  /** Sum of this HourAngle and `ha`. Exact, commutative, invertible. */
+  /**
+   * Sum of this HourAngle and `ha`. Exact, commutative, invertible.
+   * @group Operations
+   */
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def +(ha: HourAngle): HourAngle =
     HourAngle.fromMicroseconds(toMicroseconds.toLong + ha.toMicroseconds.toLong)
 
-  /** Difference of this HourAngle and `ha`. Exact, invertible. */
+  /**
+   * Difference of this HourAngle and `ha`. Exact, invertible.
+   * @group Operations
+   */
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def -(ha: HourAngle): HourAngle =
     HourAngle.fromMicroseconds(toMicroseconds.toLong - ha.toMicroseconds.toLong)
@@ -303,38 +392,30 @@ final class HourAngle private (µas: Long) extends Angle(µas) {
 
 object HourAngle extends HourAngleOptics {
 
-  val HourAngle0 : HourAngle = fromMicroseconds(0)
-  val HourAngle12: HourAngle = fromHours(12)
+  /** @group Constants */ lazy val HourAngle0 : HourAngle = microseconds.reverseGet(0)
+  /** @group Constants */ lazy val HourAngle12: HourAngle = hours.reverseGet(12)
 
-  /** Construct a new Angle of the given magnitude in integral microseconds, modulo 24h. Exact. */
+  /**
+   * Construct a new Angle of the given magnitude in integral microseconds, modulo 24h. Exact.
+   * @group Constructors
+   */
   def fromMicroseconds(µs: Long): HourAngle = {
     val µsPer24 = 24L * 60L * 60L * 1000L * 1000L
     val µsʹ = (((µs % µsPer24) + µsPer24) % µsPer24)
     new HourAngle(µsʹ * 15L)
   }
 
-  /** Construct a new HourAngle of the given magnitude in integral milliseconds, modulo 24h. Exact. */
-  def fromMilliseconds(milliseconds: Int): HourAngle =
-    fromMicroseconds(milliseconds.toLong * 1000L)
-
-  /** Construct a new HourAngle of the given magnitude in integral seconds, modulo 24h. Exact. */
-  def fromSeconds(seconds: Int): HourAngle =
-    fromMilliseconds(seconds * 1000)
-
-  /** Construct a new HourAngle of the given magnitude in integral minutes, modulo 24h. Exact. */
-  def fromMinutes(minutes: Int): HourAngle =
-    fromSeconds(minutes * 60)
-
-  /** Construct a new HourAngle of the given magnitude in integral hours, modulo 24h. Exact. */
-  def fromHours(hours: Int):     HourAngle =
-    fromMinutes(hours * 60)
-
+  /**
+   * Construct a new Angle of the given magnitude in floating point hours, modulo 24h. Approximate.
+   * @group Constructors
+   */
   def fromDoubleHours(hs: Double): HourAngle =
     fromMicroseconds((hs * 60.0 * 60.0 * 1000.0).toLong)
 
   /**
    * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,
    * milliseconds, and microseconds. Exact modulo 24h.
+   * @group Constructors
    */
   def fromHMS(hours: Int, minutes: Int, seconds: Int, milliseconds: Int, microseconds: Int): HourAngle =
     fromMicroseconds(
@@ -345,7 +426,10 @@ object HourAngle extends HourAngleOptics {
       hours.toLong        * 1000L * 1000L * 60L * 60L
     )
 
-  /** HourAngle forms a commutative group. */
+  /**
+   * HourAngle forms a commutative group.
+   * @group Typeclass Instances
+   */
   implicit val AngleCommutativeGroup: CommutativeGroup[HourAngle] =
     new CommutativeGroup[HourAngle] {
       val empty: HourAngle = HourAngle0
@@ -353,10 +437,14 @@ object HourAngle extends HourAngleOptics {
       def inverse(a: HourAngle) = -a
     }
 
+  /** @group Typeclass Instances */
   implicit val HourAngleShow: Show[HourAngle] =
     Show.fromToString
 
-  /** Angles are equal if their magnitudes are equal. */
+  /**
+   * Angles are equal if their magnitudes are equal.
+   * @group Typeclass Instances
+   */
   implicit val HourAngleEqual: Eq[HourAngle] =
     Eq.by(_.toMicroarcseconds)
 
@@ -376,12 +464,83 @@ object HourAngle extends HourAngleOptics {
     def format: String = f"$hours%02d:$minutes%02d:$seconds%02d.$milliseconds%03d$microseconds%03d"
     override final def toString = format
   }
+  object HMS {
+    implicit val eqHMS: Eq[HMS] =
+      Eq.by(_.toHourAngle)
+  }
 
 }
 
-trait HourAngleOptics { this: HourAngle.type =>
+trait HourAngleOptics extends OpticsHelpers { this: HourAngle.type =>
 
-  def fromStringHMS: Format[String, HourAngle] =
-    Format(AngleParsers.hms.parseExact, _.toHMS.format)
+  /**
+   * This `HourAngle` as an `Angle`.
+   * @group Optics
+   */
+  lazy val angle: SplitMono[HourAngle, Angle] = Angle.hourAngle.reverse
+
+  /**
+   * This `HourAngle` as an `Angle`.
+   * @group Optics
+   */
+  lazy val microseconds: SplitMono[HourAngle, Long] =
+    SplitMono(_.toMicroseconds, HourAngle.fromMicroseconds)
+
+  /**
+   * This `HourAngle` in milliseconds.
+   * @group Optics
+   */
+  lazy val milliseconds: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L)
+
+  /**
+   * This `HourAngle` in seconds.
+   * @group Optics
+   */
+  lazy val seconds: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L * 1000L)
+
+  /**
+   * This `HourAngle` in minutes.
+   * @group Optics
+   */
+  lazy val minutes: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L * 1000L * 60L)
+
+  /**
+   * This `HourAngle` in hours.
+   * @group Optics
+   */
+  lazy val hours: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L * 1000L * 60L * 60L)
+
+  /**
+   * This `HourAngle` as an `HMS`.
+   * @group Optics
+   */
+  lazy val hms: Iso[HourAngle, HMS] =
+    Iso(HMS(_))(_.toHourAngle)
+
+  /**
+   * String in HMS as an `HourAngle`/
+   * @group Optics
+   */
+  lazy val fromStringHMS: Format[String, HourAngle] =
+    Format(AngleParsers.hms.parseExact, HMS(_).format)
+
+}
+
+trait OpticsHelpers {
+
+  // Syntax to scale down and squeeze into Int
+  protected implicit class SplitMonoOps[A](self: SplitMono[A, Long]) {
+
+    private val longToInt: SplitEpi[Long, Int] =
+      SplitEpi(_.toInt, _.toLong)
+
+    def scaled(n: Long): Wedge[A, Int] =
+      self.imapB[Long](_ * n, _ / n) composeSplitEpi longToInt
+
+  }
 
 }

--- a/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
@@ -76,7 +76,7 @@ final case class Coordinates(ra: RightAscension, dec: Declination) {
       val φi = atan2(z, sqrt(x * x + y * y))
       val λi = atan2(y, x)
       Coordinates(
-        RA.fromHourAngle.get(Angle.fromDoubleRadians(λi).toHourAngle),
+        RA.fromHourAngle.get(Angle.hourAngle.get(Angle.fromDoubleRadians(λi))),
         Dec.fromAngle.unsafeGet(Angle.fromDoubleRadians(φi))
       )
     }

--- a/modules/core/shared/src/main/scala/gem/math/Declination.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Declination.scala
@@ -76,7 +76,7 @@ object Declination extends DeclinationOptics {
    * @group Typeclass Instances
    */
   implicit val DeclinationOrder: Order[Declination] =
-    Order.by(_.toAngle.toSignedMicroarcseconds)
+    Order.by(dec => Angle.signedMicroarcseconds.get(dec.toAngle))
 
   implicit val DeclinationShow: Show[Declination] =
     Show.fromToString

--- a/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
@@ -23,7 +23,7 @@ final case class EphemerisCoordinates(
   def interpolate(that: EphemerisCoordinates, f: Double): EphemerisCoordinates = {
     def interpolateAngle(a: Angle, b: Angle): Angle =
       Angle.fromMicroarcseconds(
-        (a.toSignedMicroarcseconds.toDouble * (1 - f) + b.toSignedMicroarcseconds * f).round
+        (Angle.signedMicroarcseconds.get(a).toDouble * (1 - f) + Angle.signedMicroarcseconds.get(b) * f).round
       )
 
     val coordʹ = coord.interpolate(that.coord, f)

--- a/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
@@ -92,7 +92,7 @@ object ProperMotion {
   // Some constants we need
   private val secsPerDay  = 86400.0
   private val auPerKm     = 1000.0 / AstronomicalUnit.toDouble
-  private val radsPerAsec = Angle.fromArcseconds(1).toDoubleRadians
+  private val radsPerAsec = Angle.arcseconds.reverseGet(1).toDoubleRadians
 
   // We need to do things with little vectors of doubles
   private type Vec2 = (Double, Double)

--- a/modules/core/shared/src/main/scala/gem/math/RightAscension.scala
+++ b/modules/core/shared/src/main/scala/gem/math/RightAscension.scala
@@ -52,7 +52,7 @@ object RightAscension extends RightAscensionOptics {
    * @group Constructors
    */
   def fromRadians(rad: Double): RightAscension =
-    RightAscension(Angle.fromDoubleRadians(rad).toHourAngle)
+    RightAscension(Angle.hourAngle.get(Angle.fromDoubleRadians(rad)))
 
   /**
    * The `RightAscension` at zero degrees.
@@ -82,7 +82,7 @@ trait RightAscensionOptics { this: RightAscension.type =>
   val fromStringHMS: Format[String, RightAscension] =
     HourAngle.fromStringHMS composeIso fromHourAngle
 
-  val fromAngle: Prism[Angle, RightAscension] =
-    Angle.hourAngle composeIso fromHourAngle
+  val fromAngleExact: Prism[Angle, RightAscension] =
+    Angle.hourAngleExact composeIso fromHourAngle
 
 }

--- a/modules/core/shared/src/test/scala/gem/arb/ArbAngle.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbAngle.scala
@@ -17,11 +17,23 @@ trait ArbAngle {
   implicit def arbHourAngle: Arbitrary[HourAngle] =
     Arbitrary(arbitrary[Double].map(HourAngle.fromDoubleHours))
 
+  implicit def arbDMS: Arbitrary[Angle.DMS] =
+    Arbitrary(arbitrary[Angle].map(Angle.dms.get))
+
+  implicit def arbHMS: Arbitrary[HourAngle.HMS] =
+    Arbitrary(arbitrary[HourAngle].map(HourAngle.hms.get))
+
   implicit def cogAngle: Cogen[Angle] =
     Cogen[Double].contramap(_.toDoubleDegrees)
 
   implicit def cogHourAngle: Cogen[HourAngle] =
     Cogen[Double].contramap(_.toDoubleDegrees)
+
+  implicit def cogDMS: Cogen[Angle.DMS] =
+    Cogen[Angle].contramap(_.toAngle)
+
+  implicit def cogHMS: Cogen[HourAngle.HMS] =
+    Cogen[HourAngle].contramap(_.toHourAngle)
 
   private val perturbations: List[String => Gen[String]] =
     List(

--- a/modules/core/shared/src/test/scala/gem/arb/ArbOffset.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbOffset.scala
@@ -14,12 +14,12 @@ trait ArbOffset {
 
   implicit val arbOffsetP: Arbitrary[Offset.P] =
     Arbitrary(
-      Gen.chooseNum(-10000, 10000).map(mas => Offset.P(Angle.fromMilliarcseconds(mas)))
+      Gen.chooseNum(-10000, 10000).map(mas => Offset.P(Angle.milliarcseconds.reverseGet(mas)))
     )
 
   implicit val arbOffsetQ: Arbitrary[Offset.Q] =
     Arbitrary(
-      Gen.chooseNum(-10000, 10000).map(mas => Offset.Q(Angle.fromMilliarcseconds(mas)))
+      Gen.chooseNum(-10000, 10000).map(mas => Offset.Q(Angle.milliarcseconds.reverseGet(mas)))
     )
 
   implicit val arbOffset: Arbitrary[Offset] =

--- a/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
@@ -76,7 +76,7 @@ final class CoordinatesSpec extends CatsSuite {
   test("angularDistance must be symmetric to within 1µas") {
     forAll { (a: Coordinates, b: Coordinates) =>
       val Δ = a.angularDistance(b) - b.angularDistance(a)
-      Δ.toSignedMicroarcseconds.abs should be <= 1L
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 1L
     }
   }
 
@@ -102,7 +102,7 @@ final class CoordinatesSpec extends CatsSuite {
       val pole = Coordinates(ra1, if (b) Dec.Min else Dec.Max)
       val Δdec = dec.toAngle + Angle.Angle90 // [0, 180]
       val Δ    = pole.angularDistance(pole.offset(ra2.toHourAngle, Δdec)) - Δdec
-      Δ.toSignedMicroarcseconds.abs should be <= 1L
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 1L
     }
   }
 
@@ -112,7 +112,7 @@ final class CoordinatesSpec extends CatsSuite {
       val a = Coordinates(ra, Dec.Zero)
       val b = a.offset(ha, Angle.Angle0)
       val d = a.angularDistance(b)
-      val Δ = d.toSignedMicroarcseconds.abs - ha.toSignedMicroarcseconds.abs
+      val Δ = Angle.signedMicroarcseconds.get(d).abs - Angle.signedMicroarcseconds.get(ha).abs
       Δ.abs should be <= 1L
     }
   }
@@ -120,14 +120,14 @@ final class CoordinatesSpec extends CatsSuite {
   test("interpolate should result in angular distance of 0° from `a` for factor 0.0, within 1µsec (15µas)") {
     forAll { (a: Coordinates, b: Coordinates) =>
       val Δ = a.angularDistance(a.interpolate(b, 0.0))
-      Δ.toSignedMicroarcseconds.abs should be <= 15L
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 15L
     }
   }
 
   test("interpolate should result in angular distance of 0° from `b` for factor 1.0, within 1µsec (15µas)") {
     forAll { (a: Coordinates, b: Coordinates) =>
       val Δ = b.angularDistance(a.interpolate(b, 1.0))
-      Δ.toSignedMicroarcseconds.abs should be <= 15L
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 15L
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
@@ -58,10 +58,10 @@ final class EphemerisCoordinatesSpec extends CatsSuite {
 
   private def midpoint(a: EphemerisCoordinates, b: EphemerisCoordinates, f: Offset => Angle): Assertion = {
     val m  = a.interpolate(b, 0.5).delta
-    val mΔ = f(m).toSignedMicroarcseconds
+    val mΔ = Angle.signedMicroarcseconds.get(f(m))
 
-    val aΔ = f(a.delta).toSignedMicroarcseconds
-    val bΔ = f(b.delta).toSignedMicroarcseconds
+    val aΔ = Angle.signedMicroarcseconds.get(f(a.delta))
+    val bΔ = Angle.signedMicroarcseconds.get(f(b.delta))
 
     mΔ shouldEqual ((aΔ + bΔ)/2.0).round
   }

--- a/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
@@ -8,6 +8,7 @@ import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import gem.arb._
 import gem.laws.discipline._
+import monocle.law.discipline._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class HourAngleSpec extends CatsSuite {
@@ -16,6 +17,15 @@ final class HourAngleSpec extends CatsSuite {
   // Laws
   checkAll("HourAngle", CommutativeGroupTests[HourAngle].commutativeGroup)
   checkAll("HourAngle", EqTests[HourAngle].eqv)
+
+  // Optics
+  checkAll("angle", SplitMonoTests(HourAngle.angle).splitMono)
+  checkAll("microseconds", SplitMonoTests(HourAngle.microseconds).splitMono)
+  checkAll("milliseconds", WedgeTests(HourAngle.milliseconds).wedge)
+  checkAll("seconds", WedgeTests(HourAngle.seconds).wedge)
+  checkAll("minutes", WedgeTests(HourAngle.minutes).wedge)
+  checkAll("hours", WedgeTests(HourAngle.hours).wedge)
+  checkAll("hms", IsoTests(HourAngle.hms))
   checkAll("fromStringHMS", FormatTests(HourAngle.fromStringHMS).formatWith(ArbAngle.stringsHMS))
 
   test("Equality must be natural") {
@@ -39,7 +49,7 @@ final class HourAngleSpec extends CatsSuite {
 
   test("Conversion to HMS must be invertable") {
     forAll { (a: HourAngle) =>
-      val hms = a.toHMS
+      val hms = HourAngle.hms.get(a)
       HourAngle.fromHMS(
         hms.hours,
         hms.minutes,
@@ -47,18 +57,6 @@ final class HourAngleSpec extends CatsSuite {
         hms.milliseconds,
         hms.microseconds
       ) shouldEqual a
-    }
-  }
-
-  test("Widening to Angle must be invertable") {
-    forAll { (a: HourAngle) =>
-      a.toAngle.toHourAngle shouldEqual a
-    }
-  }
-
-  test("Widening to Angle must also work for toHourAngleExact") {
-    forAll { (a: HourAngle) =>
-      a.toAngle.toHourAngleExact shouldEqual Some(a)
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/math/RightAscensionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/RightAscensionSpec.scala
@@ -17,7 +17,7 @@ final class RightAscensionSpec extends CatsSuite {
 
   // Laws
   checkAll("RightAscension", OrderTests[RightAscension].order)
-  checkAll("fromAngle", PrismTests(RightAscension.fromAngle))
+  checkAll("fromAngleExact", PrismTests(RightAscension.fromAngleExact))
   checkAll("fromHourAngle", IsoTests(RightAscension.fromHourAngle))
   checkAll("fromStringHMS", FormatTests(RightAscension.fromStringHMS).formatWith(ArbAngle.stringsHMS))
 


### PR DESCRIPTION
This unifies the to/from data conversion pairs for `Angle` and `HourAngle` by defining optics that have defined laws we can check. This should help ensure that 2-way conversions remain consistent as the code evolves.

There is a question of whether to include accessors at all, or just force the user to go through optics all the time. Apparently this is a common design issue with no good answer. The compromise I reached here is that `Angle` wraps `Long` microarcseconds and `HourAngle` [logically] wraps `Long` microseconds so these "direct" members have traditional accessors. Unrelated/derived types and units have no accessors so you must use optics for these.

The huge diff for `Angle.scala` is mostly Scaladoc comments to group members by function.