### PR TITLE
move index to its own compilation unit

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -7,8 +7,7 @@ import cats.{ Functor, Order, Show }
 import cats.implicits._
 import gem.config.{ StaticConfig, DynamicConfig }
 import gem.enum.Instrument
-import gem.syntax.string._
-import mouse.boolean._
+import gem.math.Index
 
 /**
  * An observation, parameterized over the types of its targets, static config
@@ -51,38 +50,6 @@ object Observation {
       def narrow: (Instrument.Aux[I], Observation.Full.Aux[I]) forSome { type I <: Instrument with Singleton } =
         narrowImpl(o)
 
-  }
-
-  /** A positive, non-zero integer for use in ids. */
-  sealed abstract case class Index(toShort: Short) {
-    def format: String =
-      s"$toShort"
-  }
-
-  object Index {
-    val One: Index =
-      unsafeFromShort(1)
-
-    def fromShort(i: Short): Option[Index] =
-      (i > 0) option new Index(i) {}
-
-    def unsafeFromShort(i: Short): Index =
-      fromShort(i).getOrElse(sys.error(s"Negative index: $i"))
-
-    def fromString(s: String): Option[Index] =
-      s.parseShortOption.filter(_ > 0).map(new Index(_) {})
-
-    def unsafeFromString(s: String): Index =
-      fromString(s).getOrElse(sys.error(s"Malformed observation index: '$s'"))
-
-    implicit val OrderIndex: Order[Index] =
-      Order.by(_.toShort)
-
-    implicit val OrderingIndex: scala.math.Ordering[Index] =
-      OrderIndex.toOrdering
-
-    implicit val showIndex: Show[Index] =
-      Show.fromToString
   }
 
   /** An observation is identified by its program and a serial index. */

--- a/modules/core/shared/src/main/scala/gem/Program.scala
+++ b/modules/core/shared/src/main/scala/gem/Program.scala
@@ -5,7 +5,7 @@ package gem
 
 import cats.{ Applicative, Eval, Traverse }
 import cats.implicits._
-
+import gem.math.Index
 import gem.syntax.treemap._
 
 import scala.collection.immutable.TreeMap
@@ -16,7 +16,7 @@ import scala.collection.immutable.TreeMap
  * or `Nothing` for a minimally-specified program.
  * @group Program Model
  */
-final case class Program[+A](id: Program.Id, title: String, observations: TreeMap[Observation.Index, A])
+final case class Program[+A](id: Program.Id, title: String, observations: TreeMap[Index, A])
 
 object Program {
 

--- a/modules/core/shared/src/main/scala/gem/math/Index.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Index.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{ Order, Show }
+import cats.instances.short._
+import mouse.boolean._
+import gem.syntax.string._
+
+/** A positive, non-zero value for numbered identifiers. */
+sealed abstract case class Index(toShort: Short) {
+  def format: String =
+    s"$toShort"
+}
+
+object Index {
+
+  val One: Index =
+    unsafeFromShort(1)
+
+  def fromShort(i: Short): Option[Index] =
+    (i > 0) option new Index(i) {}
+
+  def unsafeFromShort(i: Short): Index =
+    fromShort(i).getOrElse(sys.error(s"Negative index: $i"))
+
+  def fromString(s: String): Option[Index] =
+    s.parseShortOption.filter(_ > 0).map(new Index(_) {})
+
+  def unsafeFromString(s: String): Index =
+    fromString(s).getOrElse(sys.error(s"Malformed observation index: '$s'"))
+
+  implicit val OrderIndex: Order[Index] =
+    Order.by(_.toShort)
+
+  implicit val OrderingIndex: scala.math.Ordering[Index] =
+    OrderIndex.toOrdering
+
+  implicit val showIndex: Show[Index] =
+    Show.fromToString
+
+}

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import gem.arb._
 import gem.config.{ DynamicConfig, GcalConfig, TelescopeConfig }
 import gem.enum.{Instrument, SmartGcalType}
-import gem.math.Offset
+import gem.math.{ Index, Offset }
 import gem.syntax.treemap._
 import gem.util.Location
 import org.scalacheck._
@@ -107,10 +107,10 @@ trait Arbitraries extends gem.config.Arbitraries  {
       } yield o
     }
 
-  def genObservationMap(limit: Int): Gen[TreeMap[Observation.Index, Observation.Full]] =
+  def genObservationMap(limit: Int): Gen[TreeMap[Index, Observation.Full]] =
     for {
       count   <- Gen.choose(0, limit)
-      obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Observation.Index.unsafeFromShort))
+      obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Index.unsafeFromShort))
       obsList <- obsIdxs.traverse(_ => arbitrary[Observation.Full])
     } yield TreeMap.fromList(obsIdxs.zip(obsList))
 }

--- a/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
@@ -7,6 +7,7 @@ import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.arb._
+import gem.math.Index
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class ObservationIdSpec extends CatsSuite {
@@ -24,7 +25,7 @@ final class ObservationIdSpec extends CatsSuite {
   test("Equalty must act pairwise") {
     forAll { (a: Observation.Id, b: Observation.Id) =>
       Eq[Program.Id].eqv(a.pid, b.pid) &&
-      Eq[Observation.Index].eqv(a.index, b.index) shouldEqual Eq[Observation.Id].eqv(a, b)
+      Eq[Index].eqv(a.index, b.index) shouldEqual Eq[Observation.Id].eqv(a, b)
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.Index
+import org.scalacheck._
+import org.scalacheck.Gen._
+
+trait ArbIndex {
+
+  val genIndex: Gen[Index] =
+    choose[Short](0, Short.MaxValue).map(Index.unsafeFromShort)
+
+  implicit val arbIndex: Arbitrary[Index] =
+    Arbitrary(genIndex)
+
+  implicit val cogIndex: Cogen[Index] =
+    Cogen[Short].contramap(_.toShort)
+
+}
+
+object ArbIndex extends ArbIndex

--- a/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
@@ -5,6 +5,7 @@ package gem
 package arb
 
 import gem.enum.Instrument
+import gem.math.Index
 import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
@@ -12,6 +13,7 @@ import org.scalacheck.Cogen._
 
 trait ArbObservation extends gem.config.Arbitraries {
   import ArbEnumerated._
+  import ArbIndex._
   import ArbProgramId._
   import ArbTargetEnvironment._
 
@@ -20,7 +22,7 @@ trait ArbObservation extends gem.config.Arbitraries {
       for {
         pid <- arbitrary[ProgramId]
         num <- choose[Short](1, 100)
-      } yield Observation.Id(pid, Observation.Index.unsafeFromShort(num))
+      } yield Observation.Id(pid, Index.unsafeFromShort(num))
     }
 
   def genObservation[I <: Instrument with Singleton](i: Instrument.Aux[I]): Gen[Observation.Full] =
@@ -39,11 +41,8 @@ trait ArbObservation extends gem.config.Arbitraries {
       } yield o
     }
 
-  implicit val cogObservationIdex: Cogen[Observation.Index] =
-    Cogen[Short].contramap(_.toShort)
-
   implicit val cogObservationId: Cogen[Observation.Id] =
-    Cogen[(ProgramId, Observation.Index)].contramap(oid => (oid.pid, oid.index))
+    Cogen[(ProgramId, Index)].contramap(oid => (oid.pid, oid.index))
 
 }
 

--- a/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+import gem.arb._
+
+final class IndexSpec extends CatsSuite {
+  import ArbIndex._
+
+  // Laws
+  checkAll("Index", OrderTests[Index].order)
+
+}

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import doobie._
 import doobie.implicits._
 import gem.enum.AsterismType
+import gem.math.Index
 import gem.syntax.treemap._
 import scala.collection.immutable.{ TreeMap, TreeSet }
 
@@ -25,7 +26,7 @@ object TargetEnvironmentDao {
       u <- UserTargetDao.selectObs(oid)
     } yield TargetEnvironment(a, u)
 
-  def selectProg(pid: Program.Id, ats: Set[AsterismType]): ConnectionIO[Map[Observation.Index, TargetEnvironment]] =
+  def selectProg(pid: Program.Id, ats: Set[AsterismType]): ConnectionIO[Map[Index, TargetEnvironment]] =
     for {
       am <- ats.toList.traverse(AsterismDao.selectAll(pid, _)).map(ms => TreeMap.join(ms))
       um <- UserTargetDao.selectProg(pid)

--- a/modules/db/src/main/scala/gem/dao/meta/ObservationIndexMeta.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ObservationIndexMeta.scala
@@ -4,14 +4,14 @@
 package gem.dao.meta
 
 import doobie._
-import gem.Observation
+import gem.math.Index
 
 trait ObservationIndexMeta {
 
-  // Observation.Index has a DISTINCT type due to its check constraint so we
+  // Index has a DISTINCT type due to its check constraint so we
   // need a fine-grained mapping here to satisfy the query checker.
-  implicit val ObservationIndexMeta: Meta[Observation.Index] =
-    Distinct.short("id_index").xmap(Observation.Index.unsafeFromShort, _.toShort)
+  implicit val ObservationIndexMeta: Meta[Index] =
+    Distinct.short("id_index").xmap(Index.unsafeFromShort, _.toShort)
 
 }
 object ObservationIndexMeta extends ObservationIndexMeta

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -5,7 +5,8 @@ package gem.dao
 
 import cats.effect.IO
 import doobie._, doobie.implicits._
-import gem.{ Observation, Program, Step }
+import gem.{ Program, Step }
+import gem.math.Index
 
 import scala.collection.immutable.TreeMap
 
@@ -14,12 +15,12 @@ import scala.collection.immutable.TreeMap
 trait DaoTest extends gem.Arbitraries {
   val pid = Program.Id.unsafeFromString("GS-1234A-Q-1")
 
-  protected val xa: Transactor[IO] = 
+  protected val xa: Transactor[IO] =
     Transactor.after.set(DatabaseConfiguration.forTesting.transactor[IO], HC.rollback)
 
   def withProgram[A](test: ConnectionIO[A]): A =
     (for {
-      _ <- ProgramDao.insertFlat(Program(pid, "Test Prog", TreeMap.empty[Observation.Index, Step[Nothing]]))
+      _ <- ProgramDao.insertFlat(Program(pid, "Test Prog", TreeMap.empty[Index, Step[Nothing]]))
       a <- test
     } yield a).transact(xa).unsafeRunSync()
 

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import doobie.implicits._
 import gem.Observation
 import gem.enum._
+import gem.math.Index
 import org.scalatest._
 import org.scalatest.prop._
 import org.scalatest.Matchers._
@@ -27,7 +28,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should select flat observations") {
-    val oid = Observation.Id(pid, Observation.Index.One)
+    val oid = Observation.Id(pid, Index.One)
 
     forAll { (obsIn: Observation.Full) =>
       val obsOut = withProgram {
@@ -48,7 +49,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should select static-only observations") {
-    val oid = Observation.Id(pid, Observation.Index.One)
+    val oid = Observation.Id(pid, Index.One)
 
     forAll { (obsIn: Observation.Full) =>
       val obsOut = withProgram {
@@ -68,7 +69,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should select target-only observations") {
-    val oid = Observation.Id(pid, Observation.Index.One)
+    val oid = Observation.Id(pid, Index.One)
 
     forAll { (obsIn: Observation.Full) =>
       val obsOut = withProgram {
@@ -89,7 +90,7 @@ class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
   }
 
   property("ObservationDao should roundtrip complete observations") {
-    val oid = Observation.Id(pid, Observation.Index.One)
+    val oid = Observation.Id(pid, Index.One)
 
     forAll { (obsIn: Observation.Full) =>
       val obsOut = withProgram {

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -11,6 +11,7 @@ import gem.config._
 import gem.config.F2Config.F2FpuChoice.Builtin
 import gem.config.GcalConfig.GcalLamp
 import gem.enum._
+import gem.math.Index
 import gem.util.Location
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import java.time.Duration
@@ -90,7 +91,7 @@ class SmartGcalSpec extends FlatSpec with Matchers with DaoTest {
     ss.values.toList shouldEqual lookup(m).map(Step.Gcal(f2, _))
   }
 
-  private val oid = Observation.Id(pid, Observation.Index.One)
+  private val oid = Observation.Id(pid, Index.One)
 
   private def doTest[A](test: ConnectionIO[A]): A =
     withProgram {

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -19,7 +19,7 @@ class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
 
   "StepDao" should "serialize telescope configurations properly" in {
 
-    val idx  = Observation.Index.One
+    val idx  = Index.One
 
     // We specifically want to test round-tripping of telescope offsets.
     val pid  = Program.Id.unsafeFromString("GS-1234A-Q-1")

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -6,7 +6,7 @@ package dao
 
 import cats.implicits._
 import doobie.implicits._
-
+import gem.math.Index
 import org.scalatest._
 import org.scalatest.prop._
 import org.scalatest.Matchers._
@@ -17,7 +17,7 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
 
   property("UserTargetDao should roundtrip") {
     forAll { (obs: Observation.Full, ut: UserTarget) =>
-      val oid = Observation.Id(pid, Observation.Index.One)
+      val oid = Observation.Id(pid, Index.One)
 
       val utʹ = withProgram {
         for {
@@ -33,7 +33,7 @@ class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
 
   property("UserTargetDao should bulk select observation") {
     forAll { (obs: Observation.Full) =>
-      val oid = Observation.Id(pid, Observation.Index.One)
+      val oid = Observation.Id(pid, Index.One)
 
       val actual = withProgram {
         for {

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -39,7 +39,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val programType      = ProgramType.C
     val dailyProgramId   = Program.Id.Daily(site, DailyProgramType.ENG, LocalDate.now())
     val scienceProgramId = Program.Id.Science(site, semester, programType, 0)
-    val observationId    = Observation.Id(programId, Observation.Index.One)
+    val observationId    = Observation.Id(programId, Index.One)
     val datasetLabel     = Dataset.Label(observationId, 0)
     val dataset          = Dataset(datasetLabel, "", instant)
     val eventType        = EventType.Abort

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -68,9 +68,9 @@ package object json {
   val AngleAsSignedMilliarcsecondsEncoder: Encoder[Angle] = Encoder[BigDecimal].contramap(_.toSignedMilliarcseconds)
   val AngleAsSignedMilliarcsecondsDecoder: Decoder[Angle] = Decoder[BigDecimal].map(Angle.fromSignedMilliarcseconds)
 
-  // Observation.Index to Integer.
-  implicit val ObservationIndexEncoder: Encoder[Observation.Index] = Encoder[Short].contramap(_.toShort)
-  implicit val ObservationIndexDecoder: Decoder[Observation.Index] = Decoder[Short].map(Observation.Index.unsafeFromShort)
+  // Index to Short.
+  implicit val ObservationIndexEncoder: Encoder[Index] = Encoder[Short].contramap(_.toShort)
+  implicit val ObservationIndexDecoder: Decoder[Index] = Decoder[Short].map(Index.unsafeFromShort)
 
   // Wavelength mapping to integral Angstroms.
   implicit val (
@@ -174,11 +174,11 @@ package object json {
   implicit def programIdKeyedMapDecoder[A: Decoder]: Decoder[Map[Program.Id, A]] =
     Decoder[Map[String, A]].map(_.map { case (k, v) => (Program.Id.unsafeFromString(k), v) })
 
-  // Codec for maps keyed by Observation.Index
-  implicit def observationIndexMapEncoder[A: Encoder]: Encoder[TreeMap[Observation.Index, A]] =
+  // Codec for maps keyed by Index
+  implicit def observationIndexMapEncoder[A: Encoder]: Encoder[TreeMap[Index, A]] =
     Encoder[TreeMap[Short, A]].contramap(_.map { case (k, v) => (k.toShort, v) })
-  implicit def observationIndexMapDecoder[A: Decoder]: Decoder[TreeMap[Observation.Index, A]] =
-    Decoder[TreeMap[Short, A]].map(_.map { case (k, v) => (Observation.Index.unsafeFromShort(k), v) })
+  implicit def observationIndexMapDecoder[A: Decoder]: Decoder[TreeMap[Index, A]] =
+    Decoder[TreeMap[Short, A]].map(_.map { case (k, v) => (Index.unsafeFromShort(k), v) })
 
   // GmosCustomRoiEntry as a quad of shorts
   implicit val GmosCustomRoiEntryEncoder: Encoder[GmosCustomRoiEntry] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -159,7 +159,7 @@ object Decoders {
       (n \\* "obsExecLog" \\* "&datasets" \\* "&dataset").decode[Dataset]
     }
 
-  implicit val ObservationIndexDecoder: PioDecoder[Observation.Index] =
+  implicit val ObservationIndexDecoder: PioDecoder[Index] =
     PioDecoder { n =>
       (n \! "@name").decode[Observation.Id].map(_.index)
     }
@@ -217,7 +217,7 @@ object Decoders {
       for {
         id <- (n \!  "@name"           ).decode[Program.Id]
         t  <- (n \!  "data" \? "#title").decodeOrZero[String]
-        is <- (n \\* "observation"     ).decode[Observation.Index]
+        is <- (n \\* "observation"     ).decode[Index]
         os <- (n \\* "observation"     ).decode[Observation.Full]
       } yield Program(id, t, TreeMap.fromList(is.zip(os)))
     }

--- a/modules/ui/src/main/scala/gem/ui/Main.scala
+++ b/modules/ui/src/main/scala/gem/ui/Main.scala
@@ -67,10 +67,10 @@ object TestProgram {
     Program(
       pid,
       "Test Program",
-      TreeMap[Observation.Index, Observation.Full](
-        Observation.Index.unsafeFromShort(1) -> f2,
-        Observation.Index.unsafeFromShort(2) -> gmosS,
-        Observation.Index.unsafeFromShort(3) -> gmosN
+      TreeMap[Index, Observation.Full](
+        Index.unsafeFromShort(1) -> f2,
+        Index.unsafeFromShort(2) -> gmosS,
+        Index.unsafeFromShort(3) -> gmosN
       )
     )
 


### PR DESCRIPTION
`Observation.Id` uses `Observation.Index` to guarantee a positive observation number, but this is useful in other places as well (like `Program.Id` and `Dataset.Label`) so I'm pulling it out into its own compilation unit. This makes no changes other than disentanglement from `Observation`.