### PR TITLE
Fix HourAngle.fromDoubleHours

### DIFF
--- a/modules/core/shared/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Angle.scala
@@ -369,6 +369,13 @@ final class HourAngle private (µas: Long) extends Angle(µas) {
     toMicroarcseconds / 15
 
   /**
+   * This `HourAngle` in decimal hours. Approximate.
+   * @group Conversions
+   */
+  def toDoubleHours: Double =
+    toMicroseconds.toDouble / HourAngle.µsPerHour
+
+  /**
    * Sum of this HourAngle and `ha`. Exact, commutative, invertible.
    * @group Operations
    */
@@ -392,6 +399,8 @@ final class HourAngle private (µas: Long) extends Angle(µas) {
 
 object HourAngle extends HourAngleOptics {
 
+  private val µsPerHour: Long = 60L * 60L * 1000L * 1000L
+
   /** @group Constants */ lazy val HourAngle0 : HourAngle = microseconds.reverseGet(0)
   /** @group Constants */ lazy val HourAngle12: HourAngle = hours.reverseGet(12)
 
@@ -400,7 +409,7 @@ object HourAngle extends HourAngleOptics {
    * @group Constructors
    */
   def fromMicroseconds(µs: Long): HourAngle = {
-    val µsPer24 = 24L * 60L * 60L * 1000L * 1000L
+    val µsPer24 = 24L * µsPerHour
     val µsʹ = (((µs % µsPer24) + µsPer24) % µsPer24)
     new HourAngle(µsʹ * 15L)
   }
@@ -410,7 +419,7 @@ object HourAngle extends HourAngleOptics {
    * @group Constructors
    */
   def fromDoubleHours(hs: Double): HourAngle =
-    fromMicroseconds((hs * 60.0 * 60.0 * 1000.0).toLong)
+    fromMicroseconds((hs * µsPerHour).round)
 
   /**
    * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,

--- a/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
@@ -125,4 +125,12 @@ final class AngleSpec extends CatsSuite {
     }
   }
 
+  test("HourAngle should (almost) round-trip double hours") {
+    forAll { (a: HourAngle) =>
+      val hrs  = a.toDoubleHours
+      val hrsʹ = HourAngle.fromDoubleHours(hrs).toDoubleHours
+      hrs shouldEqual hrsʹ +- 0.000000001
+    }
+  }
+
 }


### PR DESCRIPTION
This PR fixes a bug in `HourAngle.fromDoubleHours`.  It also adds a `toDoubleHours` method.  I could easily be convinced to place that in the test method itself though.  I don't have a good enough feel for optics to know whether there should be a `doubleHours` optic but I didn't try to add one since I didn't see any others for approximate conversions like that one.