### PR TITLE
Switch back to LBS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
   - oraclejdk8
 
 scala:
-  - 2.12.2
+  - 2.12.5
 
 addons:
   postgresql: "9.5"

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 import com.typesafe.sbt.packager.docker._
 
-lazy val circeVersion         = "0.9.2"
-lazy val attoVersion          = "0.6.2-M1"
-lazy val catsEffectVersion    = "0.10"
+lazy val circeVersion         = "0.9.3"
+lazy val attoVersion          = "0.6.2"
+lazy val catsEffectVersion    = "0.10.1"
 lazy val catsVersion          = "1.1.0"
 lazy val declineVersion       = "0.4.1"
-lazy val doobieVersion        = "0.5.1"
+lazy val doobieVersion        = "0.5.2"
 lazy val flywayVersion        = "5.0.7"
 lazy val fs2Version           = "0.10.3"
-lazy val http4sVersion        = "0.18.3"
+lazy val http4sVersion        = "0.18.9"
 lazy val jwtVersion           = "0.16.0"
 lazy val kpVersion            = "0.9.6"
 lazy val monocleVersion       = "1.5.1-cats"
@@ -107,8 +107,7 @@ lazy val commonSettings = Seq(
   wartremoverErrors in (Compile, compile) := gemWarts,
   wartremoverErrors in (Test,    compile) := gemWarts,
 
-  scalaOrganization := "org.typelevel",
-  scalaVersion := "2.12.3-bin-typelevel-4",
+  scalaVersion := "2.12.5",
   scalacOptions ++= Seq(
     "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
     "-encoding", "utf-8",                // Specify character encoding used by source files.
@@ -155,11 +154,6 @@ lazy val commonSettings = Seq(
     "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
     "-Ywarn-unused:privates",            // Warn if a private member is unused.
     "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
-    "-Yinduction-heuristics",            // speeds up the compilation of inductive implicit resolution
-    // "-Ykind-polymorphism",               // type and method definitions with type parameters of arbitrary kinds
-    "-Yliteral-types",                   // literals can appear in type position
-    "-Xstrict-patmat-analysis",          // more accurate reporting of failures of match exhaustivity
-    "-Xlint:strict-unsealed-patmat"      // warn on inexhaustive matches against unsealed traits
   ),
   scalacOptions in (Compile, console) ~= (_.filterNot(Set(
     "-Xfatal-warnings",

--- a/build.sbt
+++ b/build.sbt
@@ -178,11 +178,6 @@ lazy val commonSettings = Seq(
 )
 
 lazy val commonJSSettings = Seq(
-  // These settings allow to use TLS with scala.js
-  // Remove the dependency on the scalajs-compiler
-  libraryDependencies := libraryDependencies.value.filterNot(_.name == "scalajs-compiler"),
-  // And add a custom one
-  addCompilerPlugin("org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.patch),
   // Make JS tests run fine on travis
   parallelExecution in Test := false
 )

--- a/modules/db/src/main/scala/gem/dao/composite/ProperMotion.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/ProperMotion.scala
@@ -28,7 +28,8 @@ private object ProperMotionCompositeLemmas {
   import RadialVelocityMeta._
 
   // The parallax member is an angle, which we will store as signed milliarcseconds
-  private implicit lazy val AngleMasMeta: Meta[Angle] =
+  // N.B. if this is marked private we get a spurious "unused" warning
+  implicit lazy val AngleMasMeta: Meta[Angle] =
     AngleMeta.AngleMetaAsSignedMilliarcseconds
 
   val ProperMotionComposite: Composite[ProperMotion] = implicitly

--- a/modules/sql/src/main/scala/EnumDef.scala
+++ b/modules/sql/src/main/scala/EnumDef.scala
@@ -80,9 +80,9 @@ object EnumDef {
     implicit def caseOptionMagnitudeValue[S <: Symbol] = at[(S, Option[MagnitudeValue])] { case (s, _) => s"  val ${s.name}: Option[MagnitudeValue]" }
     implicit def caseGnirsPixelScale[S <: Symbol] = at[(S, GnirsPixelScale)] { case (s, _) => s"  val ${s.name}: GnirsPixelScale" }
 
-    implicit def caseEnumRef[T <: Symbol: ValueOf, S <: Symbol]       = at[(S, EnumRef[T])        ] { case (s, _) => s"  val ${s.name}: ${valueOf[T].name}" }
-    implicit def caseLazyEnumRef[T <: Symbol: ValueOf, S <: Symbol]   = at[(S, LazyEnumRef[T])    ] { case (s, _) => s"  val ${s.name}: Eval[${valueOf[T].name}]" }
-    implicit def caseOptionEnumRef[T <: Symbol: ValueOf, S <: Symbol] = at[(S, Option[EnumRef[T]])] { case (s, _) => s"  val ${s.name}: Option[${valueOf[T].name}]" }
+    implicit def caseEnumRef[T <: Symbol, S <: Symbol](implicit w: Witness.Aux[T])       = at[(S, EnumRef[T])        ] { case (s, _) => s"  val ${s.name}: ${w.value.name}" }
+    implicit def caseLazyEnumRef[T <: Symbol, S <: Symbol](implicit w: Witness.Aux[T])   = at[(S, LazyEnumRef[T])    ] { case (s, _) => s"  val ${s.name}: Eval[${w.value.name}]" }
+    implicit def caseOptionEnumRef[T <: Symbol, S <: Symbol](implicit w: Witness.Aux[T]) = at[(S, Option[EnumRef[T]])] { case (s, _) => s"  val ${s.name}: Option[${w.value.name}]" }
     // scalastyle:on method.type
   }
 
@@ -117,9 +117,9 @@ object EnumDef {
     implicit val caseGnirsPixelScale = at[GnirsPixelScale](a => s"GnirsPixelScale.${a.id}")
 
     // scalastyle:off method.type
-    implicit def caseEnumRef[T <: Symbol: ValueOf]       = at[EnumRef[T]        ](a => s"${valueOf[T].name}.${a.tag}")
-    implicit def caseLazyEnumRef[T <: Symbol: ValueOf]   = at[LazyEnumRef[T]        ](a => s"""cats.Eval.later(${valueOf[T].name}.unsafeFromTag("${a.tag}"))""")
-    implicit def caseOptionEnumRef[T <: Symbol: ValueOf] = at[Option[EnumRef[T]]](a => a.fold(s"Option.empty[${valueOf[T].name}]")(aʹ => s"Some(${valueOf[T].name}.${aʹ.tag})"))
+    implicit def caseEnumRef[T <: Symbol](implicit w: Witness.Aux[T])       = at[EnumRef[T]        ](a => s"${w.value.name}.${a.tag}")
+    implicit def caseLazyEnumRef[T <: Symbol](implicit w: Witness.Aux[T])   = at[LazyEnumRef[T]        ](a => s"""cats.Eval.later(${w.value.name}.unsafeFromTag("${a.tag}"))""")
+    implicit def caseOptionEnumRef[T <: Symbol](implicit w: Witness.Aux[T]) = at[Option[EnumRef[T]]](a => a.fold(s"Option.empty[${w.value.name}]")(aʹ => s"Some(${w.value.name}.${aʹ.tag})"))
     // scalastyle:on method.type
   }
 

--- a/modules/sql/src/main/scala/enum/GpiEnums.scala
+++ b/modules/sql/src/main/scala/enum/GpiEnums.scala
@@ -6,7 +6,9 @@ package enum
 
 import doobie._, doobie.implicits._
 import shapeless.record._
+import shapeless.Witness
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object GpiEnums {
   import EnumRefs._
 
@@ -19,8 +21,11 @@ object GpiEnums {
       },
 
       EnumDef.fromQuery("GpiFilter", "GPI Filter") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'band -> EnumRef['MagnitudeBand], 'obsolete -> Boolean`.T
-        sql"""SELECT id, id tag, short_name, long_name, band, obsolete FROM e_gpi_filter""".query[(String, E)]
+        val  m = Witness('MagnitudeBand)
+        type M = m.T
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'band -> EnumRef[M], 'obsolete -> Boolean`.T
+        val ret = sql"""SELECT id, id tag, short_name, long_name, band, obsolete FROM e_gpi_filter""".query[(String, E)]
+        (ret, m.value: M)._1 // convince scalac that we really do use M
       },
 
       EnumDef.fromQuery("GpiDisperser", "GPI Disperser") {
@@ -84,8 +89,15 @@ object GpiEnums {
       },
 
       EnumDef.fromQuery("GpiObservingMode", "GPI ObservingMode") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'filter -> Option[EnumRef['GpiFilter]], 'filterIterable -> Boolean, 'apodizer -> Option[EnumRef['GpiApodizer]], 'fpm -> Option[EnumRef['GpiFPM]], 'lyot -> Option[EnumRef['GpiLyot]], 'brightLimitPrism -> Option[MagnitudeValue], 'brightLimitWollaston -> Option[MagnitudeValue], 'correspondingHMode -> LazyEnumRef['GpiObservingMode], 'obsolete  -> Boolean`.T
-        sql"""SELECT id, id tag, short_name, long_name, filter, filter_iterable, apodizer, fpm, lyot, bright_limit_prism, bright_limit_wollaston, corresponding_h_mode, obsolete FROM e_gpi_observing_mode""".query[(String, E)]
+        val (a, b, c, d, e) = (Witness('GpiFilter), Witness('GpiApodizer), Witness('GpiFPM), Witness('GpiLyot), Witness('GpiObservingMode))
+        type A = a.T
+        type B = b.T
+        type C = c.T
+        type D = d.T
+        type E = e.T
+        type F = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'filter -> Option[EnumRef[A]], 'filterIterable -> Boolean, 'apodizer -> Option[EnumRef[B]], 'fpm -> Option[EnumRef[C]], 'lyot -> Option[EnumRef[D]], 'brightLimitPrism -> Option[MagnitudeValue], 'brightLimitWollaston -> Option[MagnitudeValue], 'correspondingHMode -> LazyEnumRef[E], 'obsolete  -> Boolean`.T
+        val ret = sql"""SELECT id, id tag, short_name, long_name, filter, filter_iterable, apodizer, fpm, lyot, bright_limit_prism, bright_limit_wollaston, corresponding_h_mode, obsolete FROM e_gpi_observing_mode""".query[(String, F)]
+        (ret, a.value: A, b.value: B, c.value: C, d.value: D, e.value: E)._1 // suppress unused warnigs
       }
 
     )


### PR DESCRIPTION
I think we have hit enough tool limitations that it makes sense to switch back to Lightbend Scala. The changes are relatively minor: `shapeless.Witness` rather than `ValueOf` and then some hacking to get around "unused" warnings.

(I regenerated all the enums and they were identical.)