### PR TITLE
index optics, index on programid

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -55,7 +55,7 @@ object Observation {
   /** An observation is identified by its program and a serial index. */
   final case class Id(pid: Program.Id, index: Index) {
     def format: String =
-      s"${pid.format}-${index.format}"
+      s"${pid.format}-${Index.fromString.reverseGet(index)}"
   }
   object Id {
 
@@ -64,7 +64,7 @@ object Observation {
         case -1 => None
         case  n =>
           val (a, b) = s.splitAt(n)
-          Index.fromString(b.drop(1)).flatMap { i =>
+          Index.fromString.getOption(b.drop(1)).flatMap { i =>
             Program.Id.fromString(a).map(Observation.Id(_, i))
           }
       }

--- a/modules/core/shared/src/main/scala/gem/parser/Misc.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Misc.scala
@@ -4,6 +4,7 @@
 package gem.parser
 
 import atto._, Atto._
+import gem.math.Index
 import scala.annotation.tailrec
 
 /** General-purpose parsers and combinators that aren't provided by atto. */
@@ -56,6 +57,15 @@ trait MiscParsers {
   /** Parser for a positive `Int`. */
   val positiveInt: Parser[Int] =
     int.filter(_ > 0) namedOpaque "positiveInt"
+
+  /** Parser for an `Index`. */
+  val index: Parser[Index] =
+    short.flatMap { s =>
+      Index.fromShort.getOption(s) match {
+        case Some(i) => ok(i)
+        case None    => err("Index must be positive.")
+      }
+    }
 
   /** Parser for an optional sign (+ or -), returned as a boolean indicating whether to negate. */
   val neg: Parser[Boolean] =

--- a/modules/core/shared/src/main/scala/gem/parser/ProgramId.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/ProgramId.scala
@@ -21,7 +21,7 @@ trait ProgramIdParsers {
     (site        <~ hyphen,
      semester    <~ hyphen,
      programType <~ hyphen,
-     positiveInt).mapN(Science.unsafeApply) named "science"
+     index).mapN(Science.apply) named "science"
 
   /** Parser for a daily program id like `GS-ENG20120102`. */
   val daily: Parser[Daily] =

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -8,7 +8,7 @@ import gem.arb._
 import gem.config.{ DynamicConfig, GcalConfig, TelescopeConfig }
 import gem.enum.{Instrument, SmartGcalType}
 import gem.math.{ Index, Offset }
-import gem.syntax.treemap._
+import gem.syntax.all._
 import gem.util.Location
 import org.scalacheck._
 import org.scalacheck.Gen._
@@ -110,7 +110,7 @@ trait Arbitraries extends gem.config.Arbitraries  {
   def genObservationMap(limit: Int): Gen[TreeMap[Index, Observation.Full]] =
     for {
       count   <- Gen.choose(0, limit)
-      obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Index.unsafeFromShort))
+      obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Index.fromShort.unsafeGet))
       obsList <- obsIdxs.traverse(_ => arbitrary[Observation.Full])
     } yield TreeMap.fromList(obsIdxs.zip(obsList))
 }

--- a/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
@@ -5,19 +5,31 @@ package gem
 package arb
 
 import gem.math.Index
+import gem.syntax.prism._
 import org.scalacheck._
+import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen._
 
 trait ArbIndex {
 
   val genIndex: Gen[Index] =
-    choose[Short](0, Short.MaxValue).map(Index.unsafeFromShort)
+    choose[Short](0, Short.MaxValue).map(Index.fromShort.unsafeGet)
 
   implicit val arbIndex: Arbitrary[Index] =
     Arbitrary(genIndex)
 
   implicit val cogIndex: Cogen[Index] =
     Cogen[Short].contramap(_.toShort)
+
+  private val perturbations: List[String => Gen[String]] =
+    List(
+      s => arbitrary[String], // swap for a random string
+      s => Gen.const("0" + s) // prepend a zero
+    )
+
+  // Strings that are often parsable as an Index.
+  val strings: Gen[String] =
+    arbitrary[Short].map(_.toString).flatMapOneOf(Gen.const, perturbations: _*)
 
 }
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
@@ -6,6 +6,7 @@ package arb
 
 import gem.enum.Instrument
 import gem.math.Index
+import gem.syntax.prism._
 import org.scalacheck._
 import org.scalacheck.Gen._
 import org.scalacheck.Arbitrary._
@@ -22,7 +23,7 @@ trait ArbObservation extends gem.config.Arbitraries {
       for {
         pid <- arbitrary[ProgramId]
         num <- choose[Short](1, 100)
-      } yield Observation.Id(pid, Index.unsafeFromShort(num))
+      } yield Observation.Id(pid, Index.fromShort.unsafeGet(num))
     }
 
   def genObservation[I <: Instrument with Singleton](i: Instrument.Aux[I]): Gen[Observation.Full] =

--- a/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
@@ -5,6 +5,8 @@ package gem
 package arb
 
 import gem.enum. { Site, ProgramType, DailyProgramType }
+import gem.math.Index
+import gem.syntax.prism._
 import java.time.LocalDate
 import org.scalacheck._
 import org.scalacheck.Gen._
@@ -22,8 +24,8 @@ trait ArbProgramId {
         site        <- arbitrary[Site]
         semester    <- arbitrary[Semester]
         programType <- arbitrary[ProgramType]
-        index       <- choose(1, 200)
-      } yield Science.unsafeApply(site, semester, programType, index)
+        index       <- choose[Short](1, 200).map(Index.fromShort.unsafeGet)
+      } yield Science(site, semester, programType, index)
     }
 
   implicit val arbDaily: Arbitrary[Daily] =

--- a/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
@@ -6,11 +6,15 @@ package gem.math
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline._
 import gem.arb._
+import gem.laws.discipline._
+import monocle.law.discipline._
 
 final class IndexSpec extends CatsSuite {
   import ArbIndex._
 
   // Laws
   checkAll("Index", OrderTests[Index].order)
+  checkAll("Index.fromShort", PrismTests(Index.fromShort))
+  checkAll("Index.fromString", FormatTests(Index.fromString).formatWith(strings))
 
 }

--- a/modules/db/src/main/scala/gem/dao/AsterismDao.scala
+++ b/modules/db/src/main/scala/gem/dao/AsterismDao.scala
@@ -100,7 +100,7 @@ object AsterismDao {
     import AsterismTypeMeta._
     import EnumeratedMeta._
     import ProgramIdMeta._
-    import ObservationIndexMeta._
+    import IndexMeta._
 
     object SingleTarget {
 

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -18,7 +18,7 @@ import scala.collection.immutable.TreeMap
 object ObservationDao {
   import EnumeratedMeta._
   import ObservationIdMeta._
-  import ObservationIndexMeta._
+  import IndexMeta._
   import ProgramIdMeta._
 
   /**
@@ -183,7 +183,7 @@ object ObservationDao {
       ORDER BY observation_index
       """.query[(Short, String, Option[AsterismType], Instrument)]
         .map { case (n, t, a, i) =>
-          (Index.unsafeFromShort(n), Observation(t, a, i, Nil))
+          (Index.fromShort.unsafeGet(n), Observation(t, a, i, Nil))
         }
 
   }

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -14,6 +14,7 @@ import scala.collection.immutable.TreeMap
 object ProgramDao {
   import EnumeratedMeta._
   import ProgramIdMeta._
+  import IndexMeta._
 
   /** Insert a program, disregarding its observations, if any. */
   def insertFlat(p: Program[_]): ConnectionIO[Program.Id] =
@@ -123,7 +124,7 @@ object ProgramDao {
                      ${pid.site},
                      ${pid.semester.format},
                      ${pid.programType},
-                     ${Index(pid.index)})
+                     ${pid.index})
       """.update
 
     // N.B. assumes program id slice has been inserted

--- a/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
@@ -13,7 +13,7 @@ import gem.config._
 object StaticConfigDao {
   import EnumeratedMeta._
   import ProgramIdMeta._
-  import ObservationIndexMeta._
+  import IndexMeta._
   import OffsetMeta._
 
   def insert(oid: Observation.Id, s: StaticConfig): ConnectionIO[Unit] =

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -21,7 +21,7 @@ object StepDao {
   import EnumeratedMeta._
   import LocationMeta._
   import ProgramIdMeta._
-  import ObservationIndexMeta._
+  import IndexMeta._
   import OffsetMeta._
   import TimeMeta._
   import WavelengthMeta._

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -83,7 +83,7 @@ object UserTargetDao {
   object Statements {
 
     import gem.dao.meta.ProgramIdMeta._
-    import gem.dao.meta.ObservationIndexMeta._
+    import gem.dao.meta.IndexMeta._
 
     def insert(targetId: Target.Id, targetType: UserTargetType, oid: Observation.Id): Update0 =
       sql"""

--- a/modules/db/src/main/scala/gem/dao/meta/IndexMeta.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/IndexMeta.scala
@@ -5,14 +5,15 @@ package gem.dao.meta
 
 import doobie._
 import gem.math.Index
+import gem.syntax.prism._
 
-trait ObservationIndexMeta {
+trait IndexMeta {
 
   // Index has a DISTINCT type due to its check constraint so we
   // need a fine-grained mapping here to satisfy the query checker.
-  implicit val ObservationIndexMeta: Meta[Index] =
-    Distinct.short("id_index").xmap(Index.unsafeFromShort, _.toShort)
+  implicit val IndexMeta: Meta[Index] =
+    Distinct.short("id_index").xmap(Index.fromShort.unsafeGet, _.toShort)
 
 }
-object ObservationIndexMeta extends ObservationIndexMeta
+object IndexMeta extends IndexMeta
 

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -38,7 +38,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val site             = Site.GN
     val programType      = ProgramType.C
     val dailyProgramId   = Program.Id.Daily(site, DailyProgramType.ENG, LocalDate.now())
-    val scienceProgramId = Program.Id.Science(site, semester, programType, 0)
+    val scienceProgramId = Program.Id.Science(site, semester, programType, Index.One)
     val observationId    = Observation.Id(programId, Index.One)
     val datasetLabel     = Dataset.Label(observationId, 0)
     val dataset          = Dataset(datasetLabel, "", instant)

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -69,8 +69,11 @@ package object json {
   val AngleAsSignedMilliarcsecondsDecoder: Decoder[Angle] = Decoder[BigDecimal].map(Angle.fromSignedMilliarcseconds)
 
   // Index to Short.
-  implicit val ObservationIndexEncoder: Encoder[Index] = Encoder[Short].contramap(_.toShort)
-  implicit val ObservationIndexDecoder: Decoder[Index] = Decoder[Short].map(Index.unsafeFromShort)
+  implicit val (
+    observationIndexEncoder: Encoder[Index],
+    observationIndexDecoder: Decoder[Index]
+   ) =
+    Index.fromShort.toCodec
 
   // Wavelength mapping to integral Angstroms.
   implicit val (
@@ -178,7 +181,7 @@ package object json {
   implicit def observationIndexMapEncoder[A: Encoder]: Encoder[TreeMap[Index, A]] =
     Encoder[TreeMap[Short, A]].contramap(_.map { case (k, v) => (k.toShort, v) })
   implicit def observationIndexMapDecoder[A: Decoder]: Decoder[TreeMap[Index, A]] =
-    Decoder[TreeMap[Short, A]].map(_.map { case (k, v) => (Index.unsafeFromShort(k), v) })
+    Decoder[TreeMap[Short, A]].map(_.map { case (k, v) => (Index.fromShort.unsafeGet(k), v) })
 
   // GmosCustomRoiEntry as a quad of shorts
   implicit val GmosCustomRoiEntryEncoder: Encoder[GmosCustomRoiEntry] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -11,7 +11,7 @@ import doobie.postgres.implicits._
 import java.util.logging.{ Level, Logger }
 
 /** Shared support for import applications using Doobie. */
-trait DoobieClient extends ProgramIdMeta with ObservationIndexMeta {
+trait DoobieClient extends ProgramIdMeta with IndexMeta {
 
   def configureLogging[M[_]: Effect]: M[Unit] =
     Effect[M].delay(

--- a/modules/ui/src/main/scala/gem/ui/Main.scala
+++ b/modules/ui/src/main/scala/gem/ui/Main.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable.{ TreeMap, TreeSet }
 
 object TestProgram {
   val pid: Program.Id =
-    ProgramId.Science.unsafeApply(Site.GS, Semester(Year.of(2018), Half.A), ProgramType.Q, 1)
+    ProgramId.Science(Site.GS, Semester(Year.of(2018), Half.A), ProgramType.Q, Index.One)
 
   val vega: Target =
     Target("Vega",
@@ -68,9 +68,9 @@ object TestProgram {
       pid,
       "Test Program",
       TreeMap[Index, Observation.Full](
-        Index.unsafeFromShort(1) -> f2,
-        Index.unsafeFromShort(2) -> gmosS,
-        Index.unsafeFromShort(3) -> gmosN
+        Index.fromShort.unsafeGet(1) -> f2,
+        Index.fromShort.unsafeGet(2) -> gmosS,
+        Index.fromShort.unsafeGet(3) -> gmosN
       )
     )
 


### PR DESCRIPTION
This switches `Index` construction to use `Prism`/`Format` and switches `ProgramId` to use `Index` for the science program index. I'm going to switch the parse/format pairs to use `Format` but that's going to be pretty big so I wanted to get this in first.