### PR TITLE
Add GNIRS StepDao checkers

### DIFF
--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -561,8 +561,8 @@ object StepDao {
         disperserOrder:       GnirsDisperserOrder,
         exposureTime:         Duration,
         filter:               GnirsFilter,
-        prism:                GnirsPrism,
         fpuBuilder:           GnirsFpuBuilder,
+        prism:                GnirsPrism,
         readMode:             GnirsReadMode
       ) {
         def toGnirs: DynamicConfig.Gnirs =
@@ -588,7 +588,7 @@ object StepDao {
                  i.disperser_order,
                  i.exposure_time,
                  i.filter,
-                 i.fpu_list,
+                 i.fpu_slit,
                  i.fpu_other,
                  i.prism,
                  i.read_mode
@@ -602,7 +602,7 @@ object StepDao {
       def selectOne(oid: Observation.Id, loc: Loc): Query0[DynamicConfig.Gnirs] =
         sql"""
           SELECT i.camera,
-                 i.dekcer,
+                 i.decker,
                  i.disperser,
                  i.disperser_order,
                  i.exposure_time,
@@ -645,7 +645,7 @@ object StepDao {
             ${gnirs.fpu.toOption},
             ${gnirs.fpu.swap.toOption},
             ${gnirs.prism},
-            ${gnirs.readMode}
+            ${gnirs.readMode})
         """.update
     }
   }

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -92,6 +92,8 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val target: Target =
       Target("untitled", Right(ProperMotion.const(Coordinates.Zero)))
 
+    val gnirsConfig = DynamicConfig.Gnirs.Default
+
   }
 
 

--- a/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
@@ -27,4 +27,7 @@ class StepCheck extends Check {
   it should "Gmos.selectOneNorth"   in check(Gmos.selectOneNorth(Dummy.observationId, Dummy.locationMiddle))
   it should "Gmos.selectAllSouth"   in check(Gmos.selectAllSouth(Dummy.observationId))
   it should "Gmos.selectOneSouth"   in check(Gmos.selectOneSouth(Dummy.observationId, Dummy.locationMiddle))
+  it should "Gnirs.insert"          in check(Gnirs.insert(0, Dummy.gnirsConfig))
+  it should "Gnirs.selectAll"       in check(Gnirs.selectAll(Dummy.observationId))
+  it should "Gnirs.selectOne"       in check(Gnirs.selectOne(Dummy.observationId, Dummy.locationMiddle))
 }

--- a/modules/sql/src/main/resources/db/migration/V049__Gnirs_exposure_time_bigint.sql
+++ b/modules/sql/src/main/resources/db/migration/V049__Gnirs_exposure_time_bigint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE step_gnirs ALTER COLUMN exposure_time TYPE bigint;


### PR DESCRIPTION
This also includes the fixes uncovered after running the checkers.

I came to realize that I forgot the checkers while working on the GNIRS ocs2 importer. This should also make the importer work.

BTW, the doobie error messages for the checkers were great, they pointed me directly to the errors. If I had to do this by examining the SQL statements by hand, fixing may have taken me longer.