### PR TITLE
Enumerations for GNIRS SmartGCAL key lookup

### DIFF
--- a/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
@@ -188,6 +188,7 @@ object DynamicConfig {
   }
 
   final case class Gnirs(
+    acquisitionMirror:    GnirsAcquisitionMirror,
     camera:               GnirsCamera,
     decker:               GnirsDecker,
     disperser:            GnirsDisperser,
@@ -201,6 +202,7 @@ object DynamicConfig {
 
   object Gnirs {
     val Default: Gnirs = Gnirs(
+      GnirsAcquisitionMirror.Out,
       GnirsCamera.ShortBlue,
       GnirsDecker.Acquisition,
       GnirsDisperser.D32,

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsAcquisitionMirror.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsAcquisitionMirror.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Acquisition Mirror.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsAcquisitionMirror(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable {
+  type Self = this.type
+}
+
+object GnirsAcquisitionMirror {
+
+  type Aux[A] = GnirsAcquisitionMirror { type Self = A }
+
+  /** @group Constructors */ case object In extends GnirsAcquisitionMirror("In", "In", "In")
+  /** @group Constructors */ case object Out extends GnirsAcquisitionMirror("Out", "Out", "Out")
+
+  /** All members of GnirsAcquisitionMirror, in canonical order. */
+  val all: List[GnirsAcquisitionMirror] =
+    List(In, Out)
+
+  /** Select the member of GnirsAcquisitionMirror with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsAcquisitionMirror] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsAcquisitionMirror with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsAcquisitionMirror =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsAcquisitionMirrorEnumerated: Enumerated[GnirsAcquisitionMirror] =
+    new Enumerated[GnirsAcquisitionMirror] {
+      def all = GnirsAcquisitionMirror.all
+      def tag(a: GnirsAcquisitionMirror) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsCamera.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsCamera.scala
@@ -16,7 +16,7 @@ sealed abstract class GnirsCamera(
   val tag: String,
   val shortName: String,
   val longName: String,
-  val pixelScale: BigDecimal
+  val pixelScale: GnirsPixelScale
 ) extends Product with Serializable {
   type Self = this.type
 }
@@ -25,14 +25,14 @@ object GnirsCamera {
 
   type Aux[A] = GnirsCamera { type Self = A }
 
-  /** @group Constructors */ case object ShortBlue extends GnirsCamera("ShortBlue", "Short blue", "Short blue camera", 0.15)
-  /** @group Constructors */ case object LongBlue extends GnirsCamera("LongBlue", "Long blue", "Long blue camera", 0.05)
-  /** @group Constructors */ case object ShortRed extends GnirsCamera("ShortRed", "Short red", "Short red camera", 0.15)
-  /** @group Constructors */ case object LongRed extends GnirsCamera("LongRed", "Long red", "Long red camera", 0.05)
+  /** @group Constructors */ case object LongBlue extends GnirsCamera("LongBlue", "Long blue", "Long blue camera", GnirsPixelScale.PixelScale_0_05)
+  /** @group Constructors */ case object LongRed extends GnirsCamera("LongRed", "Long red", "Long red camera", GnirsPixelScale.PixelScale_0_05)
+  /** @group Constructors */ case object ShortBlue extends GnirsCamera("ShortBlue", "Short blue", "Short blue camera", GnirsPixelScale.PixelScale_0_15)
+  /** @group Constructors */ case object ShortRed extends GnirsCamera("ShortRed", "Short red", "Short red camera", GnirsPixelScale.PixelScale_0_15)
 
   /** All members of GnirsCamera, in canonical order. */
   val all: List[GnirsCamera] =
-    List(ShortBlue, LongBlue, ShortRed, LongRed)
+    List(LongBlue, LongRed, ShortBlue, ShortRed)
 
   /** Select the member of GnirsCamera with the given tag, if any. */
   def fromTag(s: String): Option[GnirsCamera] =

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsPixelScale.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsPixelScale.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Pixel Scale.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsPixelScale(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: BigDecimal
+) extends Product with Serializable {
+  type Self = this.type
+}
+
+object GnirsPixelScale {
+
+  type Aux[A] = GnirsPixelScale { type Self = A }
+
+  /** @group Constructors */ case object PixelScale_0_05 extends GnirsPixelScale("PixelScale_0_05", "0.05 arcsec/pix", "Pixel scale for short cameras", 0.05)
+  /** @group Constructors */ case object PixelScale_0_15 extends GnirsPixelScale("PixelScale_0_15", "0.15 arcsec/pix", "Pixel scale for long cameras", 0.15)
+
+  /** All members of GnirsPixelScale, in canonical order. */
+  val all: List[GnirsPixelScale] =
+    List(PixelScale_0_05, PixelScale_0_15)
+
+  /** Select the member of GnirsPixelScale with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsPixelScale] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsPixelScale with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsPixelScale =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsPixelScaleEnumerated: Enumerated[GnirsPixelScale] =
+    new Enumerated[GnirsPixelScale] {
+      def all = GnirsPixelScale.all
+      def tag(a: GnirsPixelScale) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
@@ -234,16 +234,17 @@ trait Arbitraries {
 
   val genGnirsDynamic: Gen[DynamicConfig.Aux[Gnirs.type]] =
       for {
-        a <- arbitrary[GnirsCamera                        ]
-        b <- arbitrary[GnirsDecker                        ]
-        c <- arbitrary[GnirsDisperser                     ]
-        d <- arbitrary[Duration                           ]
-        e <- arbitrary[GnirsFilter                        ]
-        f <- arbitrary[Either[GnirsFpuOther, GnirsFpuSlit]]
-        g <- arbitrary[GnirsPrism                         ]
-        h <- arbitrary[GnirsReadMode                      ]
-        i <- Gen.choose(1000, 120000).map(Wavelength.fromAngstroms.unsafeGet)
-      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i)
+        a <- arbitrary[GnirsAcquisitionMirror             ]
+        b <- arbitrary[GnirsCamera                        ]
+        c <- arbitrary[GnirsDecker                        ]
+        d <- arbitrary[GnirsDisperser                     ]
+        e <- arbitrary[Duration                           ]
+        f <- arbitrary[GnirsFilter                        ]
+        g <- arbitrary[Either[GnirsFpuOther, GnirsFpuSlit]]
+        h <- arbitrary[GnirsPrism                         ]
+        i <- arbitrary[GnirsReadMode                      ]
+        j <- Gen.choose(1000, 120000).map(Wavelength.fromAngstroms.unsafeGet)
+      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j)
 
   def genDynamicConfigOf[I <: Instrument with Singleton](i: Instrument.Aux[I]): Gen[DynamicConfig.Aux[I]] = {
     i match {

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -551,6 +551,7 @@ object StepDao {
       def selectAll(oid: Observation.Id): Query0[(Loc, DynamicConfig.Gnirs)] =
         sql"""
           SELECT s.location,
+                 i.acquisition_mirror,
                  i.camera,
                  i.decker,
                  i.disperser,
@@ -570,7 +571,8 @@ object StepDao {
 
       def selectOne(oid: Observation.Id, loc: Loc): Query0[DynamicConfig.Gnirs] =
         sql"""
-          SELECT i.camera,
+          SELECT i.acquisition_mirror,
+                 i.camera,
                  i.decker,
                  i.disperser,
                  i.exposure_time,
@@ -592,6 +594,7 @@ object StepDao {
         sql"""
           INSERT INTO step_gnirs (
             step_gnirs_id,
+            acquisition_mirror,
             camera,
             decker,
             disperser,
@@ -605,6 +608,7 @@ object StepDao {
           )
           VALUES (
             $id,
+            ${gnirs.acquisitionMirror},
             ${gnirs.camera},
             ${gnirs.decker},
             ${gnirs.disperser},

--- a/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
@@ -140,15 +140,16 @@ object Legacy {
 
     object Gnirs {
       import Parsers.Gnirs._
-      val Camera         = Key("camera"           )(camera)
-      val Decker         = Key("decker"           )(decker)
-      val Disperser      = Key("disperser"        )(disperser)
-      val Filter         = Key("filter"           )(filter)
-      val Fpu            = Key("slitWidth"        )(fpu)
-      val Prism          = Key("crossDispersed"   )(prism)
-      val ReadMode       = Key("readMode"         )(readMode)
-      val Wavelength     = Key("centralWavelength")(centralWavelength)
-      val WellDepth      = Key("wellDepth"        )(wellDepth)
+      val AcquisitionMirror = Key("acquisitionMirror")(acquisitionMirror)
+      val Camera            = Key("camera"           )(camera)
+      val Decker            = Key("decker"           )(decker)
+      val Disperser         = Key("disperser"        )(disperser)
+      val Filter            = Key("filter"           )(filter)
+      val Fpu               = Key("slitWidth"        )(fpu)
+      val Prism             = Key("crossDispersed"   )(prism)
+      val ReadMode          = Key("readMode"         )(readMode)
+      val Wavelength        = Key("centralWavelength")(centralWavelength)
+      val WellDepth         = Key("wellDepth"        )(wellDepth)
     }
   }
 

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -540,6 +540,16 @@ object Parsers {
 
   object Gnirs {
 
+    val acquisitionMirror: PioParse[GnirsAcquisitionMirror] = {
+
+      import GnirsAcquisitionMirror._
+
+      enum(
+        "IN"  -> In,
+        "OUT" -> Out
+      )
+    }
+
     val camera: PioParse[GnirsCamera] = {
 
       import GnirsCamera._

--- a/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
@@ -174,16 +174,17 @@ object SequenceDecoder extends PioDecoder[List[Step[DynamicConfig]]] {
       import Legacy.Instrument.Gnirs._
       import gem.config.DynamicConfig.Gnirs.Default
       for {
-        a <- Camera.parse(cm)
-        b <- Decker.cparseOrElse(cm, Default.decker)
-        c <- Disperser.parse(cm)
-        d <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Default.exposureTime)
-        e <- Filter.cparseOrElse(cm, Default.filter)
-        f <- Fpu.parse(cm)
-        g <- Prism.parse(cm)
-        h <- ReadMode.parse(cm)
-        i <- Wavelength.parse(cm)
-      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i)
+        a <- AcquisitionMirror.parse(cm)
+        b <- Camera.parse(cm)
+        c <- Decker.cparseOrElse(cm, Default.decker)
+        d <- Disperser.parse(cm)
+        e <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Default.exposureTime)
+        f <- Filter.cparseOrElse(cm, Default.filter)
+        g <- Fpu.parse(cm)
+        h <- Prism.parse(cm)
+        i <- ReadMode.parse(cm)
+        j <- Wavelength.parse(cm)
+      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j)
     }
   }
 

--- a/modules/sql/src/main/resources/db/migration/V053__Gnirs_Gcal_enums.sql
+++ b/modules/sql/src/main/resources/db/migration/V053__Gnirs_Gcal_enums.sql
@@ -1,0 +1,62 @@
+DROP TYPE acquisition_mirror;
+
+--
+-- Name: e_gnirs_acquisition_mirror; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_acquisition_mirror (
+    id         identifier PRIMARY KEY,
+    short_name TEXT       NOT NULL,
+    long_name  TEXT       NOT NULL
+);
+
+ALTER TABLE e_gnirs_acquisition_mirror OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_acquisition_mirror; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_acquisition_mirror(id, short_name, long_name) FROM stdin;
+In	In	In
+Out	Out	Out
+\.
+
+
+ALTER TABLE step_gnirs
+    ADD COLUMN acquisition_mirror identifier NOT NULL REFERENCES e_gnirs_acquisition_mirror;
+
+--
+-- Name: e_gnirs_acquisition_mirror; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_pixel_scale (
+    id         identifier   PRIMARY KEY,
+    short_name TEXT         NOT NULL,
+    long_name  TEXT         NOT NULL,
+    value      numeric(3,2) NOT NULL
+);
+
+ALTER TABLE e_gnirs_pixel_scale OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_pixel_scale; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_pixel_scale(id, short_name, long_name, value) FROM stdin;
+PixelScale_0_05	0.05 as/pix	Pixel scale for short cameras	0.05
+PixelScale_0_15	0.15 as/pix	Pixel scale for long cameras	0.15
+\.
+
+COMMENT ON COLUMN e_gnirs_pixel_scale.value IS 'arcsec/pixels';
+
+ALTER TABLE e_gnirs_camera
+    DROP COLUMN pixel_scale,
+    ADD COLUMN pixel_scale identifier REFERENCES e_gnirs_pixel_scale;
+
+UPDATE e_gnirs_camera
+    SET pixel_scale = 'PixelScale_0_05' WHERE id = 'LongBlue'  OR id = 'LongRed';
+
+UPDATE e_gnirs_camera
+    SET pixel_scale = 'PixelScale_0_15' WHERE id = 'ShortBlue' OR id = 'ShortRed';
+
+ALTER TABLE e_gnirs_camera ALTER COLUMN pixel_scale SET NOT NULL;

--- a/modules/sql/src/main/scala/EnumDef.scala
+++ b/modules/sql/src/main/scala/EnumDef.scala
@@ -42,6 +42,7 @@ object EnumDef {
     implicit def caseOptionMagnitudeBand[S] = at[(S, Option[MagnitudeBand])] { _ => Option.empty[String] }
     implicit def caseMagnitudeValue[S] = at[(S, MagnitudeValue)] { _ => Some("gem.math.MagnitudeValue") }
     implicit def caseOptionMagnitudeValue[S] = at[(S, Option[MagnitudeValue])] { _ => Some("gem.math.MagnitudeValue") }
+    implicit def caseGnirsPixelScale[S] = at[(S, GnirsPixelScale)] { _ => Option.empty[String] }
     implicit def caseEnumRef[T <: Symbol, S] = at[(S, EnumRef[T])] { _ => Option.empty[String] }
     implicit def caseLazyEnumRef[T <: Symbol, S] = at[(S, LazyEnumRef[T])] { _ => Option("cats.Eval") }
     implicit def caseOptionEnumRef[T <: Symbol, S] = at[(S, Option[EnumRef[T]])] { _ => Option.empty[String] }
@@ -77,6 +78,7 @@ object EnumDef {
 
     implicit def caseMagnitudeValue      [S <: Symbol] = at[(S, MagnitudeValue)        ] { case (s, _) => s"  val ${s.name}: MagnitudeValue" }
     implicit def caseOptionMagnitudeValue[S <: Symbol] = at[(S, Option[MagnitudeValue])] { case (s, _) => s"  val ${s.name}: Option[MagnitudeValue]" }
+    implicit def caseGnirsPixelScale[S <: Symbol] = at[(S, GnirsPixelScale)] { case (s, _) => s"  val ${s.name}: GnirsPixelScale" }
 
     implicit def caseEnumRef[T <: Symbol: ValueOf, S <: Symbol]       = at[(S, EnumRef[T])        ] { case (s, _) => s"  val ${s.name}: ${valueOf[T].name}" }
     implicit def caseLazyEnumRef[T <: Symbol: ValueOf, S <: Symbol]   = at[(S, LazyEnumRef[T])    ] { case (s, _) => s"  val ${s.name}: Eval[${valueOf[T].name}]" }
@@ -112,6 +114,7 @@ object EnumDef {
 
     implicit val caseOptionWavelengthNm = at[Option[Wavelength.Nm]](a => a.fold("Option.empty[Wavelength]")(aʹ => s"""Some(Wavelength.fromAngstroms.unsafeGet(${aʹ.toAngstrom}))"""))
     implicit val caseOptionWavelengthUm = at[Option[Wavelength.Um]](a => a.fold("Option.empty[Wavelength]")(aʹ => s"""Some(Wavelength.fromAngstroms.unsafeGet(${aʹ.toAngstrom}))"""))
+    implicit val caseGnirsPixelScale = at[GnirsPixelScale](a => s"GnirsPixelScale.${a.id}")
 
     // scalastyle:off method.type
     implicit def caseEnumRef[T <: Symbol: ValueOf]       = at[EnumRef[T]        ](a => s"${valueOf[T].name}.${a.tag}")

--- a/modules/sql/src/main/scala/GnirsPixelScale.scala
+++ b/modules/sql/src/main/scala/GnirsPixelScale.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+/** Minimal PixelScale classes to support reading from the enum
+  * tables.
+  */
+
+final case class GnirsPixelScale(id: String)

--- a/modules/sql/src/main/scala/enum/GnirsEnums.scala
+++ b/modules/sql/src/main/scala/enum/GnirsEnums.scala
@@ -13,8 +13,13 @@ object GnirsEnums {
   val enums: List[ConnectionIO[EnumDef]] =
     List(
 
+      EnumDef.fromQuery("GnirsAcquisitionMirror", "GNIRS Acquisition Mirror") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"""SELECT id, id tag, short_name, long_name FROM e_gnirs_acquisition_mirror""".query[(String, R)]
+      },
+
       EnumDef.fromQuery("GnirsCamera", "GNIRS Camera") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'pixelScale -> BigDecimal`.T
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'pixelScale -> GnirsPixelScale`.T
         sql"""SELECT id, id tag, short_name, long_name, pixel_scale FROM e_gnirs_camera""".query[(String, R)]
       },
 
@@ -47,6 +52,12 @@ object GnirsEnums {
         type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gnirs_fpu_other""".query[(String, R)]
       },
+
+      EnumDef.fromQuery("GnirsPixelScale", "GNIRS Pixel Scale") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> BigDecimal`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gnirs_pixel_scale""".query[(String, R)]
+      },
+
 
       EnumDef.fromQuery("GnirsWellDepth", "GNRIS Well Depth") {
         type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'bias_level -> Int`.T


### PR DESCRIPTION
- Make Acquisition Mirror an enumeration with its own table instead of a
  postgres enum type.
- Make Pixel Scale an enumeration with its own table instead of a column of
  GNIRS camera.

See #254.