### PR TITLE
ObservingNight

### DIFF
--- a/modules/core/shared/src/main/scala/gem/math/Night.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Night.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.enum.Site
+
+import cats.implicits._
+
+import java.time.{ Duration, Instant }
+import scala.math.Ordering.Implicits._
+
+
+/** Description of the start/end times for a night according to some criterion.
+  * For example, the official observing night begins and ends at 2PM local time
+  * while twilight bounded nights start and end according to defined angles of
+  * the sun below the horizon.
+  */
+trait Night {
+
+  /** Location at which the times described by this night are valid. */
+  def site: Site
+
+  /** Start instant of the night (inclusive). */
+  def start: Instant
+
+  /** End instant of the night (exclusive). */
+  def end: Instant
+
+  /** Duration of the night. */
+  def duration: Duration =
+    Duration.between(start, end)
+
+  /** Returns `true` if the night includes the given `Instant`. */
+  def includes(time: Instant): Boolean =
+    (start <= time) && (time < end)
+}

--- a/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
@@ -1,0 +1,133 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.enum.Site
+
+import cats._
+import cats.data.Validated
+import cats.effect.IO
+import cats.implicits._
+
+import java.time._
+import java.time.format.DateTimeFormatter
+
+import scala.math.Ordering.Implicits._
+
+
+/** An observing night is defined as the period of time from 14:00 on one day
+  * until 14:00 on the following day.  In a timezone that honors daylight saving,
+  * it is sometimes onger and sometimes shorter than a period of 24 hours.  This
+  * is also true of days which contain leap seconds.
+  */
+final case class ObservingNight private (start: Instant, end: Instant, site: Site) extends Night {
+
+  // Sanity check ... should be correct via the companion constructor
+  assert(start < end)
+
+  def previous: ObservingNight =
+    ObservingNight.forInstant(start.minusNanos(1L), site)
+
+  def next: ObservingNight =
+    ObservingNight.forInstant(end, site)
+
+  def format: String =
+    ObservingNight.Formatter.withZone(site.timezone).format(end)
+
+}
+
+object ObservingNight {
+
+  /** The hour, in the local time zone, at which the night is considered to
+    * officially start.
+    *
+    * @group Constants
+    */
+  val LocalNightStartHour: Int =
+    14
+
+  /** The local time at which the night is considered to officially start.
+    *
+    * @group Constants
+    */
+  val LocalNightStart: LocalTime =
+    LocalTime.of(LocalNightStartHour, 0)
+
+  /** Formatter for nights.  The night string representation corresponds to the
+    * date YYYYMMDD for which the night ends in UTC.
+    *
+    * @group Constants
+    */
+  val Formatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyyMMdd")
+
+  /** Returns a IO that when executed the observing night corresponding to the
+    * current instant.
+    *
+    * @group Constructors
+    */
+  def now(s: Site): IO[ObservingNight] =
+    IO(Instant.now).map(forInstant(_, s))
+
+  /** Constructs the observing night that includes the given time at the
+    * specified site.
+    *
+    * @group Constructors
+    */
+  def forInstant(i: Instant, s: Site): ObservingNight = {
+    val zdt   = ZonedDateTime.ofInstant(i, s.timezone)
+
+    val twoPM = zdt.withHour(LocalNightStartHour)
+                   .withMinute(0)
+                   .withSecond(0)
+                   .withNano(0)
+
+    val (start, end) =
+      if (zdt.toLocalTime >= LocalNightStart) (twoPM, twoPM.plusDays(1L))
+      else (twoPM.minusDays(1L), twoPM)
+
+    ObservingNight(start.toInstant, end.toInstant, s)
+  }
+
+  /** Constructs the observing night for the given year, month, and day at the
+    * given site.
+    *
+    * @group Constructors
+    */
+  def forYMD(year: Year, month: Month, day: Int, site: Site): Option[ObservingNight] =
+    Validated.catchNonFatal {
+      ZonedDateTime.of(year.getValue, month.getValue, day, 0, 0, 0, 0, site.timezone)
+                   .minusNanos(1L)
+                   .toInstant
+
+    }.toOption.map(forInstant(_, site))
+
+
+  /** Parses a night string of the form YYYYMMDD into an `ObservingNight` for
+    * the given `Site`.
+    */
+  def parse(nightString: String, site: Site): Option[ObservingNight] =
+    Validated.catchNonFatal { LocalDate.parse(nightString, Formatter) }
+             .toOption
+             .map { localDate =>
+               ObservingNight.forInstant(
+                 ZonedDateTime.of(localDate, LocalNightStart, site.timezone)
+                              .minusNanos(1L)
+                              .toInstant,
+                 site)
+             }
+
+
+  /** @group Typeclass Instances. */
+  implicit val ShowObservingNight: Show[ObservingNight] =
+    Show.fromToString
+
+  /** ObservingNight is ordered by start time.
+    *
+    * @group Typeclass Instances
+    */
+  implicit val OrderObservingNight: Order[ObservingNight] =
+    Order.by(n => (n.start.getEpochSecond, n.start.getNano))
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
@@ -100,7 +100,6 @@ object ObservingNight {
       ZonedDateTime.of(year.getValue, month.getValue, day, 0, 0, 0, 0, site.timezone)
                    .minusNanos(1L)
                    .toInstant
-
     }.toOption.map(forInstant(_, site))
 
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbObservingNight.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbObservingNight.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Site
+import gem.math.ObservingNight
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+import java.time.Instant
+
+
+trait ArbObservingNight {
+
+  import ArbEnumerated._
+  import ArbTime._
+
+  implicit val arbObservingNight: Arbitrary[ObservingNight] =
+    Arbitrary {
+      for {
+        i <- arbitrary[Instant]
+        s <- arbitrary[Site]
+      } yield ObservingNight.forInstant(i, s)
+    }
+
+  implicit val cogObservingNight: Cogen[ObservingNight] =
+    Cogen[(Instant, Instant, Site)].contramap(o => (o.start, o.end, o.site))
+}
+
+object ArbObservingNight extends ArbObservingNight

--- a/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.arb._
+import gem.enum.Site
+import gem.math.ObservingNight.LocalNightStartHour
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
+import java.time._
+
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class ObservingNightSpec extends CatsSuite {
+
+  import ArbObservingNight._
+
+  checkAll("ObservingNight", OrderTests[ObservingNight].order)
+
+  test("Equality must be natural") {
+    forAll { (a: ObservingNight, b: ObservingNight) =>
+      a.equals(b) shouldEqual Eq[ObservingNight].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (o: ObservingNight) =>
+      o.toString shouldEqual Show[ObservingNight].show(o)
+    }
+  }
+
+  test("Always begins at 2PM") {
+    forAll { (o: ObservingNight) =>
+      o.start.atZone(o.site.timezone).getHour shouldEqual LocalNightStartHour
+    }
+  }
+
+  test("Always ends at 2PM") {
+    forAll { (o: ObservingNight) =>
+      o.end.atZone(o.site.timezone).getHour shouldEqual LocalNightStartHour
+    }
+  }
+
+  test("night.previous.next shouldEqual night") {
+    forAll { (o: ObservingNight) =>
+      o.previous.next shouldEqual o
+    }
+  }
+
+  test("handle daylight savings correctly (summer end)") {
+    val o = ObservingNight.forYMD(Year.of(2018), Month.MAY, 13, Site.GS)
+    o.map(_.duration.toHours) shouldEqual Some(25)
+  }
+
+  test("handle daylight savings correctly (winter end)") {
+    val o = ObservingNight.forYMD(Year.of(2018), Month.AUGUST, 12, Site.GS)
+    o.map(_.duration.toHours) shouldEqual Some(23)
+  }
+
+  test("can always parse a formatted night") {
+    forAll { (o: ObservingNight) =>
+      ObservingNight.parse(o.format, o.site) shouldEqual Some(o)
+    }
+  }
+}

--- a/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
@@ -45,6 +45,30 @@ final class ObservingNightSpec extends CatsSuite {
     }
   }
 
+  test("Is contiguous (1)") {
+    forAll { (o: ObservingNight) =>
+      o.previous.end shouldEqual o.start
+    }
+  }
+
+  test("Is contiguous (2)") {
+    forAll { (o: ObservingNight) =>
+      o.next.start shouldEqual o.end
+    }
+  }
+
+  test("Includes start") {
+    forAll { (o: ObservingNight) =>
+      o.includes(o.start) shouldBe true
+    }
+  }
+
+  test("Excludes end") {
+    forAll { (o: ObservingNight) =>
+      o.includes(o.end) shouldBe false
+    }
+  }
+
   test("night.previous.next shouldEqual night") {
     forAll { (o: ObservingNight) =>
       o.previous.next shouldEqual o


### PR DESCRIPTION
This brings `ObservingNight` from the OCS codebase, updated to Scala and the new Java time API.  `ObservingNight` will appear in a number of places but there was one immediate need -- computing the time range for exporting ephemeris data.

#### Night

The `Night` concept applies to various definitions of start and end time, so it is pulled out in a separate trait like in the OCS codebase.  We will want to add `TwilightBoundedNight` at some point because knowing twilight bounds is important in many places.

#### Formatting / Parsing

An `ObservingNight` can be formatted into yyyyMMdd and, given a `Site`, parsed back into an `ObservingNight`.  I didn't try to use any optics here because you need a `Site`. I suppose I could have tried to create a `Format` given a particular `Site`, but I wasn't sure that really made sense.

