### PR TITLE
gem.math optics

### DIFF
--- a/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
@@ -8,6 +8,8 @@ import cats._, cats.implicits._
 import gem.parser.CoordinateParsers
 import gem.optics.Format
 import gem.syntax.all._
+import monocle.Lens
+import monocle.macros._
 import scala.math.{ sin, cos, atan2, sqrt }
 
 /** A point in the sky, given right ascension and declination. */
@@ -91,6 +93,7 @@ final case class Coordinates(ra: RightAscension, dec: Declination) {
 
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Coordinates extends CoordinatesOptics {
 
   /* @group Constructors */ val Zero:      Coordinates = Coordinates(RA.Zero, Dec.Zero)
@@ -115,10 +118,21 @@ object Coordinates extends CoordinatesOptics {
 
 trait CoordinatesOptics { this: Coordinates.type =>
 
-  /** Format as a String like "17 57 48.49803 +04 41 36.2072". */
+  /**
+   * Format as a String like "17 57 48.49803 +04 41 36.2072".
+   * @group Optics
+   */
   val fromHmsDms: Format[String, Coordinates] = Format(
     CoordinateParsers.coordinates.parseExact,
     cs => s"${RightAscension.fromStringHMS.reverseGet(cs.ra)} ${Declination.fromStringSignedDMS.reverseGet(cs.dec)}"
   )
+
+  /** @group Optics */
+  val rightAscension: Lens[Coordinates, RightAscension] =
+    GenLens[Coordinates](_.ra)
+
+  /** @group Optics */
+  val declination: Lens[Coordinates, Declination] =
+    GenLens[Coordinates](_.dec)
 
 }

--- a/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
@@ -4,12 +4,14 @@
 package gem.math
 
 import cats._
+import monocle.Lens
+import monocle.macros.GenLens
 
 /** A coordinate along with a rate of change in RA and Dec for some time unit,
   * expressed as an offset in p and q.  In reality the velocity information
   * comes from horizons and is always arcseconds per hour in horizons data.
   *
-  * @param coord coordinates
+  * @param coord delta
   * @param delta rate of change in RA and dec, where the delta(RA)/time has been
   *              multiplied by the cosine of the dec
   */
@@ -35,7 +37,7 @@ final case class EphemerisCoordinates(
 
 }
 
-object EphemerisCoordinates {
+object EphemerisCoordinates extends EphemerisCoordinatesOptics {
 
   val Zero: EphemerisCoordinates =
     EphemerisCoordinates(Coordinates.Zero, Offset.Zero)
@@ -47,5 +49,33 @@ object EphemerisCoordinates {
   /** @group Typeclass Instances */
   implicit val ShowEphemerisCoordinates: Show[EphemerisCoordinates] =
     Show.fromToString
+
+}
+
+trait EphemerisCoordinatesOptics {
+
+  /** @group Optics */
+  val coordinates: Lens[EphemerisCoordinates, Coordinates] =
+    GenLens[EphemerisCoordinates](_.coord)
+
+  /** @group Optics */
+  val delta: Lens[EphemerisCoordinates, Offset] =
+    GenLens[EphemerisCoordinates](_.delta)
+
+  /** @group Optics */
+  val rightAscension: Lens[EphemerisCoordinates, RightAscension] =
+    coordinates composeLens Coordinates.rightAscension
+
+  /** @group Optics */
+  val declination: Lens[EphemerisCoordinates, Declination] =
+    coordinates composeLens Coordinates.declination
+
+  /** @group Optics */
+  val deltaP: Lens[EphemerisCoordinates, Offset.P] =
+    delta composeLens Offset.p
+
+  /** @group Optics */
+  val deltaQ: Lens[EphemerisCoordinates, Offset.Q] =
+    delta composeLens Offset.q
 
 }

--- a/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
@@ -11,7 +11,7 @@ import monocle.macros.GenLens
   * expressed as an offset in p and q.  In reality the velocity information
   * comes from horizons and is always arcseconds per hour in horizons data.
   *
-  * @param coord delta
+  * @param coord coordinates
   * @param delta rate of change in RA and dec, where the delta(RA)/time has been
   *              multiplied by the cosine of the dec
   */

--- a/modules/core/shared/src/main/scala/gem/math/LocalObservingNight.scala
+++ b/modules/core/shared/src/main/scala/gem/math/LocalObservingNight.scala
@@ -9,9 +9,10 @@ import cats.effect.Sync
 import cats.implicits._
 import gem.enum.Site
 import gem.imp.TimeInstances._
-
 import java.time._
 import java.time.format.DateTimeFormatter
+import monocle.Iso
+import monocle.macros.GenIso
 
 /** A local observing night is defined as the period of time starting at 14:00
   * (inclusive) on one day and ending at 14:00 (exclusive) the next day.
@@ -54,7 +55,7 @@ final case class LocalObservingNight(toLocalDate: LocalDate) {
     LocalObservingNight.Formatter.format(toLocalDate)
 }
 
-object LocalObservingNight {
+object LocalObservingNight extends LocalObservingNightOptics {
 
   /** The hour, in the local time zone, at which the night is considered to
     * officially start.
@@ -135,4 +136,12 @@ object LocalObservingNight {
     */
   implicit val OrderLocalObservingNight: Order[LocalObservingNight] =
     Order.by(_.toLocalDate)
+}
+
+trait LocalObservingNightOptics {
+
+  /** @group Optics */
+  val localDate: Iso[LocalObservingNight, LocalDate] =
+    GenIso[LocalObservingNight, LocalDate]
+
 }

--- a/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
@@ -8,9 +8,9 @@ import gem.enum.Site
 import cats._
 import cats.effect.Sync
 import cats.implicits._
-
 import java.time._
-
+import monocle.Lens
+import monocle.macros.GenLens
 
 /** An observing night is defined as the period of time from 14:00 on one day
   * until 14:00 on the following day.  In a timezone that honors daylight saving,
@@ -47,7 +47,7 @@ final case class ObservingNight(site: Site, toLocalObservingNight: LocalObservin
 
 }
 
-object ObservingNight {
+object ObservingNight extends ObservingNightOptics {
 
   /** Constructs the observing night that ends on the given local date for
     * for the given site.
@@ -90,5 +90,21 @@ object ObservingNight {
     */
   implicit val OrderObservingNight: Order[ObservingNight] =
     Order.by(n => (n.site, n.toLocalObservingNight))
+
+}
+
+trait ObservingNightOptics {
+
+  /** @group Optics */
+  val site: Lens[ObservingNight, Site] =
+    GenLens[ObservingNight](_.site)
+
+  /** @group Optics */
+  val localObservingNight: Lens[ObservingNight, LocalObservingNight] =
+    GenLens[ObservingNight](_.toLocalObservingNight)
+
+  /** @group Optics */
+  val localDate: Lens[ObservingNight, LocalDate] =
+    localObservingNight composeIso LocalObservingNight.localDate
 
 }

--- a/modules/core/shared/src/main/scala/gem/math/Offset.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Offset.scala
@@ -7,6 +7,8 @@ package math
 import cats.{ Order, Show }
 import cats.kernel.CommutativeGroup
 import cats.implicits._
+import monocle.{ Iso, Lens }
+import monocle.macros.{ GenIso, GenLens }
 
 /** Angular offset with P and Q components. */
 final case class Offset(p: Offset.P, q: Offset.Q) {
@@ -25,7 +27,7 @@ final case class Offset(p: Offset.P, q: Offset.Q) {
 
 }
 
-object Offset {
+object Offset extends OffsetOptics {
 
   /** The zero offset. */
   val Zero: Offset =
@@ -62,7 +64,7 @@ object Offset {
       toAngle.toSignedDoubleRadians
 
   }
-  object P {
+  object P extends POptics {
 
     /** The zero P component. */
     val Zero: P =
@@ -84,6 +86,13 @@ object Offset {
       Angle.SignedAngleOrder.contramap(_.toAngle)
 
   }
+  trait POptics {
+
+    /** @Group Optics */
+    val angle: Iso[P, Angle] =
+      GenIso[P, Angle]
+
+  }
 
   /** Q component of an angular offset.. */
   final case class Q(toAngle: Angle) {
@@ -101,7 +110,7 @@ object Offset {
       toAngle.toSignedDoubleRadians
 
   }
-  object Q {
+  object Q extends QOptics {
 
     /** The zero Q component. */
     val Zero: Q =
@@ -123,5 +132,33 @@ object Offset {
       Angle.SignedAngleOrder.contramap(_.toAngle)
 
   }
+  trait QOptics {
+
+    /** @Group Optics */
+    val angle: Iso[Q, Angle] =
+      GenIso[Q, Angle]
+
+  }
+
+
+}
+
+trait OffsetOptics {
+
+  /** @group Optics */
+  val p: Lens[Offset, Offset.P] =
+    GenLens[Offset](_.p)
+
+  /** @group Optics */
+  val q: Lens[Offset, Offset.Q] =
+    GenLens[Offset](_.q)
+
+  /** @group Optics */
+  val pAngle: Lens[Offset, Angle] =
+    p composeIso Offset.P.angle
+
+  /** @group Optics */
+  val qAngle: Lens[Offset, Angle] =
+    q composeIso Offset.Q.angle
 
 }

--- a/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
@@ -6,6 +6,8 @@ package gem.math
 import cats._
 import cats.implicits._
 import java.time.Instant
+import monocle.Lens
+import monocle.macros.GenLens
 import scala.math.{ sin, cos, hypot, atan2 }
 
 /**
@@ -54,7 +56,7 @@ final case class ProperMotion(
 }
 
 
-object ProperMotion {
+object ProperMotion extends ProperMotionOptics {
   import PhysicalConstants.{ AstronomicalUnit, TwoPi }
 
   def const(cs: Coordinates): ProperMotion =
@@ -198,6 +200,30 @@ object ProperMotion {
       order(_.parallax)
 
   }
+}
+
+trait ProperMotionOptics {
+
+  /** @group Optics */
+  val baseCoordinates: Lens[ProperMotion, Coordinates] =
+    GenLens[ProperMotion](_.baseCoordinates)
+
+  /** @group Optics */
+  val epoch: Lens[ProperMotion, Epoch] =
+    GenLens[ProperMotion](_.epoch)
+
+  /** @group Optics */
+  val properVelocity: Lens[ProperMotion, Option[Offset]] =
+    GenLens[ProperMotion](_.properVelocity)
+
+  /** @group Optics */
+  val radialVelocity: Lens[ProperMotion, Option[RadialVelocity]] =
+    GenLens[ProperMotion](_.radialVelocity)
+
+  /** @group Optics */
+  val parallax: Lens[ProperMotion, Option[Angle]] =
+    GenLens[ProperMotion](_.parallax)
+
 }
 
 

--- a/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
@@ -8,6 +8,7 @@ import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import gem.laws.discipline._
 import gem.arb._
+import monocle.law.discipline._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class CoordinatesSpec extends CatsSuite {
@@ -18,7 +19,9 @@ final class CoordinatesSpec extends CatsSuite {
 
   // Laws
   checkAll("Coordinates", OrderTests[Coordinates].order)
-  checkAll("Formats.HmsDms", FormatTests(Coordinates.fromHmsDms).formatWith(ArbCoordinates.strings))
+  checkAll("Coordinates.fromHmsDms", FormatTests(Coordinates.fromHmsDms).formatWith(ArbCoordinates.strings))
+  checkAll("Coordinates.rightAscension", LensTests(Coordinates.rightAscension))
+  checkAll("Coordinates.declination", LensTests(Coordinates.declination))
 
   test("Equality must be natural") {
     forAll { (a: Coordinates, b: Coordinates) =>

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
@@ -8,17 +8,27 @@ import gem.arb._
 import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
-
+import monocle.law.discipline._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest.Assertion
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class EphemerisCoordinatesSpec extends CatsSuite {
+  import ArbCoordinates._
   import ArbEphemeris._
+  import ArbOffset._
+  import ArbRightAscension._
+  import ArbDeclination._
   import EphemerisCoordinatesSpec._
 
   // Laws
   checkAll("EphemerisCoordinates", EqTests[EphemerisCoordinates].eqv)
+  checkAll("EphemerisCoordinates.coordinates", LensTests(EphemerisCoordinates.coordinates))
+  checkAll("EphemerisCoordinates.rightAscension", LensTests(EphemerisCoordinates.rightAscension))
+  checkAll("EphemerisCoordinates.declination", LensTests(EphemerisCoordinates.declination))
+  checkAll("EphemerisCoordinates.delta", LensTests(EphemerisCoordinates.delta))
+  checkAll("EphemerisCoordinates.deltaP", LensTests(EphemerisCoordinates.deltaP))
+  checkAll("EphemerisCoordinates.deltaQ", LensTests(EphemerisCoordinates.deltaQ))
 
   test("Equality must be natural") {
     forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates) =>

--- a/modules/core/shared/src/test/scala/gem/math/LocalObservingNightSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/LocalObservingNightSpec.scala
@@ -4,19 +4,22 @@
 package gem.math
 
 import gem.arb._
-
+import gem.imp.TimeInstances
 import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
+import monocle.law.discipline._
 
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class LocalObservingNightSpec extends CatsSuite {
-
+  import ArbTime._
   import ArbEnumerated._
   import ArbObservingNight._
+  import TimeInstances._
 
   checkAll("LocalObservingNight", OrderTests[LocalObservingNight].order)
+  checkAll("LocalObservingNight.localDate", IsoTests(LocalObservingNight.localDate))
 
   test("Equality must be natural") {
     forAll { (a: LocalObservingNight, b: LocalObservingNight) =>

--- a/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
@@ -5,22 +5,26 @@ package gem.math
 
 import gem.arb._
 import gem.enum.Site
+import gem.imp.TimeInstances
 
 import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
-
 import java.time._
+import monocle.law.discipline._
 
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class ObservingNightSpec extends CatsSuite {
-
   import ArbEnumerated._
   import ArbObservingNight._
   import ArbTime._
+  import TimeInstances._
 
   checkAll("ObservingNight", OrderTests[ObservingNight].order)
+  checkAll("ObservingNight.site", LensTests(ObservingNight.site))
+  checkAll("ObservingNight.localObservingNight", LensTests(ObservingNight.localObservingNight))
+  checkAll("ObservingNight.localDate", LensTests(ObservingNight.localDate))
 
   test("Equality must be natural") {
     forAll { (a: ObservingNight, b: ObservingNight) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
@@ -7,14 +7,17 @@ import cats.tests.CatsSuite
 import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import gem.arb._
+import monocle.law.discipline._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class OffsetPSpec extends CatsSuite {
+  import ArbAngle._
   import ArbOffset._
 
   // Laws
   checkAll("Offset.P", CommutativeGroupTests[Offset.P].commutativeGroup)
   checkAll("Offset.P", OrderTests[Offset.P].order)
+  checkAll("Offset.P.angle", IsoTests(Offset.P.angle))
 
   test("Equality must be natural") {
     forAll { (a: Offset.P, b: Offset.P) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
@@ -7,14 +7,17 @@ import cats.tests.CatsSuite
 import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import gem.arb._
+import monocle.law.discipline._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class OffsetQSpec extends CatsSuite {
+  import ArbAngle._
   import ArbOffset._
 
   // Laws
   checkAll("Offset.Q", CommutativeGroupTests[Offset.Q].commutativeGroup)
   checkAll("Offset.Q", OrderTests[Offset.Q].order)
+  checkAll("Offset.Q.angle", IsoTests(Offset.Q.angle))
 
   test("Equality must be natural") {
     forAll { (a: Offset.Q, b: Offset.Q) =>

--- a/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
@@ -7,14 +7,20 @@ import cats.tests.CatsSuite
 import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import gem.arb._
+import monocle.law.discipline._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class OffsetSpec extends CatsSuite {
+  import ArbAngle._
   import ArbOffset._
 
   // Laws
   checkAll("Offset", CommutativeGroupTests[Offset].commutativeGroup)
   checkAll("Offset", OrderTests[Offset].order)
+  checkAll("Offset.p", LensTests(Offset.p))
+  checkAll("Offset.q", LensTests(Offset.q))
+  checkAll("Offset.pAngle", LensTests(Offset.pAngle))
+  checkAll("Offset.qAngle", LensTests(Offset.qAngle))
 
   test("Equality must be natural") {
     forAll { (a: Offset, b: Offset) =>

--- a/modules/core/shared/src/test/scala/gem/math/ProperMotionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/ProperMotionSpec.scala
@@ -5,15 +5,25 @@ package gem.math
 
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline._
-
 import gem.arb._
+import monocle.law.discipline._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class ProperMotionSpec extends CatsSuite {
+  import ArbAngle._
+  import ArbCoordinates._
+  import ArbEpoch._
+  import ArbOffset._
   import ArbProperMotion._
+  import ArbRadialVelocity._
 
   // Laws
   checkAll("ProperMotion", OrderTests[ProperMotion].order)
+  checkAll("ProperMotion.baseCoordinates", LensTests(ProperMotion.baseCoordinates))
+  checkAll("ProperMotion.epoch", LensTests(ProperMotion.epoch))
+  checkAll("ProperMotion.properVelocity", LensTests(ProperMotion.properVelocity))
+  checkAll("ProperMotion.radialVelocity", LensTests(ProperMotion.radialVelocity))
+  checkAll("ProperMotion.parallax", LensTests(ProperMotion.parallax))
 
   test("ProperMotion.identity") {
     forAll { (pm: ProperMotion) =>


### PR DESCRIPTION
I needed a break from type experiments so I filled out `Lens`and `Iso` for stuff in `gem.math`. I'm using `GenLens` instead of `@Lenses` because I don't like having to suppress the bogus warning and I want a doc comment with `@group Optics` so the lenses are grouped in the Scaladoc.

This adds optics and tests but doesn't change any existing code.