### PR TITLE
Preliminary Seqexec Support

### DIFF
--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -28,6 +28,15 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
     }
 
   /**
+   * Construct a program that yields the `Observation.Full` with the matching
+   * observation id.
+   */
+  def queryObservationById(id: Observation.Id): M[Observation.Full] =
+    log.log(user, s"queryObservationById(${id.format})") {
+      ObservationDao.select(id).transact(xa)
+    }
+
+  /**
    * Construct a program that attempts to change the user's password, yielding `true` on success.
    */
   def changePassword(oldPassword: String, newPassword: String): M[Boolean] =
@@ -40,9 +49,10 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
     private val exporter = new gem.horizons.tcs.TcsEphemerisExport(xa)
     private val updater  = gem.horizons.HorizonsEphemerisUpdater(xa)
 
-    /** Constructs a program that writes an ephemeris file, returning the path
-      * of the file written.
-      */
+    /**
+     * Constructs a program that writes an ephemeris file, returning the path
+     * of the file written.
+     */
     def export(key: EphemerisKey, site: Site, start: Timestamp, end: Timestamp, dir: Path): M[Path] =
       log.log(user, s"ephemeris.export($key, $site, $start, $end, $dir)") {
         exporter.exportOne(key, site, start, end, dir).as(exporter.resolve(key, dir))
@@ -54,9 +64,10 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
         updater.report(key, site)
       }
 
-    /** Constructs a program that attempts to update ephemeris information,
-      * yielding ephemeris context.
-      */
+    /**
+     * Constructs a program that attempts to update ephemeris information,
+     * yielding ephemeris context.
+     */
     def update(key: EphemerisKey.Horizons, site: Site): M[EphemerisContext] =
       log.log(user, s"ephemeris.update($key, $site)") {
         updater.update(key, site) *> updater.report(key, site)
@@ -67,10 +78,11 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
 
     import gem.ocs2.{ Importer, OdbClient }
 
-    /** Constructs a program that fetches the corresponding observation from the
-      * indicated ODB and then stores it in the database, replacing any
-      * existing observation with the same id.
-      */
+    /**
+     * Constructs a program that fetches the corresponding observation from the
+     * indicated ODB and then stores it in the database, replacing any
+     * existing observation with the same id.
+     */
     def importObservation(host: String, oid: Observation.Id): M[Either[String, Unit]] =
       log.log(user, s"ocs2.importObservation($host, $oid)") {
         OdbClient.fetchObservation[IO](host, oid).liftIO[M].flatMap { _.traverse { case (o, ds) =>
@@ -78,10 +90,11 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
         }}
       }
 
-    /** Constructs a program that fetches the corresponding science program from
-      * the indicated ODB and then stores it in the database, replacing any
-      * existing program with the same id.
-      */
+    /**
+     * Constructs a program that fetches the corresponding science program from
+     * the indicated ODB and then stores it in the database, replacing any
+     * existing program with the same id.
+     */
     def importProgram(host: String, pid: Program.Id): M[Either[String, Unit]] =
       log.log(user, s"ocs2.importProgram($host, $pid") {
         OdbClient.fetchProgram[IO](host, pid).liftIO[M].flatMap { _.traverse { case (p, ds) =>


### PR DESCRIPTION
This PR is intended to open a conversation about what is needed to provide the seqexec with access to the new program model.  Initially we need to be able to fetch observations from the ODB and then load them from the database.

I added a simple `Service.queryObservationById(id: Observation.Id)`  method to complement `ocs2.importObservation(host: String, oid: Observation.Id)`.  In theory the seqexec can create a session by logging in and then use these two methods to obtain an observation containing a sequence.

I assume the observation you get back won't align exactly with what the seqexec needs but that's the next step.  Also we'll eventually want the seqexec to write datasets and events back to the database and we'll need to provide the API for that as well.