### PR TITLE
Add static config to smartgcal key creation

### DIFF
--- a/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
@@ -22,12 +22,13 @@ sealed abstract class DynamicConfig extends Product with Serializable {
     * configuration.
     * @return corresponding smart gcal search key, if any
     */
-  def smartGcalKey: Option[DynamicConfig.SmartGcalSearchKey] =
-    this match {
-      case f2: DynamicConfig.F2        => Some(f2.key)
-      case gn: DynamicConfig.GmosNorth => Some(gn.key)
-      case gs: DynamicConfig.GmosSouth => Some(gs.key)
-      case _                           => None
+  def smartGcalKey(s: StaticConfig): Option[DynamicConfig.SmartGcalSearchKey] =
+    (this, s) match {
+      case (d: DynamicConfig.F2,        _) => Some(d.key)
+      case (d: DynamicConfig.GmosNorth, _) => Some(d.key)
+      case (d: DynamicConfig.GmosSouth, _) => Some(d.key)
+//    case (d: DynamicConfig.Gnirs, s: StaticConfig.Gnirs) => Some(d.key(s))
+      case _                               => None
     }
 }
 

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -7,9 +7,8 @@ import cats.implicits._
 import doobie._, doobie.implicits._
 import gem.arb.ArbEnumerated._
 import gem.config.GcalConfig
-import gem.config.DynamicConfig
 import gem.config.DynamicConfig.SmartGcalSearchKey
-import gem.enum.SmartGcalType
+import gem.enum.{ Instrument, SmartGcalType }
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -21,14 +20,12 @@ object SmartGcalSample extends TimedSample with gem.config.Arbitraries {
   private def nextType(): Option[SmartGcalType] =
     arbitrary[SmartGcalType].sample
 
-  private def nextDynamicConfig(): Option[DynamicConfig] =
-    Gen.oneOf(
-      genF2Dynamic,
-      genGmosNorthDynamic
-    ).sample
-
   private def nextKey(): Option[SmartGcalSearchKey] =
-    nextDynamicConfig.flatMap(_.smartGcalKey)
+    (for {
+      i <- Gen.oneOf(Instrument.Flamingos2, Instrument.GmosN, Instrument.GmosS)
+      s <- genStaticConfigOf(i: Instrument.Aux[i.type])
+      d <- genDynamicConfigOf(i: Instrument.Aux[i.type])
+    } yield d.smartGcalKey(s)).sample.flatten
 
   private def nextTest(): Option[(SmartGcalSearchKey, SmartGcalType)] =
     for {
@@ -37,7 +34,7 @@ object SmartGcalSample extends TimedSample with gem.config.Arbitraries {
     } yield (k, t)
 
   override def runl(args: List[String]): ConnectionIO[Result] =
-    ((1 to 1000).toList.as(nextTest().toList).flatten).traverse { case (k, t) =>
+    ((1 to 1000).toList.flatMap(_ => nextTest().toList)).traverse { case (k, t) =>
       SmartGcalDao.select(k, t).map { g => (k, t, g) }
     }
 


### PR DESCRIPTION
@jdnavarro discovered that GNIRS smartgcal keys require a bit of static configuration (GNIRS well depth).  The existing smartgcal code assumes that the smartgcal key can be extracted from dynamic config alone.  This PR adds static configuration to key creation so that it can work for GNIRS as well.

You might want to look at the two commits individually or maybe focus on just the second commit since it contains the payload. 