### PR TITLE
Add coadds to GNIRS

### DIFF
--- a/modules/core/shared/src/main/scala/gem/CoAdds.scala
+++ b/modules/core/shared/src/main/scala/gem/CoAdds.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Order, Show }
+import cats.instances.short._
+import gem.syntax.prism._
+import monocle.Prism
+
+sealed abstract case class CoAdds private (toShort: Short) {
+  // Sanity check … should be correct via the companion constructor.
+  assert(toShort > 0, s"Invariant violated. $toShort is 1 or greater.")
+}
+
+object CoAdds {
+
+  final val One: CoAdds = fromShort.unsafeGet(1)
+
+  /** @group Typeclass Instances */
+  implicit val CoAddsShow: Show[CoAdds] =
+    Show.fromToString
+
+  /** @group Typeclass Instances */
+  implicit val CoAddsOrd: Order[CoAdds] =
+    Order.by(_.toShort)
+
+  /**
+    * Prism from Short into CoAdds and back.
+    * @group Optics
+    */
+  def fromShort: Prism[Short, CoAdds] =
+    Prism((n: Short) => Some(n).filter(_ > 0).map(new CoAdds(_) {}))(_.toShort)
+
+}

--- a/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
@@ -4,6 +4,7 @@
 package gem
 package config
 
+import gem.CoAdds
 import gem.enum._
 import gem.math.Wavelength
 import java.time.Duration
@@ -209,6 +210,7 @@ object DynamicConfig {
   final case class Gnirs(
     acquisitionMirror: GnirsAcquisitionMirror,
     camera:            GnirsCamera,
+    coadds:            CoAdds,
     decker:            GnirsDecker,
     disperser:         GnirsDisperser,
     exposureTime:      Duration,
@@ -239,6 +241,7 @@ object DynamicConfig {
     val Default: Gnirs = Gnirs(
       GnirsAcquisitionMirror.Out,
       GnirsCamera.ShortBlue,
+      CoAdds.One,
       GnirsDecker.Acquisition,
       GnirsDisperser.D32,
       java.time.Duration.ofSeconds(17),

--- a/modules/core/shared/src/main/scala/gem/config/GcalConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/GcalConfig.scala
@@ -6,6 +6,7 @@ package config
 
 import cats.Order
 import cats.data.OneAnd
+import gem.CoAdds
 import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
 import java.time.Duration
 import GcalConfig.GcalLamp
@@ -14,7 +15,7 @@ import GcalConfig.GcalLamp
  * Additional configuration information for [[gem.Step.Gcal Gcal]] steps.
  * @group Configurations
  */
-final case class GcalConfig(lamp: GcalLamp, filter: GcalFilter, diffuser: GcalDiffuser, shutter: GcalShutter, exposureTime: Duration, coadds: Short) {
+final case class GcalConfig(lamp: GcalLamp, filter: GcalFilter, diffuser: GcalDiffuser, shutter: GcalShutter, exposureTime: Duration, coadds: CoAdds) {
   def continuum: Option[GcalContinuum] =
     lamp.swap.toOption
 

--- a/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
@@ -5,6 +5,7 @@ package gem.config
 
 import cats._
 
+import gem.CoAdds
 import gem.arb._
 import gem.config.F2Config.F2FpuChoice
 import gem.config.GcalConfig.{GcalArcs, GcalLamp}
@@ -39,6 +40,9 @@ trait Arbitraries {
     def pure[A](a: A): Gen[A] =
       Gen.const(a)
   }
+
+  implicit val arbCoAdds: Arbitrary[CoAdds] =
+    Arbitrary(Gen.posNum[Short].map(CoAdds.fromShort.unsafeGet))
 
   implicit val arbDuration: Arbitrary[Duration] =
     Arbitrary(Gen.posNum[Long].map(Duration.ofMillis))
@@ -236,15 +240,16 @@ trait Arbitraries {
       for {
         a <- arbitrary[GnirsAcquisitionMirror             ]
         b <- arbitrary[GnirsCamera                        ]
-        c <- arbitrary[GnirsDecker                        ]
-        d <- arbitrary[GnirsDisperser                     ]
-        e <- arbitrary[Duration                           ]
-        f <- arbitrary[GnirsFilter                        ]
-        g <- arbitrary[Either[GnirsFpuOther, GnirsFpuSlit]]
-        h <- arbitrary[GnirsPrism                         ]
-        i <- arbitrary[GnirsReadMode                      ]
-        j <- Gen.choose(1000, 120000).map(Wavelength.fromAngstroms.unsafeGet)
-      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j)
+        c <- arbitrary[CoAdds                             ]
+        d <- arbitrary[GnirsDecker                        ]
+        e <- arbitrary[GnirsDisperser                     ]
+        f <- arbitrary[Duration                           ]
+        g <- arbitrary[GnirsFilter                        ]
+        h <- arbitrary[Either[GnirsFpuOther, GnirsFpuSlit]]
+        i <- arbitrary[GnirsPrism                         ]
+        j <- arbitrary[GnirsReadMode                      ]
+        k <- Gen.choose(1000, 120000).map(Wavelength.fromAngstroms.unsafeGet)
+      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j, k)
 
   def genDynamicConfigOf[I <: Instrument with Singleton](i: Instrument.Aux[I]): Gen[DynamicConfig.Aux[I]] = {
     i match {
@@ -291,7 +296,7 @@ trait Arbitraries {
         d <- arbitrary[GcalDiffuser]
         s <- arbitrary[GcalShutter ]
         e <- arbitrary[Duration    ]
-        c <- Gen.posNum[Short]
+        c <- arbitrary[CoAdds      ]
       } yield GcalConfig(l, f, d, s, e, c)
     }
 }

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -7,6 +7,7 @@ package dao
 import cats.implicits._
 import doobie._, doobie.implicits._
 import gem.util.Location
+import gem.CoAdds
 import gem.config._
 import gem.config.GcalConfig.GcalLamp
 import gem.dao.composite._
@@ -18,6 +19,7 @@ import java.time.Duration
 import scala.collection.immutable.TreeMap
 
 object StepDao {
+  import CoAddsMeta._
   import EnumeratedMeta._
   import LocationMeta._
   import ProgramIdMeta._
@@ -208,7 +210,7 @@ object StepDao {
             d    <- diffuserOpt
             s    <- shutterOpt
             e    <- exposureOpt
-            c    <- coaddsOpt
+            c    <- coaddsOpt.flatMap(CoAdds.fromShort.getOption)
           } yield Step.Gcal(i, GcalConfig(l, f, d, s, e, c))).getOrElse(sys.error(s"missing gcal information: $gcal"))
 
         case StepType.SmartGcal =>
@@ -553,6 +555,7 @@ object StepDao {
           SELECT s.location,
                  i.acquisition_mirror,
                  i.camera,
+                 i.coadds,
                  i.decker,
                  i.disperser,
                  i.exposure_time,
@@ -573,6 +576,7 @@ object StepDao {
         sql"""
           SELECT i.acquisition_mirror,
                  i.camera,
+                 i.coadds,
                  i.decker,
                  i.disperser,
                  i.exposure_time,
@@ -596,6 +600,7 @@ object StepDao {
             step_gnirs_id,
             acquisition_mirror,
             camera,
+            coadds,
             decker,
             disperser,
             exposure_time,
@@ -610,6 +615,7 @@ object StepDao {
             $id,
             ${gnirs.acquisitionMirror},
             ${gnirs.camera},
+            ${gnirs.coadds},
             ${gnirs.decker},
             ${gnirs.disperser},
             ${gnirs.exposureTime},

--- a/modules/db/src/main/scala/gem/dao/meta/CoAdds.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/CoAdds.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.CoAdds
+import gem.syntax.prism._
+
+trait CoAddsMeta {
+
+  implicit val CoAddsMetaShort: Meta[CoAdds] =
+    Distinct.short("coadds").xmap(CoAdds.fromShort.unsafeGet(_), _.toShort)
+
+}
+
+object CoAddsMeta extends CoAddsMeta

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -149,7 +149,7 @@ object SmartGcalSpec {
         GcalDiffuser.Ir,
         GcalShutter.Closed,
         Duration.ofMillis(30000),
-        1
+        CoAdds.One
       )),
       (Flat, Night, GcalConfig(
         GcalLamp.fromContinuum(GcalContinuum.IrGreyBodyHigh),
@@ -157,7 +157,7 @@ object SmartGcalSpec {
         GcalDiffuser.Ir,
         GcalShutter.Open,
         Duration.ofMillis(20000),
-        1
+        CoAdds.One
       ))
     )
 }

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -33,7 +33,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
   object Dummy {
     val instant          = java.time.Instant.EPOCH
     val duration         = java.time.Duration.ZERO
-    val programId        = Program.Id.unsafeFromString("GS-foobar") match { case n: Program.Id.Nonstandard => n ; case _ => sys.error("unpossbile") }
+    val programId        = Program.Id.unsafeFromString("GS-foobar") match { case n: Program.Id.Nonstandard => n ; case _ => sys.error("unpossible") }
     val semester         = Semester.unsafeFromString("2015B")
     val site             = Site.GN
     val programType      = ProgramType.C
@@ -47,7 +47,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
     val gcalFilter       = GcalFilter.None
     val gcalDiffuser     = GcalDiffuser.Ir
     val gcalShutter      = GcalShutter.Open
-    val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, 0)
+    val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, CoAdds.One)
     val user             = User[Nothing]("", "", "", "", false, Map.empty)
     val observation      = Observation[TargetEnvironment, StaticConfig, Nothing]("", TargetEnvironment.empty, StaticConfig.F2.Default, Nil)
     val program          = Program(programId, "", TreeMap.empty)

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -75,6 +75,13 @@ package object json {
    ) =
     Index.fromShort.toCodec
 
+  // Coadds to Short
+  implicit val (
+    coAddsEncoder: Encoder[CoAdds],
+    coAddsIndexDecoder: Decoder[CoAdds]
+  ) =
+    CoAdds.fromShort.toCodec
+
   // Wavelength mapping to integral Angstroms.
   implicit val (
     wavelengthEncoderAngstroms: Encoder[Wavelength],

--- a/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
@@ -142,6 +142,7 @@ object Legacy {
       import Parsers.Gnirs._
       val AcquisitionMirror = Key("acquisitionMirror")(acquisitionMirror)
       val Camera            = Key("camera"           )(camera)
+      val CoAdds            = Key("coadds"           )(Parsers.coadds)
       val Decker            = Key("decker"           )(decker)
       val Disperser         = Key("disperser"        )(disperser)
       val Filter            = Key("filter"           )(filter)
@@ -160,6 +161,6 @@ object Legacy {
     val Diffuser     = Key("diffuser"    )(diffuser        )
     val Shutter      = Key("shutter"     )(shutter         )
     val ExposureTime = Key("exposureTime")(PioParse.seconds)
-    val Coadds       = Key("coadds"      )(PioParse.int    )
+    val CoAdds       = Key("coadds"      )(Parsers.coadds)
   }
 }

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -4,7 +4,7 @@
 package gem.ocs2
 
 import cats.implicits._
-import gem.{ Dataset, Observation, Program }
+import gem.{ CoAdds, Dataset, Observation, Program }
 import gem.enum._
 import gem.config.GcalConfig.GcalLamp
 import gem.math._
@@ -123,6 +123,8 @@ object Parsers {
     "tuningStar"  -> UserTargetType.TuningStar,
     "other"       -> UserTargetType.Other
   )
+
+  val coadds: PioParse[CoAdds] = positiveShort.map(CoAdds.fromShort.unsafeGet)
 
   object Calibration {
 

--- a/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
@@ -46,8 +46,8 @@ object SequenceDecoder extends PioDecoder[List[Step[DynamicConfig]]] {
             d <- Diffuser.parse(cm)
             s <- Shutter.parse(cm)
             e <- ExposureTime.parse(cm)
-            c <- Coadds.parse(cm)
-          } yield Step.Gcal(instrument, GcalConfig(l, f, d, s, e, c.toShort))
+            c <- CoAdds.parse(cm)
+          } yield Step.Gcal(instrument, GcalConfig(l, f, d, s, e, c))
 
         case x =>
           PioError.parseError(x, "ObserveType").asLeft
@@ -173,18 +173,20 @@ object SequenceDecoder extends PioDecoder[List[Step[DynamicConfig]]] {
     def parse(cm: ConfigMap): Either[PioError, DynamicConfig] = {
       import Legacy.Instrument.Gnirs._
       import gem.config.DynamicConfig.Gnirs.Default
+
       for {
         a <- AcquisitionMirror.parse(cm)
         b <- Camera.parse(cm)
-        c <- Decker.cparseOrElse(cm, Default.decker)
-        d <- Disperser.parse(cm)
-        e <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Default.exposureTime)
-        f <- Filter.cparseOrElse(cm, Default.filter)
-        g <- Fpu.parse(cm)
-        h <- Prism.parse(cm)
-        i <- ReadMode.parse(cm)
-        j <- Wavelength.parse(cm)
-      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j)
+        c <- CoAdds.parse(cm)
+        d <- Decker.cparseOrElse(cm, Default.decker)
+        e <- Disperser.parse(cm)
+        f <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Default.exposureTime)
+        g <- Filter.cparseOrElse(cm, Default.filter)
+        h <- Fpu.parse(cm)
+        i <- Prism.parse(cm)
+        j <- ReadMode.parse(cm)
+        k <- Wavelength.parse(cm)
+      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j, k)
     }
   }
 

--- a/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
@@ -183,7 +183,7 @@ object SmartGcalImporter extends DoobieClient {
     val d = diffuserS.parseAs(diffuser)
     val s = shutterS .parseAs(shutter )
     val e = Duration.ofMillis(expS.parseAs(PioParse.long))
-    val c = coaddsS  .parseAs(PioParse.short)
+    val c = coaddsS  .parseAs(Parsers.coadds)
 
     val b = baselineS.parseAs(baseline)
 

--- a/modules/sql/src/main/resources/db/migration/V053__Gnirs_Gcal_enums.sql
+++ b/modules/sql/src/main/resources/db/migration/V053__Gnirs_Gcal_enums.sql
@@ -54,7 +54,7 @@ ALTER TABLE e_gnirs_camera
     ADD COLUMN pixel_scale identifier REFERENCES e_gnirs_pixel_scale;
 
 UPDATE e_gnirs_camera
-    SET pixel_scale = 'PixelScale_0_05' WHERE id = 'LongBlue'  OR id = 'LongRed';
+    SET pixel_scale = 'PixelScale_0_05' WHERE id = 'LongBlue' OR id = 'LongRed';
 
 UPDATE e_gnirs_camera
     SET pixel_scale = 'PixelScale_0_15' WHERE id = 'ShortBlue' OR id = 'ShortRed';

--- a/modules/sql/src/main/resources/db/migration/V055__Gnirs_Coadds.sql
+++ b/modules/sql/src/main/resources/db/migration/V055__Gnirs_Coadds.sql
@@ -1,0 +1,1 @@
+ALTER TABLE step_gnirs ADD COLUMN coadds coadds NOT NULL;

--- a/modules/ui/src/main/scala/gem/ui/Main.scala
+++ b/modules/ui/src/main/scala/gem/ui/Main.scala
@@ -4,6 +4,7 @@
 package gem
 package ui
 
+import gem.CoAdds
 import gem.config._
 import gem.enum._
 import gem.math._
@@ -36,7 +37,7 @@ object TestProgram {
       GcalDiffuser.Ir,
       GcalShutter.Open,
       Duration.ofSeconds(1L),
-      1
+      CoAdds.One
     )
 
   val f2: Observation.Full.Aux[Instrument.Flamingos2.type] =


### PR DESCRIPTION
The type CoAdds was already existing for GCAL but it was factored out so it
could be used in GNIRS.

In the beginning this sounded like a trivial change but in the end I had to tweak the code in many places.