### PR TITLE
ProgramId.fromString

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -55,7 +55,7 @@ object Observation {
   /** An observation is identified by its program and a serial index. */
   final case class Id(pid: Program.Id, index: Index) {
     def format: String =
-      s"${pid.format}-${Index.fromString.reverseGet(index)}"
+      s"${ProgramId.fromString.reverseGet(pid)}-${Index.fromString.reverseGet(index)}"
   }
   object Id {
 
@@ -65,7 +65,7 @@ object Observation {
         case  n =>
           val (a, b) = s.splitAt(n)
           Index.fromString.getOption(b.drop(1)).flatMap { i =>
-            Program.Id.fromString(a).map(Observation.Id(_, i))
+            Program.Id.fromString.getOption(a).map(Observation.Id(_, i))
           }
       }
 

--- a/modules/core/shared/src/main/scala/gem/math/Index.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Index.scala
@@ -6,7 +6,6 @@ package gem.math
 import cats.{ Order, Show }
 import cats.instances.short._
 import mouse.boolean._
-import gem.optics.Format
 import gem.parser.MiscParsers
 import gem.syntax.all._
 import monocle.Prism
@@ -36,7 +35,7 @@ trait IndexOptics {
     Prism((i: Short) => (i > 0) option new Index(i) {})(_.toShort)
 
   /** @group Optics */
-  val fromString: Format[String, Index] =
-    Format(MiscParsers.index.parseExact, _.toShort.toString)
+  val fromString: Prism[String, Index] =
+    Prism(MiscParsers.index.parseExact)(_.toShort.toString)
 
 }

--- a/modules/core/shared/src/main/scala/gem/parser/Misc.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Misc.scala
@@ -5,6 +5,7 @@ package gem.parser
 
 import atto._, Atto._
 import gem.math.Index
+import gem.syntax.prism._
 import scala.annotation.tailrec
 
 /** General-purpose parsers and combinators that aren't provided by atto. */
@@ -58,13 +59,12 @@ trait MiscParsers {
   val positiveInt: Parser[Int] =
     int.filter(_ > 0) namedOpaque "positiveInt"
 
-  /** Parser for an `Index`. */
+  /** Parser for an `Index`, which must be a positive Short with no leading zeros. */
   val index: Parser[Index] =
-    short.flatMap { s =>
-      Index.fromShort.getOption(s) match {
-        case Some(i) => ok(i)
-        case None    => err("Index must be positive.")
-      }
+    ensure(1).flatMap { s =>
+      val c = s(0) // safe
+      if (c >= '1' && c <= '9') short.map(Index.fromShort.unsafeGet)
+      else err("Expected non-zero leading digit.")
     }
 
   /** Parser for an optional sign (+ or -), returned as a boolean indicating whether to negate. */

--- a/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
@@ -8,6 +8,7 @@ import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.arb._
 import gem.enum.{ Site, DailyProgramType }
+import gem.laws.discipline._
 import java.time._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
@@ -20,6 +21,9 @@ final class ProgramIdSpec extends CatsSuite {
   // Laws
   checkAll("Program.Id", OrderTests[Program.Id].order)
 
+  // Laws - Science
+  checkAll("Program.Id.Science.fromString", FormatTests(Program.Id.Science.fromString).formatWith(stringsScience))
+
   test("Equality must be natural") {
     forAll { (a: ProgramId, b: ProgramId) =>
       a.equals(b) shouldEqual Eq[ProgramId].eqv(a, b)
@@ -29,12 +33,6 @@ final class ProgramIdSpec extends CatsSuite {
   test("Show must be natural") {
     forAll { (a: ProgramId) =>
       a.toString shouldEqual Show[ProgramId].show(a)
-    }
-  }
-
-  test("Science must reparse") {
-    forAll { (sid: Science) =>
-      Science.fromString(sid.format) shouldEqual Some(sid)
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
@@ -21,10 +21,10 @@ final class ProgramIdSpec extends CatsSuite {
 
   // Laws
   checkAll("Program.Id", OrderTests[Program.Id].order)
-
   checkAll("Program.Id.Science.fromString", FormatTests(Program.Id.Science.fromString).formatWith(stringsScience))
   checkAll("Program.Id.Daily.fromString", PrismTests(Program.Id.Daily.fromString))
   checkAll("Program.Id.Nonstandard.fromString", PrismTests(Program.Id.Nonstandard.fromString))
+  checkAll("Program.Id.fromString", FormatTests(Program.Id.fromString).formatWith(strings))
 
   test("Equality must be natural") {
     forAll { (a: ProgramId, b: ProgramId) =>
@@ -40,13 +40,13 @@ final class ProgramIdSpec extends CatsSuite {
 
   test("Science should never reparse into a Nonstandard, even if we try") {
     forAll { (sid: Science) =>
-      Nonstandard.fromString.getOption(sid.format) shouldEqual None
+      Nonstandard.fromString.getOption(ProgramId.fromString.reverseGet(sid)) shouldEqual None
     }
   }
 
   test("Daily should never reparse into a Nonstandard, even if we try") {
     forAll { (did: Daily) =>
-      Nonstandard.fromString.getOption(did.format) shouldEqual None
+      Nonstandard.fromString.getOption(ProgramId.fromString.reverseGet(did)) shouldEqual None
     }
   }
 
@@ -81,12 +81,6 @@ final class ProgramIdSpec extends CatsSuite {
   test("Daily should have a consistent date and semester") {
     forAll { (did: Daily) =>
       Semester.fromLocalDate(did.localDate) shouldEqual did.semester
-    }
-  }
-
-  test("ProgramId must reparse") {
-    forAll { (pid: ProgramId) =>
-      ProgramId.fromString(pid.format) shouldEqual Some(pid)
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
@@ -8,7 +8,6 @@ import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.arb._
 import gem.enum.{ Site, DailyProgramType }
-import gem.laws.discipline._
 import java.time._
 import monocle.law.discipline._
 
@@ -21,10 +20,10 @@ final class ProgramIdSpec extends CatsSuite {
 
   // Laws
   checkAll("Program.Id", OrderTests[Program.Id].order)
-  checkAll("Program.Id.Science.fromString", FormatTests(Program.Id.Science.fromString).formatWith(stringsScience))
+  checkAll("Program.Id.Science.fromString", PrismTests(Program.Id.Science.fromString))
   checkAll("Program.Id.Daily.fromString", PrismTests(Program.Id.Daily.fromString))
   checkAll("Program.Id.Nonstandard.fromString", PrismTests(Program.Id.Nonstandard.fromString))
-  checkAll("Program.Id.fromString", FormatTests(Program.Id.fromString).formatWith(strings))
+  checkAll("Program.Id.fromString", PrismTests(Program.Id.fromString))
 
   test("Equality must be natural") {
     forAll { (a: ProgramId, b: ProgramId) =>

--- a/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
@@ -24,6 +24,7 @@ final class ProgramIdSpec extends CatsSuite {
 
   checkAll("Program.Id.Science.fromString", FormatTests(Program.Id.Science.fromString).formatWith(stringsScience))
   checkAll("Program.Id.Daily.fromString", PrismTests(Program.Id.Daily.fromString))
+  checkAll("Program.Id.Nonstandard.fromString", PrismTests(Program.Id.Nonstandard.fromString))
 
   test("Equality must be natural") {
     forAll { (a: ProgramId, b: ProgramId) =>
@@ -39,13 +40,13 @@ final class ProgramIdSpec extends CatsSuite {
 
   test("Science should never reparse into a Nonstandard, even if we try") {
     forAll { (sid: Science) =>
-      Nonstandard.fromString(sid.format) shouldEqual None
+      Nonstandard.fromString.getOption(sid.format) shouldEqual None
     }
   }
 
   test("Daily should never reparse into a Nonstandard, even if we try") {
     forAll { (did: Daily) =>
-      Nonstandard.fromString(did.format) shouldEqual None
+      Nonstandard.fromString.getOption(did.format) shouldEqual None
     }
   }
 
@@ -80,12 +81,6 @@ final class ProgramIdSpec extends CatsSuite {
   test("Daily should have a consistent date and semester") {
     forAll { (did: Daily) =>
       Semester.fromLocalDate(did.localDate) shouldEqual did.semester
-    }
-  }
-
-  test("Nonstandard must reparse") {
-    forAll { (nid: Nonstandard) =>
-      Nonstandard.fromString(nid.format) shouldEqual Some(nid)
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
@@ -10,6 +10,7 @@ import gem.arb._
 import gem.enum.{ Site, DailyProgramType }
 import gem.laws.discipline._
 import java.time._
+import monocle.law.discipline._
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class ProgramIdSpec extends CatsSuite {
@@ -21,8 +22,8 @@ final class ProgramIdSpec extends CatsSuite {
   // Laws
   checkAll("Program.Id", OrderTests[Program.Id].order)
 
-  // Laws - Science
   checkAll("Program.Id.Science.fromString", FormatTests(Program.Id.Science.fromString).formatWith(stringsScience))
+  checkAll("Program.Id.Daily.fromString", PrismTests(Program.Id.Daily.fromString))
 
   test("Equality must be natural") {
     forAll { (a: ProgramId, b: ProgramId) =>
@@ -42,15 +43,9 @@ final class ProgramIdSpec extends CatsSuite {
     }
   }
 
-  test("Daily must reparse") {
-    forAll { (did: Daily) =>
-      Daily.fromString(did.format) shouldEqual Some(did)
-    }
-  }
-
   test("Daily should never reparse into a Nonstandard, even if we try") {
-    forAll { (did: Science) =>
-      Daily.fromString(did.format) shouldEqual None
+    forAll { (did: Daily) =>
+      Nonstandard.fromString(did.format) shouldEqual None
     }
   }
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
@@ -7,7 +7,6 @@ package arb
 import gem.math.Index
 import gem.syntax.prism._
 import org.scalacheck._
-import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen._
 
 trait ArbIndex {
@@ -20,16 +19,6 @@ trait ArbIndex {
 
   implicit val cogIndex: Cogen[Index] =
     Cogen[Short].contramap(_.toShort)
-
-  private val perturbations: List[String => Gen[String]] =
-    List(
-      s => arbitrary[String], // swap for a random string
-      s => Gen.const("0" + s) // prepend a zero
-    )
-
-  // Strings that are often parsable as an Index.
-  val strings: Gen[String] =
-    arbitrary[Short].map(_.toString).flatMapOneOf(Gen.const, perturbations: _*)
 
 }
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
@@ -67,6 +67,9 @@ trait ArbProgramId {
   implicit val cogProgramId: Cogen[ProgramId] =
     Cogen[String].contramap(_.format)
 
+  implicit val cogDaily: Cogen[ProgramId.Daily] =
+    Cogen[String].contramap(_.format)
+
   private val perturbations: List[String => Gen[String]] =
     List(
       s => arbitrary[String],                          // swap for a random string

--- a/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
@@ -67,6 +67,16 @@ trait ArbProgramId {
   implicit val cogProgramId: Cogen[ProgramId] =
     Cogen[String].contramap(_.format)
 
+  private val perturbations: List[String => Gen[String]] =
+    List(
+      s => arbitrary[String],                          // swap for a random string
+      s => Gen.const("\\d+$".r.replaceAllIn(s, "0$0")) // add a leading zero to the index
+    )
+
+  // Strings that are often parsable as a program id.
+  val stringsScience: Gen[String] =
+    arbitrary[Science].map(_.format).flatMapOneOf(Gen.const, perturbations: _*)
+
 }
 
 object ArbProgramId extends ArbProgramId

--- a/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
@@ -70,6 +70,9 @@ trait ArbProgramId {
   implicit val cogDaily: Cogen[ProgramId.Daily] =
     Cogen[String].contramap(_.format)
 
+  implicit val cogNonstandard: Cogen[ProgramId.Nonstandard] =
+    Cogen[String].contramap(_.format)
+
   private val perturbations: List[String => Gen[String]] =
     List(
       s => arbitrary[String],                          // swap for a random string

--- a/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
@@ -67,25 +67,14 @@ trait ArbProgramId {
   implicit val cogProgramId: Cogen[ProgramId] =
     Cogen[String].contramap(ProgramId.fromString.reverseGet)
 
+  implicit val cogScience: Cogen[ProgramId.Science] =
+    Cogen[String].contramap(ProgramId.Science.fromString.reverseGet)
+
   implicit val cogDaily: Cogen[ProgramId.Daily] =
-    Cogen[String].contramap(ProgramId.fromString.reverseGet)
+    Cogen[String].contramap(ProgramId.Daily.fromString.reverseGet)
 
   implicit val cogNonstandard: Cogen[ProgramId.Nonstandard] =
-    Cogen[String].contramap(ProgramId.fromString.reverseGet)
-
-  private val perturbations: List[String => Gen[String]] =
-    List(
-      s => arbitrary[String],                          // swap for a random string
-      s => Gen.const("\\d+$".r.replaceAllIn(s, "0$0")) // add a leading zero to the index
-    )
-
-  // Strings that are often parsable as a science program id.
-  val stringsScience: Gen[String] =
-    arbitrary[Science].map(ProgramId.fromString.reverseGet).flatMapOneOf(Gen.const, perturbations: _*)
-
-  // Strings that are often parsable as a program id.
-  val strings: Gen[String] =
-    arbitrary[ProgramId].map(ProgramId.fromString.reverseGet).flatMapOneOf(Gen.const, perturbations: _*)
+    Cogen[String].contramap(ProgramId.Nonstandard.fromString.reverseGet)
 
 }
 

--- a/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
@@ -6,7 +6,6 @@ package gem.math
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline._
 import gem.arb._
-import gem.laws.discipline._
 import monocle.law.discipline._
 
 final class IndexSpec extends CatsSuite {
@@ -15,6 +14,6 @@ final class IndexSpec extends CatsSuite {
   // Laws
   checkAll("Index", OrderTests[Index].order)
   checkAll("Index.fromShort", PrismTests(Index.fromShort))
-  checkAll("Index.fromString", FormatTests(Index.fromString).formatWith(strings))
+  checkAll("Index.fromString", PrismTests(Index.fromString))
 
 }

--- a/modules/core/shared/src/test/scala/gem/parser/MiscParsersSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/parser/MiscParsersSpec.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.parser
+
+import atto._, Atto._
+import cats.tests.CatsSuite
+import gem.math.Index
+import gem.parser.MiscParsers.index
+
+final class MiscParsersSpec extends CatsSuite {
+
+  test("index parser must be consistent with Index.fromShort") {
+    forAll { (s: Short) =>
+      index.parseOnly(s.toString).option shouldEqual Index.fromShort.getOption(s)
+    }
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
@@ -7,7 +7,7 @@ import doobie._
 import gem.Program
 
 trait ProgramIdMeta {
-  import FormatMeta._
+  import PrismMeta._
 
   // Program.Id as string
   implicit val ProgramIdMeta: Meta[Program.Id] =

--- a/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
@@ -7,10 +7,11 @@ import doobie._
 import gem.Program
 
 trait ProgramIdMeta {
+  import FormatMeta._
 
   // Program.Id as string
   implicit val ProgramIdMeta: Meta[Program.Id] =
-    Meta[String].xmap(Program.Id.unsafeFromString, _.format)
+    Program.Id.fromString.asMeta
 
 }
 object ProgramIdMeta extends ProgramIdMeta

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -7,6 +7,7 @@ import cats.effect.IO
 import doobie._, doobie.implicits._
 import gem.{ Program, Step }
 import gem.math.Index
+import gem.syntax.prism._
 
 import scala.collection.immutable.TreeMap
 

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable.TreeMap
 /** Base trait for DAO test cases.
   */
 trait DaoTest extends gem.Arbitraries {
-  val pid = Program.Id.unsafeFromString("GS-1234A-Q-1")
+  val pid = Program.Id.fromString.unsafeGet("GS-1234A-Q-1")
 
   protected val xa: Transactor[IO] =
     Transactor.after.set(DatabaseConfiguration.forTesting.transactor[IO], HC.rollback)

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -22,7 +22,7 @@ class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
     val idx  = Index.One
 
     // We specifically want to test round-tripping of telescope offsets.
-    val pid  = Program.Id.unsafeFromString("GS-1234A-Q-1")
+    val pid  = Program.Id.fromString.unsafeGet("GS-1234A-Q-1")
     val orig = Program(
       pid,
       "Untitled Prog",

--- a/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
@@ -8,6 +8,7 @@ import doobie._, doobie.implicits._
 import doobie.postgres.implicits._
 import gem._
 import gem.enum.ProgramRole
+import gem.syntax.prism._
 import org.scalatest._
 
 import scala.collection.immutable.TreeMap

--- a/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
@@ -15,8 +15,8 @@ import scala.collection.immutable.TreeMap
 
 class UserDaoSpec extends FlatSpec with Matchers with DaoTest {
 
-  private val pid1 = Program.Id.unsafeFromString("GS-1234A-Q-1")
-  private val pid2 = Program.Id.unsafeFromString("GS-1234A-Q-3")
+  private val pid1 = Program.Id.fromString.unsafeGet("GS-1234A-Q-1")
+  private val pid2 = Program.Id.fromString.unsafeGet("GS-1234A-Q-3")
 
   private val prog1 = Program(pid1, "prog1", TreeMap.empty)
   private val prog2 = Program(pid2, "prog2", TreeMap.empty)

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -33,7 +33,7 @@ trait Check extends FlatSpec with Matchers with IOChecker {
   object Dummy {
     val instant          = java.time.Instant.EPOCH
     val duration         = java.time.Duration.ZERO
-    val programId        = Program.Id.unsafeFromString("GS-foobar") match { case n: Program.Id.Nonstandard => n ; case _ => sys.error("unpossible") }
+    val programId        = Program.Id.fromString.unsafeGet("GS-foobar") match { case n: Program.Id.Nonstandard => n ; case _ => sys.error("unpossbile") }
     val semester         = Semester.unsafeFromString("2015B")
     val site             = Site.GN
     val programType      = ProgramType.C

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -122,8 +122,11 @@ package object json {
   implicit def enumeratedDecoder[A](implicit ev: Enumerated[A]): Decoder[A] = Decoder[String].map(ev.unsafeFromTag)
 
   // Program ID in canonical form
-  implicit val ProgramIdEncoder: Encoder[Program.Id] = Encoder[String].contramap(_.format)
-  implicit val ProgramIdDecoder: Decoder[Program.Id] = Decoder[String].map(Program.Id.unsafeFromString)
+  implicit val (
+    programIdEncoder: Encoder[Program.Id],
+    programIdDecoder: Decoder[Program.Id]
+   ) =
+    Program.Id.fromString.toCodec
 
   // Right Ascension in canonical form
   implicit val (
@@ -180,9 +183,9 @@ package object json {
 
   // Codec for maps keyed by Program.Id
   implicit def programIdKeyedMapEncoder[A: Encoder]: Encoder[Map[Program.Id, A]] =
-    Encoder[Map[String, A]].contramap(_.map { case (k, v) => (k.format, v) })
+    Encoder[Map[String, A]].contramap(_.map { case (k, v) => (Program.Id.fromString.reverseGet(k), v) })
   implicit def programIdKeyedMapDecoder[A: Decoder]: Decoder[Map[Program.Id, A]] =
-    Decoder[Map[String, A]].map(_.map { case (k, v) => (Program.Id.unsafeFromString(k), v) })
+    Decoder[Map[String, A]].map(_.map { case (k, v) => (Program.Id.fromString.unsafeGet(k), v) })
 
   // Codec for maps keyed by Index
   implicit def observationIndexMapEncoder[A: Encoder]: Encoder[TreeMap[Index, A]] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -52,7 +52,7 @@ final class ImportServer(ocsHost: String) {
   def importProgram(pidStr: String): IO[Response[IO]] = {
     importRemote[Program.Id](
       pidStr,
-      ProgramId.fromString,
+      ProgramId.fromString.getOption,
       "program",
       OdbClient.importProgram(ocsHost, _, xa)
     )

--- a/modules/ocs2/src/main/scala/gem/ocs2/OdbClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/OdbClient.scala
@@ -38,7 +38,7 @@ object OdbClient {
     host: String,
     id:   Program.Id
   ): M[Either[String, (Program[Observation.Full], List[Dataset])]] =
-    fetch[Program[Observation.Full], M](host, id.format)
+    fetch[Program[Observation.Full], M](host, Program.Id.fromString.reverseGet(id))
 
   /** Fetches an observation from the ODB and stores it in the database. */
   def importObservation[M[_]: Effect](

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -103,7 +103,7 @@ object Parsers {
   )
 
   val progId: PioParse[Program.Id] =
-    PioParse(s => Option(Program.Id.unsafeFromString(s)))
+    PioParse(Program.Id.fromString.getOption)
 
   val obsId: PioParse[Observation.Id] =
     PioParse(Observation.Id.fromString)

--- a/modules/telnetd/src/main/scala/command/fetch.scala
+++ b/modules/telnetd/src/main/scala/command/fetch.scala
@@ -34,7 +34,7 @@ object fetch {
     Opts.argument[String](
       metavar = "prog-id"
     ).mapValidated { s =>
-      ProgramId.fromString(s).toValidNel(s"Could not parse '$s' as a program id")
+      ProgramId.fromString.getOption(s).toValidNel(s"Could not parse '$s' as a program id")
     }
 
   val obsCommand: GemCommand =
@@ -54,7 +54,10 @@ object fetch {
       (host, pid).mapN { (h: String, id: Program.Id) => (d: GemState) => {
         for {
           r <- d.ocs2.importProgram(h, id)
-          _ <- writeLn(r.fold(m => s"Failed to import ${id.format}: $m", _ => s"Imported ${id.format}"))
+          _ <- writeLn(r.fold(
+                 m => s"Failed to import ${Program.Id.fromString.reverseGet(id)}: $m",
+                 _ => s"Imported ${Program.Id.fromString.reverseGet(id)}"
+               ))
         } yield d
       }}
     ).zoom(Session.data[GemState])


### PR DESCRIPTION
This fuses the parse/format pairs for program ids.

- Strings containing whitespace are not valid program ids. All other strings are. This means we have at best a `Prism`.
- Leading zeroes on science program indices are allowed (and discarded) which weakens the relationship to `Format`. If we drop this behavior we go back up to `Prism`.


