### PR TITLE
add subgroup test for HourAngle

### DIFF
--- a/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
@@ -13,7 +13,7 @@ import org.scalacheck.Gen._
 trait ArbIndex {
 
   val genIndex: Gen[Index] =
-    choose[Short](0, Short.MaxValue).map(Index.fromShort.unsafeGet)
+    choose[Short](1, Short.MaxValue).map(Index.fromShort.unsafeGet)
 
   implicit val arbIndex: Arbitrary[Index] =
     Arbitrary(genIndex)

--- a/modules/core/shared/src/test/scala/gem/laws/HomomorphismLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/HomomorphismLaws.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.{ Semigroup, Monoid, Group }
+
+abstract class SemigroupHomomorphismLaws[A, B](f: A => B) {
+  val A: Semigroup[A]
+  val B: Semigroup[B]
+
+  def combine(a: A, b: A): IsEq[B] =
+    f(A.combine(a, b)) <-> B.combine(f(a), f(b))
+
+}
+
+abstract class MonoidHomomorphismLaws[A, B](f: A => B) extends SemigroupHomomorphismLaws[A, B](f) {
+  override val A: Monoid[A]
+  override val B: Monoid[B]
+
+  def empty: IsEq[B] =
+    f(A.empty) <-> B.empty
+
+}
+
+abstract class GroupHomomorphismLaws[A, B](f: A => B) extends MonoidHomomorphismLaws[A, B](f) {
+  override val A: Group[A]
+  override val B: Group[B]
+
+  def inverse(a: A): IsEq[B] =
+    f(A.inverse(a)) <-> B.inverse(f(a))
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/SubgroupLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/SubgroupLaws.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+// A is a subgroup of B if covariant widening is a group homomorphism.
+abstract class SubgroupLaws[A, B](f: A <:< B) extends GroupHomomorphismLaws[A, B](f)

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/SubgroupTests.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/SubgroupTests.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+package discipline
+
+import cats._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait SubgroupTests[A, B] extends Laws {
+  val laws: SubgroupLaws[A, B]
+
+  def subgroup(
+    implicit aa: Arbitrary[A],
+             eq: Eq[B]
+  ): SimpleRuleSet = {
+    new SimpleRuleSet("subgroup",
+      "combine"  -> forAll((a: A, b: A) => laws.combine(a, b)),
+      "identity" -> laws.empty,
+      "inverse"  -> forAll((a: A) => laws.inverse(a))
+    )
+  }
+
+}
+
+object SubgroupTests extends Laws {
+
+  def apply[A, B](
+    implicit ev: A <:< B,
+             ia: Group[A],
+             ib: Group[B]
+  ): SubgroupTests[A, B] =
+    new SubgroupTests[A, B] {
+      val laws = new SubgroupLaws[A, B](ev) {
+        val A = ia
+        val B = ib
+      }
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
@@ -17,6 +17,7 @@ final class HourAngleSpec extends CatsSuite {
   // Laws
   checkAll("HourAngle", CommutativeGroupTests[HourAngle].commutativeGroup)
   checkAll("HourAngle", EqTests[HourAngle].eqv)
+  checkAll("HourAngle <: Angle", SubgroupTests[HourAngle, Angle].subgroup)
 
   // Optics
   checkAll("angle", SplitMonoTests(HourAngle.angle).splitMono)


### PR DESCRIPTION
It occurred to me that we hadn't actually proved `HourAngle` is a subgroup of `Angle` so I added a test for that. Slightly roundabout but the laws might come in handy again if we identify other structure-preserving transformations in the future.