### PR TITLE
Rework into LocalObservingNight / ObservingNight

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Semester.scala
+++ b/modules/core/shared/src/main/scala/gem/Semester.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.implicits._
 import gem.enum.{ Half, Site }
 import gem.imp.TimeInstances._
+import gem.math.LocalObservingNight
 import gem.parser.SemesterParsers
 import gem.syntax.parser._
 import java.time._
@@ -100,16 +101,16 @@ object Semester {
 
   /**
    * Semester for the specified local date and time. This handles the 2pm switchover on the last
-   * day of the semester by adding 10 hours to the given date-time, then looking up by month.
+   * day of the semester.
    */
   def fromLocalDateTime(d: LocalDateTime): Semester = {
-    val dʹ = d.plusHours(10)
+    val dʹ = LocalObservingNight.fromLocalDateTime(d).toLocalDate
     fromYearMonth(YearMonth.of(dʹ.getYear, dʹ.getMonth))
   }
 
   /**
    * Semester for the specified zoned date and time. This handles the 2pm switchover on the last
-   * day of the semester by adding 10 hours to the given date-time, then looking up by month.
+   * day of the semester.
    */
   def fromZonedDateTime(d: ZonedDateTime): Semester =
     fromLocalDateTime(d.toLocalDateTime)

--- a/modules/core/shared/src/main/scala/gem/imp/TimeInstances.scala
+++ b/modules/core/shared/src/main/scala/gem/imp/TimeInstances.scala
@@ -20,10 +20,11 @@ trait TimeInstances {
 
   // This looks like repetition but it's not. The isBefore methods have the same name but are
   // unrelated by any common supertype.
-  implicit val InstantOrder:   Order[Instant]   = naturalOrder(_ isBefore _)
-  implicit val YearOrder:      Order[Year]      = naturalOrder(_ isBefore _)
-  implicit val LocalDateOrder: Order[LocalDate] = naturalOrder(_ isBefore _)
-
+  implicit val InstantOrder:       Order[Instant]       = naturalOrder(_ isBefore _)
+  implicit val YearOrder:          Order[Year]          = naturalOrder(_ isBefore _)
+  implicit val LocalTimeOrder:     Order[LocalTime]     = naturalOrder(_ isBefore _)
+  implicit val LocalDateOrder:     Order[LocalDate]     = naturalOrder(_ isBefore _)
+  implicit val LocalDateTimeOrder: Order[LocalDateTime] = naturalOrder(_ isBefore _)
 
 }
 object TimeInstances extends TimeInstances

--- a/modules/core/shared/src/main/scala/gem/math/LocalObservingNight.scala
+++ b/modules/core/shared/src/main/scala/gem/math/LocalObservingNight.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats._
+import cats.data.Validated
+import cats.effect.Sync
+import cats.implicits._
+import gem.enum.Site
+import gem.imp.TimeInstances._
+
+import java.time._
+import java.time.format.DateTimeFormatter
+
+/** A local observing night is defined as the period of time starting at 14:00
+  * (inclusive) on one day and ending at 14:00 (exclusive) the next day.
+  *
+  * A `LocalObservingNight` is site-agnostic.  Use `atSite` to obtain precise
+  * start / end times in an `ObservingNight`.
+  */
+final case class LocalObservingNight(toLocalDate: LocalDate) {
+
+  /** Constructs an ObservingNight associated with a particular Site. */
+  def atSite(site: Site): ObservingNight =
+    ObservingNight(site, this)
+
+  /** The start time (inclusive) of the local observing night. */
+  def start: LocalDateTime =
+    end.minusDays(1L)
+
+  /** The end time (exclusive) of the local observing night. */
+  def end: LocalDateTime =
+    LocalDateTime.of(toLocalDate, LocalObservingNight.Start)
+
+  /** The previous local observing night. */
+  def previous: LocalObservingNight =
+    LocalObservingNight(toLocalDate.minusDays(1L))
+
+  /** The next local observing night. */
+  def next: LocalObservingNight =
+    LocalObservingNight(toLocalDate.plusDays(1L))
+
+  /** Returns `true` if the local date time is included in this night, but
+    * `false` otherwise.
+    */
+  def includes(d: LocalDateTime): Boolean =
+    (start <= d) && (d < end)
+
+  /** Formats the LocalObservingNight to a String `YYYYMMDD` that is readable by
+    * `LocalObservingNight.fromString`.
+    */
+  def format: String =
+    LocalObservingNight.Formatter.format(toLocalDate)
+}
+
+object LocalObservingNight {
+
+  /** The hour, in the local time zone, at which the night is considered to
+    * officially start.
+    *
+    * @group Constants
+    */
+  val StartHour: Int =
+    14
+
+  /** The local time at which the night is considered to officially start.
+    *
+    * @group Constants
+    */
+  val Start: LocalTime =
+    LocalTime.of(StartHour, 0)
+
+  /** Formatter for nights.  The night string representation corresponds to the
+    * date YYYYMMDD for which the night ends in UTC.
+    *
+    * @group Constants
+    */
+  val Formatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyyMMdd")
+
+  /** Constructs the LocalObservingNight corresponding to the given date and
+    * time, taking into account the 2PM switchover hour.
+    *
+    * @group Constructors
+    */
+  def fromLocalDateTime(d: LocalDateTime): LocalObservingNight =
+    LocalObservingNight(
+      d.toLocalDate.plusDays(if (d.toLocalTime >= Start) 1L else 0L)
+    )
+
+  /** Constructs the LocalObservingNight corresponding to the given time, taking
+    * into account the 2PM switchover hour.
+    *
+    * @group Constructors
+    */
+  def fromZonedDateTime(d: ZonedDateTime): LocalObservingNight =
+    fromLocalDateTime(d.toLocalDateTime)
+
+  /** Constructs the LocalObservingNight corresponding to the given time, taking
+    * into account the 2PM switchover hour.
+    *
+    * @group Constructors
+    */
+  def fromSiteAndInstant(s: Site, i: Instant): LocalObservingNight =
+    fromZonedDateTime(ZonedDateTime.ofInstant(i, s.timezone))
+
+  /** Returns a program in M that computes the LocalObservingNight for the
+    * instant it is executed.
+    *
+    * @group Constructors
+    */
+  def current[M[_]: Sync]: M[LocalObservingNight] =
+    Sync[M].delay(LocalDateTime.now).map(fromLocalDateTime)
+
+  /** Parse a LocalObservingNight like `20180307` from a String, if possible. */
+  def fromString(s: String): Option[LocalObservingNight] =
+    Validated.catchNonFatal { LocalDate.parse(s, Formatter) }
+             .toOption
+             .map(LocalObservingNight(_))
+
+  /** Parse a LocalObservingNight like `20180307` from a String, throwing on
+    * failure.
+    */
+  def unsafeFromString(s: String): LocalObservingNight =
+    fromString(s).getOrElse(sys.error(s"Invalid night: $s"))
+
+  /** @group Typeclass Instances. */
+  implicit val ShowLocalObservingNight: Show[LocalObservingNight] =
+    Show.fromToString
+
+  /** LocalObservingNight is ordered by local date.
+    *
+    * @group Typeclass Instances
+    */
+  implicit val OrderLocalObservingNight: Order[LocalObservingNight] =
+    Order.by(_.toLocalDate)
+}

--- a/modules/core/shared/src/test/scala/gem/arb/ArbObservingNight.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbObservingNight.scala
@@ -5,12 +5,12 @@ package gem
 package arb
 
 import gem.enum.Site
-import gem.math.ObservingNight
+import gem.math.{ LocalObservingNight, ObservingNight }
 
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 
-import java.time.Instant
+import java.time.LocalDate
 
 
 trait ArbObservingNight {
@@ -18,16 +18,24 @@ trait ArbObservingNight {
   import ArbEnumerated._
   import ArbTime._
 
+  implicit val arbLocalObservingNight: Arbitrary[LocalObservingNight] =
+    Arbitrary {
+      arbitrary[LocalDate].map(LocalObservingNight(_))
+    }
+
   implicit val arbObservingNight: Arbitrary[ObservingNight] =
     Arbitrary {
       for {
-        i <- arbitrary[Instant]
+        n <- arbitrary[LocalObservingNight]
         s <- arbitrary[Site]
-      } yield ObservingNight.forInstant(i, s)
+      } yield n.atSite(s)
     }
 
+  implicit val cogLocalObservingNight: Cogen[LocalObservingNight] =
+    Cogen[LocalDate].contramap(_.toLocalDate)
+
   implicit val cogObservingNight: Cogen[ObservingNight] =
-    Cogen[(Instant, Instant, Site)].contramap(o => (o.start, o.end, o.site))
+    Cogen[(Site, LocalObservingNight)].contramap(o => (o.site, o.toLocalObservingNight))
 }
 
 object ArbObservingNight extends ArbObservingNight

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
@@ -87,6 +87,9 @@ trait ArbTime {
   implicit val cogInstant: Cogen[Instant] =
     Cogen[(Long, Int)].contramap(t => (t.getEpochSecond, t.getNano))
 
+  implicit val cogLocalDate: Cogen[LocalDate] =
+    Cogen[(Int, Int)].contramap(d => (d.getYear, d.getDayOfYear))
+
   implicit val cogTimestamp: Cogen[Timestamp] =
     Cogen[Instant].contramap(_.toInstant)
 

--- a/modules/core/shared/src/test/scala/gem/math/LocalObservingNightSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/LocalObservingNightSpec.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.arb._
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class LocalObservingNightSpec extends CatsSuite {
+
+  import ArbEnumerated._
+  import ArbObservingNight._
+
+  checkAll("LocalObservingNight", OrderTests[LocalObservingNight].order)
+
+  test("Equality must be natural") {
+    forAll { (a: LocalObservingNight, b: LocalObservingNight) =>
+      a.equals(b) shouldEqual Eq[LocalObservingNight].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (o: LocalObservingNight) =>
+      o.toString shouldEqual Show[LocalObservingNight].show(o)
+    }
+  }
+
+  test("Always begins at 2PM") {
+    forAll { (o: LocalObservingNight) =>
+      o.start.getHour shouldEqual LocalObservingNight.StartHour
+    }
+  }
+
+  test("Always ends at 2PM") {
+    forAll { (o: LocalObservingNight) =>
+      o.end.getHour shouldEqual LocalObservingNight.StartHour
+    }
+  }
+
+  test("Is contiguous (1)") {
+    forAll { (o: LocalObservingNight) =>
+      o.previous.end shouldEqual o.start
+    }
+  }
+
+  test("Is contiguous (2)") {
+    forAll { (o: LocalObservingNight) =>
+      o.next.start shouldEqual o.end
+    }
+  }
+
+  test("Includes start") {
+    forAll { (o: LocalObservingNight) =>
+      o.includes(o.start) shouldBe true
+    }
+  }
+
+  test("Excludes end") {
+    forAll { (o: LocalObservingNight) =>
+      o.includes(o.end) shouldBe false
+    }
+  }
+
+  test("night.previous.next shouldEqual night") {
+    forAll { (o: LocalObservingNight) =>
+      o.previous.next shouldEqual o
+    }
+  }
+
+  test("can always parse a formatted night") {
+    forAll { (o: LocalObservingNight) =>
+      LocalObservingNight.fromString(o.format) shouldEqual Some(o)
+    }
+  }
+
+}

--- a/modules/telnetd/src/main/scala/command/eph.scala
+++ b/modules/telnetd/src/main/scala/command/eph.scala
@@ -83,7 +83,7 @@ object eph extends SiteOpt {
     */
   val exportCommand: GemCommand = {
     def range(now: Instant, s: Site): (Timestamp, Timestamp) = {
-      val n = ObservingNight.forInstant(now, s)
+      val n = ObservingNight.fromSiteAndInstant(s, now)
       (Timestamp.unsafeFromInstant(n.start), Timestamp.unsafeFromInstant(n.end))
     }
 


### PR DESCRIPTION
This PR takes a cue from the new Java time library and splits observing night into a site-agnostic `LocalObservingNight` and a site-specific `ObservingNight`.  The `LocalObservingNight` handles the 2PM switchover logic and the `ObservingNight` combines a `Site` and a `LocalObservingNight` to provide precise start/end times.

Along the way it addresses #251, updating `Semester` to use `LocalObservingNight` to do the switchover logic. It also makes the constructor names consistent with those used in `Semester`.